### PR TITLE
Add support for no-password login.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
+- Add support for no-password login.
 - Update logo/text in mobile app callouts.
 - Docker images are now tagged with the major.minor version number (e.g. `2.3`), the major.minor.bugfix version number (e.g. `2.3.1`), the short commit id (e.g. `sha-c5cda3a`), and `production` or `qa`.
 - Sync from NYPL-Simplified/circulation-patron-web:

--- a/src/auth/BasicAuthHandler.tsx
+++ b/src/auth/BasicAuthHandler.tsx
@@ -12,6 +12,7 @@ import useUser from "components/context/UserContext";
 import { ServerError } from "errors";
 import useLogin from "auth/useLogin";
 import useLibraryContext from "components/context/LibraryContext";
+import { Keyboard } from "types/opds1";
 
 type FormData = {
   [key: string]: string;
@@ -43,6 +44,9 @@ const BasicAuthHandler: React.FC<{ method: ClientBasicMethod }> = ({
 
   const hasMultipleMethods = authMethods.length > 1;
 
+  const hasPasswordInput =
+    method.inputs?.password?.keyboard !== Keyboard.NoInput;
+
   return (
     <form
       onSubmit={onSubmit}
@@ -65,17 +69,20 @@ const BasicAuthHandler: React.FC<{ method: ClientBasicMethod }> = ({
           errors[usernameInputName] && `Your ${usernameInputName} is required.`
         }
       />
-      <FormInput
-        name={passwordInputName}
-        label={passwordInputName}
-        ref={register({ required: true, maxLength: 25 })}
-        id="password"
-        type="password"
-        placeholder={passwordInputName}
-        error={
-          errors[passwordInputName] && `Your ${passwordInputName} is required.`
-        }
-      />
+      {hasPasswordInput && (
+        <FormInput
+          name={passwordInputName}
+          label={passwordInputName}
+          ref={register({ required: true, maxLength: 25 })}
+          id="password"
+          type="password"
+          placeholder={passwordInputName}
+          error={
+            errors[passwordInputName] &&
+            `Your ${passwordInputName} is required.`
+          }
+        />
+      )}
 
       <Button
         type="submit"

--- a/src/auth/useCredentials.ts
+++ b/src/auth/useCredentials.ts
@@ -3,6 +3,7 @@ import Cookie from "js-cookie";
 import { AuthCredentials, OPDS1 } from "interfaces";
 import { IS_SERVER } from "utils/env";
 import { NextRouter, useRouter } from "next/router";
+import { generateCredentials } from "utils/auth";
 import { SAML_LOGIN_QUERY_PARAM } from "utils/constants";
 
 /**
@@ -88,9 +89,8 @@ function clearCredentialsCookie(librarySlug: string | null) {
   Cookie.remove(cookieName(librarySlug));
 }
 
-export function generateToken(username: string, password: string) {
-  const btoaStr = btoa(`${username}:${password}`);
-  return `Basic ${btoaStr}`;
+export function generateToken(username: string, password?: string) {
+  return generateCredentials(username, password);
 }
 
 /**

--- a/src/types/opds1.ts
+++ b/src/types/opds1.ts
@@ -176,10 +176,26 @@ export interface ServerSamlMethod
 export interface CleverAuthMethod extends AuthMethod<typeof CleverAuthType> {}
 
 export interface BasicAuthMethod extends AuthMethod<typeof BasicAuthType> {
+  inputs?: {
+    login?: AuthInput;
+    password?: AuthInput;
+  };
+
   labels: {
     login: string;
     password: string;
   };
+}
+
+export interface AuthInput {
+  keyboard?: Keyboard;
+}
+
+export enum Keyboard {
+  Default = "Default",
+  NoInput = "No input",
+  NumberPad = "Number pad",
+  EmailAddress = "Email address"
 }
 
 export type ServerAuthMethod =

--- a/src/utils/__tests__/auth.test.ts
+++ b/src/utils/__tests__/auth.test.ts
@@ -1,0 +1,18 @@
+import { generateCredentials } from "../auth";
+
+describe("generateCredentials", () => {
+  test("returns basic auth credentials for the username and password", () => {
+    const username = "foo";
+    const password = "bar";
+    const encoded = btoa(`${username}:${password}`);
+
+    expect(generateCredentials(username, password)).toEqual(`Basic ${encoded}`);
+  });
+
+  test("treats undefined password as empty string", () => {
+    const username = "foo";
+    const encoded = btoa(`${username}:`);
+
+    expect(generateCredentials(username)).toEqual(`Basic ${encoded}`);
+  });
+});

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -36,7 +36,7 @@ function serverToClientSamlMethods(
 export const getEnglishValue = (arr: [{ language: string; value: string }]) =>
   arr.find(item => item.language === "en")?.value;
 
-export function generateCredentials(username: string, password: string) {
+export function generateCredentials(username: string, password = "") {
   const btoaStr = btoa(`${username}:${password}`);
   return `Basic ${btoaStr}`;
 }


### PR DESCRIPTION
## Description

This adds support for no-password/pin logins.

1. When the `authentication` in the authentication document contains the property `inputs.password.keyboard` with the value `"No input"`, the password input is not displayed.
2. This allows the password to be `undefined` when the basic auth header is generated. The function that does this wasn't expecting this, and turned it into the string `"undefined"`.  An undefined password is now treated as `""`.
3. There were two identical functions to generate the basic auth header. These have been consolidated.
4. Added unit tests.

Screenshot:

<img src="https://user-images.githubusercontent.com/1395885/127517397-ae6b8d0e-9653-417c-a58f-ce76fb6c8621.png" height="400px"/>

## Motivation and Context

https://www.notion.so/lyrasis/Add-No-Pin-Password-login-support-for-CPW-3395a1065ec7479390c4a2d831a82d0b

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Checked that no-pin login works in Chrome and Firefox (using Kalama)
- Checked that login with pin continues to work (using Lyrasis)
- Added unit tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
