### PR TITLE
Update iOS App Store badge to link to Palace app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
+- Update iOS App Store badge to link to Palace app.
 - Fix foreign-language books not appearing in search results.
 - Update Google Play Store badge to link to Palace app.
 - Add support for Biblioteca, Axis360, and DPLA Exchange audiobooks.

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -102,7 +102,7 @@ describe("toggling SimplyE Branding", () => {
     expect(iosbadge).toBeInTheDocument();
     expect(iosbadge).toHaveAttribute(
       "href",
-      "https://apps.apple.com/us/app/simplye/id1046583900"
+      "https://apps.apple.com/us/app/the-palace-project/id1574359693"
     );
 
     const googleBadge = utils.getByRole("link", {

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -122,7 +122,7 @@ describe("book details page", () => {
     expect(iosBadge).toBeInTheDocument();
     expect(iosBadge).toHaveAttribute(
       "href",
-      "https://apps.apple.com/us/app/simplye/id1046583900"
+      "https://apps.apple.com/us/app/the-palace-project/id1574359693"
     );
 
     const googleBadge = utils.getByRole("link", {

--- a/src/components/storeBadges/IosBadge.tsx
+++ b/src/components/storeBadges/IosBadge.tsx
@@ -8,8 +8,7 @@ const IosBadge = (props: React.ComponentProps<"a">) => {
     <a
       rel="noopener noreferrer"
       target="__blank"
-      // TODO: Replace with correct URL when Palace is in the App Store.
-      href="https://apps.apple.com/us/app/simplye/id1046583900"
+      href="https://apps.apple.com/us/app/the-palace-project/id1574359693"
       aria-label="Download Palace on the Apple App Store"
       sx={{ display: "block" }}
       {...props}


### PR DESCRIPTION
## Description

Update the iOS App Store badge (in the mobile app callout and footer) to link to the Palace app instead of SimplyE.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This completes the updating of app store links and logos in web-patron. 

Notion: https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=90916a8dfd7b4981bcb327f9362d7ea0&p=beddece52d5f44c687cb467b844d7921.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Checked that clicking on the App Store badge opens Palace app page in the store.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
