### PR TITLE
Create sync.yml

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,39 @@
+name: Sync branch with NYPL
+on:
+  schedule:
+    - cron:  '0 7 * * *'
+
+  workflow_dispatch:
+
+jobs:
+  sync_with_nypl:
+    runs-on: ubuntu-latest
+
+    env:
+      UPSTREAM_ORG: NYPL-Simplified
+      UPSTREAM_REPO: circulation-patron-web
+      UPSTREAM_BRANCH: dev
+      ORIGIN_BRANCH: nypl/dev
+
+    steps:
+      - name: Checkout repo to sync
+        uses: actions/checkout@v2
+        with:
+          path: code
+
+      - name: Checkout CI scripts
+        uses: actions/checkout@v2
+        with:
+          repository: 'ThePalaceProject/ci-scripts'
+          path: ci
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Python requirements
+        run: pip install -r ci/sync-requirements.txt
+
+      - name: Sync branch with upstream
+        run: python ci/sync.py code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
+- Add new github action to sync a branch with NYPL.
 - Update iOS App Store badge to link to Palace app.
 - Fix foreign-language books not appearing in search results.
 - Update Google Play Store badge to link to Palace app.


### PR DESCRIPTION
## Description

Add github action that syncs a branch (`nypl/dev`) on this repo with NYPL every night. This makes it easier to pull in changes from upstream and resolve any merge conflicts, when we want to pull in changes. 

We are doing a similar sync on:
- circulation 
- circulation-core 
- circulation-admin 
- library-registry
- library-registry-admin

I thought it probably makes sense to do this here as well. 
