### PR TITLE
Add support for additional audiobook distributors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
+- Add support for Biblioteca, Axis360, and DPLA Exchange audiobooks.
 - Add support for no-password login.
 - Update logo/text in mobile app callouts.
 - Docker images are now tagged with the major.minor version number (e.g. `2.3`), the major.minor.bugfix version number (e.g. `2.3.1`), the short commit id (e.g. `sha-c5cda3a`), and `production` or `qa`.

--- a/community-config.yml
+++ b/community-config.yml
@@ -1,15 +1,15 @@
-# Set an instance name to be used in bug tracking and for other debugging purposes. 
+# Set an instance name to be used in bug tracking and for other debugging purposes.
 # This is not patron-facing, so call it something that will be meaningful to you when
 # reviewing bugs, especially if you operate multiple instances.
 instance_name: Patron Web Catalog - Community Demo
 
 # APP MEDIA SUPPORT
 # Each entry has a setting of "show", "redirect" or "show-and-redirect".
-# 
-# "redirect" tells the app to display a prompt directing the 
+#
+# "redirect" tells the app to display a prompt directing the
 # user to read the book in the companion mobile app (usually SimplyE).
-# 
-# The default for unlisted entries is unsupported. The format will be 
+#
+# The default for unlisted entries is unsupported. The format will be
 # completely hidden. Any OPDS Entry with only this one unsupported format
 # will not be visible in the app.
 media_support:
@@ -27,14 +27,16 @@ media_support:
   # Audiobooks
   application/audiobook+json: redirect
   application/vnd.overdrive.circulation.api+json;profile=audiobook: redirect
+  application/audiobook+json;profile="http://www.feedbooks.com/audiobooks/access-restriction": redirect
+  application/vnd.librarysimplified.findaway.license+json: redirect
 
   ### INDIRECT TYPES
   # OPDS Entry Indirection type
-  application/atom+xml;type=entry;profile=opds-catalog: 
+  application/atom+xml;type=entry;profile=opds-catalog:
     text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media": show
 
   # Adobe Encryption
-  application/vnd.adobe.adept+xml: 
+  application/vnd.adobe.adept+xml:
     application/epub+zip: redirect-and-show
 
   # Bearer Token Exchange (web app currently doesn't support this)

--- a/src/components/BookStatus.tsx
+++ b/src/components/BookStatus.tsx
@@ -17,7 +17,7 @@ const BookStatus: React.FC<{ book: AnyBook }> = ({ book }) => {
     : false;
 
   const companionApp =
-    APP_CONFIG.companionApp === "openebooks" ? "Open eBooks" : "SimplyE";
+    APP_CONFIG.companionApp === "openebooks" ? "Open eBooks" : "Palace";
 
   const str =
     status === "borrowable"

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -460,7 +460,7 @@ describe("FulfillableBook", () => {
       utils.getByText(`You have this book on loan until ${MOCK_DATE_STRING}.`)
     ).toBeInTheDocument();
     expect(
-      utils.queryByText("You're ready to read this book in SimplyE!")
+      utils.queryByText("Ready to Read in Palace!")
     ).not.toBeInTheDocument();
   });
   const bookWithRedirect = mergeBook<FulfillableBook>({
@@ -480,7 +480,7 @@ describe("FulfillableBook", () => {
     });
     const utils = render(<FulfillmentCard book={bookWithRedirect} />);
     expect(utils.queryByText("Ready to Read!")).not.toBeInTheDocument();
-    expect(utils.getByText("Ready to Read in SimplyE!")).toBeInTheDocument();
+    expect(utils.getByText("Ready to Read in Palace!")).toBeInTheDocument();
     expect(
       utils.getByText("If you would rather read on your computer, you can:")
     ).toBeInTheDocument();

--- a/src/types/opds1.ts
+++ b/src/types/opds1.ts
@@ -89,6 +89,8 @@ export const AxisNowWebpubMediaType =
   "application/vnd.librarysimplified.axisnow+json";
 export const AccessRestrictionAudiobookMediaType =
   'application/audiobook+json;profile="http://www.feedbooks.com/audiobooks/access-restriction"';
+export const FindawayAudiobookMediaType =
+  "application/vnd.librarysimplified.findaway.license+json";
 
 export type ReadOnlineMediaType =
   | typeof ExternalReaderMediaType
@@ -105,7 +107,8 @@ export type DownloadMediaType =
 export type UnsupportedMediaType =
   | typeof AccessRestrictionAudiobookMediaType
   | typeof AudiobookMediaType
-  | typeof OverdriveAudiobookMediaType;
+  | typeof OverdriveAudiobookMediaType
+  | typeof FindawayAudiobookMediaType;
 
 export type AnyBookMediaType =
   | ReadOnlineMediaType


### PR DESCRIPTION
## Description

Add support for borrowing audiobooks from Biblioteca, Axis360, and DPLA Exchange. This adds config to recognize the following mime types as audiobooks that can be played in the mobile app:

- `application/audiobook+json;profile="http://www.feedbooks.com/audiobooks/access-restriction"` for DPLA Exchange
- `application/vnd.librarysimplified.findaway.license+json` for Biblioteca and Axis360

Also change the text "Ready to Read in SimplyE" to "Ready to Read in Palace" for ebooks/audiobooks that are on loan, but must be read in the app.

Screenshot:

<img src="https://user-images.githubusercontent.com/1395885/127699854-e6b20eb1-a379-4f15-9b2d-bebfeef9d8f8.png" height="400px"/>


## Motivation and Context

Notion tickets:
- https://www.notion.so/lyrasis/Add-support-for-Bibliotheca-Audiobooks-7aa8bd056c62489bbffa601cdf4782b6
- https://www.notion.so/lyrasis/Add-Lending-Support-for-Axis-360-Audiobooks-777be50a882b420aa31e7c45abba868c
- https://www.notion.so/lyrasis/Add-support-for-Axis-360-Audiobooks-13d6f537a14042e781504ad61a6fc689
- https://www.notion.so/lyrasis/Add-lending-support-for-DPLA-Exchange-Audiobooks-in-CPW-2b922b3c78b24ed4934b8c01b216743e
- https://www.notion.so/lyrasis/Audiobook-page-should-show-Ready-to-Listen-on-SimplyE-message-not-Unsupported-e32b303c5d944ef68beb17ce36f86cd9

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Checked that the Borrow button appears and works for Biblioteca, Axis360, and DPLA Exchange audiobooks (instead of "Unsupported"). Used the following books in LYRASIS library:
- "Ladies' Night" (Axis360)
- "The Summoning" (Biblioteca)
- "The Lost Book of Adana Moreau" (DPLA Exchange)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
