### PR TITLE
Update Google Play Store badge to link to Palace app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
+- Update Google Play Store badge to link to Palace app.
 - Add support for Biblioteca, Axis360, and DPLA Exchange audiobooks.
 - Add support for no-password login.
 - Update logo/text in mobile app callouts.

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -111,7 +111,7 @@ describe("toggling SimplyE Branding", () => {
     expect(googleBadge).toBeInTheDocument();
     expect(googleBadge).toHaveAttribute(
       "href",
-      "https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
+      "https://play.google.com/store/apps/details?id=org.thepalaceproject.palace&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
     );
 
     // my books nav link

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -132,7 +132,7 @@ describe("book details page", () => {
     expect(googleBadge).toBeInTheDocument();
     expect(googleBadge).toHaveAttribute(
       "href",
-      "https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
+      "https://play.google.com/store/apps/details?id=org.thepalaceproject.palace&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
     );
   });
 

--- a/src/components/storeBadges/GooglePlayBadge.tsx
+++ b/src/components/storeBadges/GooglePlayBadge.tsx
@@ -9,7 +9,7 @@ const GooglePlayBadge = (props: React.ComponentProps<"a">) => {
       target="__blank"
       aria-label="Get Palace on the Google Play Store"
       // TODO: Replace with correct URL when Palace is in the Play Store.
-      href="https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
+      href="https://play.google.com/store/apps/details?id=org.thepalaceproject.palace&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
       sx={{ display: "block" }}
       {...props}
     >


### PR DESCRIPTION
## Description

Update the Google Play Store badge (in the Palace callout and the footer) to link to the Palace app instead of SimplyE.

Note: The URL was generated using the Google Play [badge generator](https://play.google.com/intl/en_us/badges/). The `pcampaignid` parameter is the default.

## Motivation and Context

https://www.notion.so/lyrasis/Update-CPW-Apps-Store-links-and-Logos-beddece52d5f44c687cb467b844d7921

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Checked that clicking on the Google Play Store badge goes to the Palace app page on the Play Store (not SimplyE).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
