### PR TITLE
Accept all languages when retrieving feeds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
+- Fix foreign-language books not appearing in search results.
 - Update Google Play Store badge to link to Palace app.
 - Add support for Biblioteca, Axis360, and DPLA Exchange audiobooks.
 - Add support for no-password login.

--- a/src/auth/__tests__/BasicAuthForm.test.tsx
+++ b/src/auth/__tests__/BasicAuthForm.test.tsx
@@ -95,7 +95,11 @@ test("sumbits", async () => {
 
     // we also trigger a loans request with the cookie
     expect(fetchMock).toHaveBeenCalledWith("/shelf-url", {
-      headers: { Authorization: token, "X-Requested-With": "XMLHttpRequest" }
+      headers: {
+        Authorization: token,
+        "X-Requested-With": "XMLHttpRequest",
+        "Accept-Language": "*"
+      }
     });
   });
 });
@@ -136,7 +140,8 @@ test("displays server error", async () => {
   expect(fetchMock).toHaveBeenCalledWith("/shelf-url", {
     headers: {
       Authorization: "token",
-      "X-Requested-With": "XMLHttpRequest"
+      "X-Requested-With": "XMLHttpRequest",
+      "Accept-Language": "*"
     }
   });
   const serverError = await utils.findByText(
@@ -214,7 +219,11 @@ test("submits with no password input", async () => {
 
     // we also trigger a loans request with the cookie
     expect(fetchMock).toHaveBeenCalledWith("/shelf-url", {
-      headers: { Authorization: token, "X-Requested-With": "XMLHttpRequest" }
+      headers: {
+        Authorization: token,
+        "X-Requested-With": "XMLHttpRequest",
+        "Accept-Language": "*"
+      }
     });
   });
 });

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -17,7 +17,10 @@ describe("fetching catalog", () => {
     fetchMock.mockResponseOnce(rawCatalog);
     await fetchFeed("some-url");
     expect(fetchMock).toHaveBeenCalledWith("some-url", {
-      headers: { "X-Requested-With": "XMLHttpRequest" }
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        "Accept-Language": "*"
+      }
     });
   });
 

--- a/src/dataflow/fetch.ts
+++ b/src/dataflow/fetch.ts
@@ -5,8 +5,13 @@
 
 import { FetchError } from "errors";
 
-export default async function fetchWithHeaders(url: string, token?: string) {
-  const headers = prepareHeaders(token);
+export default async function fetchWithHeaders(
+  url: string,
+  token?: string,
+  additionalHeaders?: { [key: string]: string }
+) {
+  const headers = prepareHeaders(token, additionalHeaders);
+
   /**
    * Fetch doesn't reject if it receives a response from the server,
    * only if the actual fetch fails due to network failure or permission failure like
@@ -19,11 +24,15 @@ export default async function fetchWithHeaders(url: string, token?: string) {
   }
 }
 
-function prepareHeaders(token?: string) {
+function prepareHeaders(
+  token?: string,
+  additionalHeaders?: { [key: string]: string }
+) {
   const headers: {
     [key: string]: string;
   } = {
-    "X-Requested-With": "XMLHttpRequest"
+    "X-Requested-With": "XMLHttpRequest",
+    ...additionalHeaders
   };
   if (token) {
     headers["Authorization"] = token;

--- a/src/dataflow/opds1/fetch.ts
+++ b/src/dataflow/opds1/fetch.ts
@@ -12,9 +12,10 @@ const parser = new OPDSParser();
  */
 export async function fetchOPDS(
   url: string,
-  token?: string
+  token?: string,
+  additionalHeaders?: { [key: string]: string }
 ): Promise<OPDSEntry | OPDSFeed> {
-  const response = await fetchWithHeaders(url, token);
+  const response = await fetchWithHeaders(url, token, additionalHeaders);
   // If the status code is not in the range 200-299,
   // we still try to parse and throw it.
   if (!response.ok) {
@@ -45,7 +46,12 @@ export async function fetchFeed(
   url: string,
   token?: string
 ): Promise<OPDSFeed> {
-  const result = await fetchOPDS(url, token);
+  const result = await fetchOPDS(url, token, {
+    // Explicitly accept all languages when fetching feeds. Otherwise, the browser will send an
+    // Accept-Language header for its current language, which causes books in other languages to
+    // be filtered out of search results.
+    "Accept-Language": "*"
+  });
   if (result instanceof OPDSFeed) {
     return result;
   }


### PR DESCRIPTION
## Description

Send `Accept-Language: *` HTTP header with requests to retrieve feeds. Otherwise, the browser sends an `Accept-Language` header for its current language, which causes books of other languages to be filtered out of search results.

## Motivation and Context

This fixes foreign-language books not appearing in search results: https://www.notion.so/lyrasis/Search-results-are-filtered-by-browser-language-71b1726623834709b8328ac12ca2ac19

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests now check that the `Accept-Language: *` header is sent with requests to retrieve feeds.

Checked that foreign-language books now appear in search results:
1. Open the Columbia University Libraries - Demo library.
2. In the search box, enter "Lin Loon Magazine" and click the Search button.
3. Ensure Chinese-language books (e.g. "玲瓏/Ling long, Issue 072") appear in the results.
4. In the browser dev tools, ensure that the `Accept-Language: *` header is sent with the search request (e.g. `/columbia/search/1444?available=all&min_score=500&entrypoint=All&order=title&collection=full&q=lin%20loon%20magazine`).

Checked that retrieving (not searching) feeds continues to work:
1. Open the Columbia University Libraries - Demo library.
2. Browse to the contents of a lane (e.g. SPRINGER2).
3. Ensure all books appear.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
