### PR TITLE
Update logo and text in mobile app callouts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
+- Update logo/text in mobile app callouts.
 - Docker images are now tagged with the major.minor version number (e.g. `2.3`), the major.minor.bugfix version number (e.g. `2.3.1`), the short commit id (e.g. `sha-c5cda3a`), and `production` or `qa`.
 - Sync from NYPL-Simplified/circulation-patron-web:
   - Add: Set up e2e testing on vercel deploys via cypress

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -107,11 +107,11 @@ const DownloadSimplyECallout = () => (
   <div sx={{ maxWidth: 300, flex: "0 1 auto", mt: 5 }}>
     <H3 sx={{ mt: 0, display: "flex", alignItems: "center" }}>
       <SvgPhone sx={{ mr: 1 }} />
-      Download SimplyE
+      Download Palace
     </H3>
     <Text>
       Our mobile app lets you browse, borrow and read from our whole collection
-      of eBooks and Audiobooks right on your phone!
+      of ebooks and audiobooks right on your phone!
     </Text>
     <div sx={{ width: "75%", overflow: "hidden", ml: -3 }}>
       <IosBadge sx={{ p: 3, pb: 0 }} />

--- a/src/components/PalaceLogo.tsx
+++ b/src/components/PalaceLogo.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+function PalaceLogo(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 713.68 882"
+      aria-label="Palace Logo"
+      {...props}
+    >
+      <polygon
+        fill="#3eb9e7"
+        points="357.43 451.68 357.43 628.23 597.52 460.11 597.52 283.56 357.43 451.68"
+      />
+      <polygon
+        fill="#2225ae"
+        points="597.52 283.56 597.52 283.56 357.43 115.45 357.43 322.24 449.86 386.96 597.52 283.56"
+      />
+      <polygon
+        fill="#fc8442"
+        points="117.34 656.89 191.67 622.19 266.01 760.99 266.01 387.66 117.34 283.56 117.34 656.89"
+      />
+      <polygon
+        fill="#fb361d"
+        points="117.34 283.56 117.83 283.91 266.01 387.66 357.43 322.24 357.43 115.45 117.34 283.56"
+      />
+    </svg>
+  );
+}
+
+export default PalaceLogo;

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -52,23 +52,23 @@ describe("toggling SimplyE Branding", () => {
 
     const utils = render(<Footer />);
 
-    expect(utils.queryByText(/download simplye/i)).not.toBeInTheDocument();
+    expect(utils.queryByText(/download palace/i)).not.toBeInTheDocument();
 
     expect(
       utils.queryByText(
-        "Our mobile app lets you browse, borrow and read from our whole collection of eBooks and Audiobooks right on your phone!"
+        "Our mobile app lets you browse, borrow and read from our whole collection of ebooks and audiobooks right on your phone!"
       )
     ).not.toBeInTheDocument();
 
     // badges
     const iosbadge = utils.queryByText(
-      /download simplye on the apple app store/i
+      /download palace on the apple app store/i
     );
 
     expect(iosbadge).not.toBeInTheDocument();
 
     const googleBadge = utils.queryByText(
-      /get simplye on the google play store/
+      /get palace on the google play store/
     );
     expect(googleBadge).not.toBeInTheDocument();
 
@@ -85,19 +85,19 @@ describe("toggling SimplyE Branding", () => {
 
     expect(
       utils.getByRole("heading", {
-        name: /download simplye/i
+        name: /download palace/i
       })
     ).toBeInTheDocument();
 
     expect(
       utils.getByText(
-        "Our mobile app lets you browse, borrow and read from our whole collection of eBooks and Audiobooks right on your phone!"
+        "Our mobile app lets you browse, borrow and read from our whole collection of ebooks and audiobooks right on your phone!"
       )
     ).toBeInTheDocument();
 
     // badges
     const iosbadge = utils.getByRole("link", {
-      name: /download simplye on the apple app store/i
+      name: /download palace on the apple app store/i
     });
     expect(iosbadge).toBeInTheDocument();
     expect(iosbadge).toHaveAttribute(
@@ -106,7 +106,7 @@ describe("toggling SimplyE Branding", () => {
     );
 
     const googleBadge = utils.getByRole("link", {
-      name: /get simplye on the google play store/i
+      name: /get palace on the google play store/i
     });
     expect(googleBadge).toBeInTheDocument();
     expect(googleBadge).toHaveAttribute(

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -92,14 +92,12 @@ describe("book details page", () => {
     mockSwr({ data: fixtures.book });
     const utils = render(<BookDetails />);
 
-    expect(
-      utils.queryByText("Read Now. Read Everywhere.")
-    ).not.toBeInTheDocument();
+    expect(utils.queryByText("Download Palace")).not.toBeInTheDocument();
 
-    expect(utils.queryByText("SimplyE Logo")).not.toBeInTheDocument();
+    expect(utils.queryByText("Palace Logo")).not.toBeInTheDocument();
     expect(
       utils.queryByText(
-        "Browse and read our collection of eBooks and Audiobooks right from your phone."
+        "Browse and read our collection of ebooks and audiobooks right from your phone."
       )
     ).not.toBeInTheDocument();
   });
@@ -109,16 +107,16 @@ describe("book details page", () => {
     mockSwr({ data: fixtures.book });
     const utils = render(<BookDetails />);
 
-    expect(utils.getByText("Read Now. Read Everywhere.")).toBeInTheDocument();
-    expect(utils.getByLabelText("SimplyE Logo")).toBeInTheDocument();
+    expect(utils.getByText("Download Palace")).toBeInTheDocument();
+    expect(utils.getByLabelText("Palace Logo")).toBeInTheDocument();
     expect(
       utils.getByText(
-        "Browse and read our collection of eBooks and Audiobooks right from your phone."
+        "Browse and read our collection of ebooks and audiobooks right from your phone."
       )
     ).toBeInTheDocument();
 
     const iosBadge = utils.getByRole("link", {
-      name: "Download SimplyE on the Apple App Store",
+      name: "Download Palace on the Apple App Store",
       hidden: true // it is initially hidden by a media query, only displayed on desktop
     });
     expect(iosBadge).toBeInTheDocument();
@@ -128,7 +126,7 @@ describe("book details page", () => {
     );
 
     const googleBadge = utils.getByRole("link", {
-      name: "Get SimplyE on the Google Play Store",
+      name: "Get Palace on the Google Play Store",
       hidden: true // hidden initially on mobile
     });
     expect(googleBadge).toBeInTheDocument();

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -13,7 +13,7 @@ import ReportProblem from "./ReportProblem";
 import Head from "next/head";
 import { H1, H2, H3, Text } from "components/Text";
 import MediumIndicator from "components/MediumIndicator";
-import SimplyELogo from "components/SimplyELogo";
+import PalaceLogo from "components/PalaceLogo";
 import IosBadge from "components/storeBadges/IosBadge";
 import GooglePlayBadge from "components/storeBadges/GooglePlayBadge";
 import { useRouter } from "next/router";
@@ -120,7 +120,7 @@ const Summary: React.FC<{ book: AnyBook; className?: string }> = ({
 const SimplyECallout: React.FC<{ className?: "string" }> = ({ className }) => {
   return (
     <section
-      aria-label="Download the SimplyE Mobile App"
+      aria-label="Download the Palace Mobile App"
       sx={{
         mt: 4,
         bg: "ui.gray.lightWarm",
@@ -131,10 +131,10 @@ const SimplyECallout: React.FC<{ className?: "string" }> = ({ className }) => {
       }}
       className={className}
     >
-      <SimplyELogo sx={{ m: 3 }} />
-      <H3 sx={{ mt: 0 }}>Read Now. Read Everywhere.</H3>
+      <PalaceLogo sx={{ mt: 3, height: "120px" }} />
+      <H3 sx={{ mt: 0 }}>Download Palace</H3>
       <Text>
-        Browse and read our collection of eBooks and Audiobooks right from your
+        Browse and read our collection of ebooks and audiobooks right from your
         phone.
       </Text>
       <div sx={{ maxWidth: 140, mx: "auto", mt: 3 }}>

--- a/src/components/storeBadges/GooglePlayBadge.tsx
+++ b/src/components/storeBadges/GooglePlayBadge.tsx
@@ -7,7 +7,8 @@ const GooglePlayBadge = (props: React.ComponentProps<"a">) => {
     <a
       rel="noopener noreferrer"
       target="__blank"
-      aria-label="Get SimplyE on the Google Play Store"
+      aria-label="Get Palace on the Google Play Store"
+      // TODO: Replace with correct URL when Palace is in the Play Store.
       href="https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
       sx={{ display: "block" }}
       {...props}

--- a/src/components/storeBadges/IosBadge.tsx
+++ b/src/components/storeBadges/IosBadge.tsx
@@ -8,8 +8,9 @@ const IosBadge = (props: React.ComponentProps<"a">) => {
     <a
       rel="noopener noreferrer"
       target="__blank"
+      // TODO: Replace with correct URL when Palace is in the App Store.
       href="https://apps.apple.com/us/app/simplye/id1046583900"
-      aria-label="Download SimplyE on the Apple App Store"
+      aria-label="Download Palace on the Apple App Store"
       sx={{ display: "block" }}
       {...props}
     >


### PR DESCRIPTION
## Description

Updates the logo and text in the mobile app callouts (on book detail page and in footer). The logo is changed to the Palace logo from the SimplyE logo, and the text is changed to refer to Palace instead of SimplyE.

The app store links still point to SimplyE. These will need to be updated when Palace is in the stores:
https://github.com/ThePalaceProject/web-patron/blob/f5d1a289cfe45ee90c94c0918d5c9e0d9e08f693/src/components/storeBadges/GooglePlayBadge.tsx#L11
https://github.com/ThePalaceProject/web-patron/blob/f5d1a289cfe45ee90c94c0918d5c9e0d9e08f693/src/components/storeBadges/IosBadge.tsx#L11

Screenshot:

<img src="https://user-images.githubusercontent.com/1395885/127345812-fe93ae12-3f74-483d-b66f-1645f3f29ede.png" height="800px">

## Motivation and Context

https://www.notion.so/lyrasis/Update-CPW-Apps-Store-links-and-Logos-beddece52d5f44c687cb467b844d7921

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Updated and ran unit tests
- Viewed in Chrome and Firefox on various screen sizes 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
