### PR TITLE
Implement indirect bearer token fulfillment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
+- Implement indirect bearer token borrowing (adds support for Johns Hopkins, Biblioboard, ProQuest, and other distributors).
 - Update iOS App Store badge to link to Palace app.
 - Fix foreign-language books not appearing in search results.
 - Update Google Play Store badge to link to Palace app.

--- a/community-config.yml
+++ b/community-config.yml
@@ -40,7 +40,9 @@ media_support:
     application/epub+zip: redirect-and-show
 
   # Bearer Token Exchange (web app currently doesn't support this)
-  # application/vnd.librarysimplified.bearer-token+json:
+  application/vnd.librarysimplified.bearer-token+json:
+    application/pdf: show
+    application/epub+zip: show
 
 # defines the companion app for the instance. Can be "simplye" or "openebooks"
 # default is "simplye"

--- a/community-config.yml
+++ b/community-config.yml
@@ -39,7 +39,7 @@ media_support:
   application/vnd.adobe.adept+xml:
     application/epub+zip: redirect-and-show
 
-  # Bearer Token Exchange (web app currently doesn't support this)
+  # Bearer Token Exchange
   application/vnd.librarysimplified.bearer-token+json:
     application/pdf: show
     application/epub+zip: show

--- a/src/components/FulfillmentButton.tsx
+++ b/src/components/FulfillmentButton.tsx
@@ -85,11 +85,15 @@ const ReadOnlineExternal: React.FC<{
     try {
       // the url may be behind indirection, so we fetch it with the
       // provided function
-      const url = await details.getUrl(catalogUrl, token);
+      const { url: externalReaderUrl } = await details.getLocation(
+        catalogUrl,
+        token
+      );
+
       // we are about to open the book, so send a track event
       track.openBook(trackOpenBookUrl);
       setLoading(false);
-      window.open(url, "__blank");
+      window.open(externalReaderUrl, "__blank");
     } catch (e) {
       setLoading(false);
       handleError(e);
@@ -147,8 +151,17 @@ const DownloadButton: React.FC<{
     setLoading(true);
     clearError();
     try {
-      const url = await details.getUrl(catalogUrl, token);
-      await downloadFile(url, title, details.contentType, token);
+      const {
+        url: downloadUrl,
+        token: downloadToken
+      } = await details.getLocation(catalogUrl, token);
+
+      await downloadFile(
+        downloadUrl,
+        title,
+        details.contentType,
+        downloadToken
+      );
     } catch (e) {
       setLoading(false);
       handleError(e);

--- a/src/dataflow/__tests__/download.test.ts
+++ b/src/dataflow/__tests__/download.test.ts
@@ -1,0 +1,78 @@
+import fetchMock from "jest-fetch-mock";
+import downloadFile from "../download";
+
+describe("downloadFile", () => {
+  test("should fetch the url with the supplied token", async () => {
+    fetchMock.mockResponseOnce("nice job");
+
+    await downloadFile(
+      "some-url",
+      "title",
+      "application/epub+zip",
+      "this token"
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("some-url", {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        Authorization: "this token"
+      }
+    });
+  });
+
+  test("should retry the request without the X-Requested-With header if there is a network/CORS error", async () => {
+    fetchMock.mockRejectOnce();
+    fetchMock.mockResponseOnce("nice job");
+
+    await downloadFile(
+      "some-url",
+      "title",
+      "application/epub+zip",
+      "this token"
+    );
+
+    expect(fetchMock).toBeCalledTimes(2);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "some-url", {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        Authorization: "this token"
+      }
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "some-url", {
+      headers: {
+        Authorization: "this token"
+      }
+    });
+  });
+
+  test("should retry the request to the redirected url, without any headers, if there is an error response after a redirect", async () => {
+    fetchMock.mockResponseOnce("oh no", {
+      status: 400,
+      // counter >= 1 indicates a redirect occurred in Node's fetch implementation
+      counter: 1,
+      url: "redirected-url"
+    });
+
+    fetchMock.mockResponseOnce("ok cool");
+
+    await downloadFile(
+      "some-url",
+      "title",
+      "application/epub+zip",
+      "this token"
+    );
+
+    expect(fetchMock).toBeCalledTimes(2);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "some-url", {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        Authorization: "this token"
+      }
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "redirected-url");
+  });
+});

--- a/src/dataflow/__tests__/fetch.test.ts
+++ b/src/dataflow/__tests__/fetch.test.ts
@@ -1,0 +1,107 @@
+import fetchMock from "jest-fetch-mock";
+import fetchWithHeaders from "../fetch";
+
+describe("fetchWithHeaders", () => {
+  test("adds the X-Requested-With header", async () => {
+    fetchMock.mockResponseOnce("you did it!");
+
+    await fetchWithHeaders("some-url");
+
+    expect(fetchMock).toHaveBeenCalledWith("some-url", {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest"
+      }
+    });
+  });
+
+  test("adds the Authorization header when a token is supplied", async () => {
+    fetchMock.mockResponseOnce("you did it!");
+
+    await fetchWithHeaders("some-url", "some token");
+
+    expect(fetchMock).toHaveBeenCalledWith("some-url", {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        Authorization: "some token"
+      }
+    });
+  });
+
+  test("adds any additonal headers that are supplied", async () => {
+    fetchMock.mockResponseOnce("you did it!");
+
+    await fetchWithHeaders("some-url", "some token", {
+      "Accept-Language": "us-en",
+      "X-Something-Else": "what?"
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("some-url", {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        Authorization: "some token",
+        "Accept-Language": "us-en",
+        "X-Something-Else": "what?"
+      }
+    });
+  });
+
+  test("does not add the Authorization header when the token is undefined", async () => {
+    fetchMock.mockResponseOnce("you did it!");
+
+    await fetchWithHeaders("some-url", undefined, {
+      "X-Something-Else": "what?"
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("some-url", {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        "X-Something-Else": "what?"
+      }
+    });
+  });
+
+  test("overrides default headers with any supplied additional headers of the same name", async () => {
+    fetchMock.mockResponseOnce("you did it!");
+
+    await fetchWithHeaders("some-url", "some token", {
+      "X-Requested-With": "I changed it"
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("some-url", {
+      headers: {
+        "X-Requested-With": "I changed it",
+        Authorization: "some token"
+      }
+    });
+  });
+
+  test("does not allow the Authorization header to be overridden when a token is supplied", async () => {
+    fetchMock.mockResponseOnce("you did it!");
+
+    await fetchWithHeaders("some-url", "some token", {
+      Authorization: "should not change"
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("some-url", {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        Authorization: "some token"
+      }
+    });
+  });
+
+  test("does not send headers with undefined value", async () => {
+    fetchMock.mockResponseOnce("you did it!");
+
+    await fetchWithHeaders("some-url", "some token", {
+      "X-Requested-With": undefined,
+      "X-Something-Else": undefined
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("some-url", {
+      headers: {
+        Authorization: "some token"
+      }
+    });
+  });
+});

--- a/src/dataflow/fetch.ts
+++ b/src/dataflow/fetch.ts
@@ -8,7 +8,7 @@ import { FetchError } from "errors";
 export default async function fetchWithHeaders(
   url: string,
   token?: string,
-  additionalHeaders?: { [key: string]: string }
+  additionalHeaders?: { [key: string]: string | undefined }
 ) {
   const headers = prepareHeaders(token, additionalHeaders);
 
@@ -26,16 +26,38 @@ export default async function fetchWithHeaders(
 
 function prepareHeaders(
   token?: string,
-  additionalHeaders?: { [key: string]: string }
+  additionalHeaders?: { [key: string]: string | undefined }
 ) {
-  const headers: {
-    [key: string]: string;
+  // Merge the additional headers into any default headers.
+
+  const mergedHeaders: {
+    [key: string]: string | undefined;
   } = {
     "X-Requested-With": "XMLHttpRequest",
     ...additionalHeaders
   };
+
+  // The headers to be returned.
+
+  const headers: {
+    [key: string]: string;
+  } = {};
+
+  // Return only the headers that are not undefined.
+
+  Object.keys(mergedHeaders).forEach(key => {
+    const value = mergedHeaders[key];
+
+    if (value !== undefined) {
+      headers[key] = value;
+    }
+  });
+
+  // Add the authorization header if a token is present.
+
   if (token) {
     headers["Authorization"] = token;
   }
+
   return headers;
 }

--- a/src/dataflow/opds1/fetch.ts
+++ b/src/dataflow/opds1/fetch.ts
@@ -1,6 +1,6 @@
 import OPDSParser, { OPDSFeed, OPDSEntry } from "opds-feed-parser";
 import ApplicationError, { ServerError } from "errors";
-import { AnyBook, CollectionData } from "interfaces";
+import { AnyBook, CollectionData, OPDS1 } from "interfaces";
 import { entryToBook, feedToCollection } from "dataflow/opds1/parse";
 import fetchWithHeaders from "dataflow/fetch";
 import parseSearchData from "dataflow/opds1/parseSearchData";
@@ -101,6 +101,23 @@ export async function fetchBook(
   const entry = await fetchEntry(url, token);
   const book = entryToBook(entry, catalogUrl);
   return book;
+}
+
+/**
+ * Fetch a bearer token to use to download a book
+ */
+export async function fetchBearerToken(
+  url: string,
+  token?: string
+): Promise<OPDS1.BearerTokenDocument> {
+  const response = await fetchWithHeaders(url, token);
+  const json = await response.json();
+
+  if (!response.ok) {
+    throw new ServerError(url, response.status, json);
+  }
+
+  return json;
 }
 
 /**

--- a/src/types/opds1.ts
+++ b/src/types/opds1.ts
@@ -226,6 +226,18 @@ export interface AuthDocument {
 }
 
 /**
+ * Bearer token propagation document
+ * See: https://github.com/NYPL-Simplified/Simplified/wiki/OPDSForDistributors#how-it-works
+ */
+
+export interface BearerTokenDocument {
+  expires_in: string;
+  token_type: string;
+  access_token: string;
+  location: string;
+}
+
+/**
  * SAML is an extension on the OPDS1 spec which only
  * works when backed by a Circulation Manager
  */

--- a/src/utils/__tests__/fulfill.test.ts
+++ b/src/utils/__tests__/fulfill.test.ts
@@ -1,0 +1,41 @@
+import fetchMock from "jest-fetch-mock";
+import { MediaSupportLevel, OPDS1 } from "../../interfaces";
+import { DownloadFulfillment, getFulfillmentFromLink } from "../fulfill";
+
+describe("getFulfillmentFromLink", () => {
+  describe("for an indirect bearer token link", () => {
+    const link = {
+      contentType: OPDS1.EpubMediaType as OPDS1.AnyBookMediaType,
+      url: "link-url",
+      indirectionType: OPDS1.BearerTokenMediaType as OPDS1.IndirectAcquisitionType,
+      supportLevel: "show" as MediaSupportLevel
+    };
+
+    test("should return a fulfillment that gets the download url and token by retrieving a bearer token propagation document", async () => {
+      const fulfillment = getFulfillmentFromLink(link) as DownloadFulfillment;
+
+      fetchMock.mockResponseOnce(
+        /* eslint-disable camelcase */
+        JSON.stringify({
+          expires_in: 60,
+          token_type: "Token-type",
+          access_token: "download-token",
+          location: "download-url"
+        })
+        /* eslint-enable camelcase */
+      );
+
+      const location = await fulfillment.getLocation("catalog-url", "token");
+
+      expect(fetchMock).toHaveBeenCalledWith("link-url", {
+        headers: {
+          "X-Requested-With": "XMLHttpRequest",
+          Authorization: "token"
+        }
+      });
+
+      expect(location.url).toBe("download-url");
+      expect(location.token).toBe("Token-type download-token");
+    });
+  });
+});


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Implement indirect bearer token fulfillment, as described here: https://github.com/NYPL-Simplified/Simplified/wiki/OPDSForDistributors#how-it-works

- Configure indirect bearer token links to pdf and epub content to be downloadable.
- When resolving indirect links, allow receiving a download token in addition to a download URL. Previously, an indirect link was expected to resolve to a URL only.
- When downloading a book, if a network/CORS error occurs, retry the request without the `X-Requested-With` header. This non-standard (though not uncommon) header may not be whitelisted for CORS by some distributors' servers. This solves a problem downloading from BiblioBoard's S3 bucket. We can ask them to modify their CORS rules on S3, but I expect this might be a problem with other distributors as well.
- When passing headers to the function that performs HTTP requests, an `undefined` value now causes the header to be deleted. This enables the selective removal of default headers. This is used to implement the above.
- Add unit tests for the new functionality, and for some things that weren't previously tested.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This adds support for distributors that use bearer tokens for download, e.g. Johns Hopkins, Casalini, Biblioboard, ProQuest.

Notion: https://www.notion.so/lyrasis/Add-support-for-Biblioboard-eBooks-in-CPW-13b9d749f5f24713ad82d9ccb27ac259

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified borrowing and downloading some books from Biblioboard:

On LYRASIS:
"The Hound of the Baskervilles (Edition 1)" (epub)
"X : Volume One, Big Bad (Volume 1)" (pdf)

On Ferguson:
"Back to Basics :" (pdf)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
