### PR TITLE
Restore Palace branding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### UNRELEASED CHANGES
 - Fix "Cannot find module 'sharp'" error on installation.
+- Update iOS App Store badge to link to Palace app.
 - Update Google Play Store badge to link to Palace app.
 - Update logo/text in mobile app callouts.
 - Implement indirect bearer token borrowing (adds support for Johns Hopkins, Biblioboard, ProQuest, and other distributors).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
-- Fix "Cannot find module 'sharp'" error on installation.
+- Change font to Open Sans.
 - Update iOS App Store badge to link to Palace app.
 - Update Google Play Store badge to link to Palace app.
 - Update logo/text in mobile app callouts.
+- Fix "Cannot find module 'sharp'" error on installation.
 - Implement indirect bearer token borrowing (adds support for Johns Hopkins, Biblioboard, ProQuest, and other distributors).
 - Add new github action to sync a branch with NYPL.
 - Fix foreign-language books not appearing in search results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### UNRELEASED CHANGES
 - Fix "Cannot find module 'sharp'" error on installation.
+- Update Google Play Store badge to link to Palace app.
 - Update logo/text in mobile app callouts.
 - Implement indirect bearer token borrowing (adds support for Johns Hopkins, Biblioboard, ProQuest, and other distributors).
 - Add new github action to sync a branch with NYPL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### UNRELEASED CHANGES
 - Fix "Cannot find module 'sharp'" error on installation.
+- Update logo/text in mobile app callouts.
 - Implement indirect bearer token borrowing (adds support for Johns Hopkins, Biblioboard, ProQuest, and other distributors).
 - Add new github action to sync a branch with NYPL.
 - Fix foreign-language books not appearing in search results.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "request": "^2.88.2",
         "styled-system": "^5.1.2",
         "swr": "^0.3.2",
-        "system-font-css": "^2.0.2",
         "theme-ui": "^0.3.1",
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "request": "^2.88.2",
     "styled-system": "^5.1.2",
     "swr": "^0.3.2",
-    "system-font-css": "^2.0.2",
     "theme-ui": "^0.3.1",
     "tslib": "^2.3.0"
   },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -107,11 +107,11 @@ const DownloadSimplyECallout = () => (
   <div sx={{ maxWidth: 300, flex: "0 1 auto", mt: 5 }}>
     <H3 sx={{ mt: 0, display: "flex", alignItems: "center" }}>
       <SvgPhone sx={{ mr: 1 }} />
-      Download SimplyE
+      Download Palace
     </H3>
     <Text>
       Our mobile app lets you browse, borrow and read from our whole collection
-      of eBooks and Audiobooks right on your phone!
+      of ebooks and audiobooks right on your phone!
     </Text>
     <div sx={{ width: "75%", overflow: "hidden", ml: -3 }}>
       <IosBadge sx={{ p: 3, pb: 0 }} />

--- a/src/components/PalaceLogo.tsx
+++ b/src/components/PalaceLogo.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+function PalaceLogo(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 713.68 882"
+      aria-label="Palace Logo"
+      {...props}
+    >
+      <polygon
+        fill="#3eb9e7"
+        points="357.43 451.68 357.43 628.23 597.52 460.11 597.52 283.56 357.43 451.68"
+      />
+      <polygon
+        fill="#2225ae"
+        points="597.52 283.56 597.52 283.56 357.43 115.45 357.43 322.24 449.86 386.96 597.52 283.56"
+      />
+      <polygon
+        fill="#fc8442"
+        points="117.34 656.89 191.67 622.19 266.01 760.99 266.01 387.66 117.34 283.56 117.34 656.89"
+      />
+      <polygon
+        fill="#fb361d"
+        points="117.34 283.56 117.83 283.91 266.01 387.66 357.43 322.24 357.43 115.45 117.34 283.56"
+      />
+    </svg>
+  );
+}
+
+export default PalaceLogo;

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -111,7 +111,7 @@ describe("toggling SimplyE Branding", () => {
     expect(googleBadge).toBeInTheDocument();
     expect(googleBadge).toHaveAttribute(
       "href",
-      "https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
+      "https://play.google.com/store/apps/details?id=org.thepalaceproject.palace&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
     );
 
     // my books nav link

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -102,7 +102,7 @@ describe("toggling SimplyE Branding", () => {
     expect(iosbadge).toBeInTheDocument();
     expect(iosbadge).toHaveAttribute(
       "href",
-      "https://apps.apple.com/us/app/simplye/id1046583900"
+      "https://apps.apple.com/us/app/the-palace-project/id1574359693"
     );
 
     const googleBadge = utils.getByRole("link", {

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -52,23 +52,23 @@ describe("toggling SimplyE Branding", () => {
 
     const utils = render(<Footer />);
 
-    expect(utils.queryByText(/download simplye/i)).not.toBeInTheDocument();
+    expect(utils.queryByText(/download palace/i)).not.toBeInTheDocument();
 
     expect(
       utils.queryByText(
-        "Our mobile app lets you browse, borrow and read from our whole collection of eBooks and Audiobooks right on your phone!"
+        "Our mobile app lets you browse, borrow and read from our whole collection of ebooks and audiobooks right on your phone!"
       )
     ).not.toBeInTheDocument();
 
     // badges
     const iosbadge = utils.queryByText(
-      /download simplye on the apple app store/i
+      /download palace on the apple app store/i
     );
 
     expect(iosbadge).not.toBeInTheDocument();
 
     const googleBadge = utils.queryByText(
-      /get simplye on the google play store/
+      /get palace on the google play store/
     );
     expect(googleBadge).not.toBeInTheDocument();
 
@@ -85,19 +85,19 @@ describe("toggling SimplyE Branding", () => {
 
     expect(
       utils.getByRole("heading", {
-        name: /download simplye/i
+        name: /download palace/i
       })
     ).toBeInTheDocument();
 
     expect(
       utils.getByText(
-        "Our mobile app lets you browse, borrow and read from our whole collection of eBooks and Audiobooks right on your phone!"
+        "Our mobile app lets you browse, borrow and read from our whole collection of ebooks and audiobooks right on your phone!"
       )
     ).toBeInTheDocument();
 
     // badges
     const iosbadge = utils.getByRole("link", {
-      name: /download simplye on the apple app store/i
+      name: /download palace on the apple app store/i
     });
     expect(iosbadge).toBeInTheDocument();
     expect(iosbadge).toHaveAttribute(
@@ -106,7 +106,7 @@ describe("toggling SimplyE Branding", () => {
     );
 
     const googleBadge = utils.getByRole("link", {
-      name: /get simplye on the google play store/i
+      name: /get palace on the google play store/i
     });
     expect(googleBadge).toBeInTheDocument();
     expect(googleBadge).toHaveAttribute(

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`LinkButton renders correct element 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;
@@ -73,7 +73,7 @@ exports[`NavButton renders correct element 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: inherit;
-  font-family: -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;
@@ -147,7 +147,7 @@ exports[`NavButton renders correct element 1`] = `
 
 exports[`variants filled (default) 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;
@@ -215,7 +215,7 @@ exports[`variants filled (default) 1`] = `
 
 exports[`variants ghost 1`] = `
 .emotion-0 {
-  font-family: -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-size: 0.875rem;
   font-weight: 700;
   line-height: 1.5;
@@ -299,7 +299,7 @@ exports[`variants link 1`] = `
   -webkit-text-decoration: underline;
   text-decoration: underline;
   background-color: transparent;
-  font-family: -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-size: 1rem;
   font-weight: 300;
   line-height: 1.5;

--- a/src/components/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Select.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`select matches snapshot 1`] = `
   padding-bottom: 4px;
   border: 1px solid #bdbdbd;
   border-radius: 2px;
-  font-family: -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TextInput renders properly and passes styles through 1`] = `
   padding-top: 4px;
   padding-bottom: 4px;
   font-size: 1rem;
-  font-family: -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-weight: 300;
   line-height: 1.5;
   width: 100%;
@@ -55,7 +55,7 @@ exports[`type textarea renders properly and passes styles throug 1`] = `
   padding-top: 4px;
   padding-bottom: 4px;
   font-size: 1rem;
-  font-family: -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-weight: 300;
   line-height: 1.5;
   width: 100%;

--- a/src/components/__tests__/__snapshots__/form.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/form.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders as expected 1`] = `
   padding-top: 4px;
   padding-bottom: 4px;
   font-size: 1rem;
-  font-family: -apple-system,BlinkMacSystemFont,system-ui,sans-serif;
+  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-weight: 300;
   line-height: 1.5;
   width: 100%;

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -122,7 +122,7 @@ describe("book details page", () => {
     expect(iosBadge).toBeInTheDocument();
     expect(iosBadge).toHaveAttribute(
       "href",
-      "https://apps.apple.com/us/app/simplye/id1046583900"
+      "https://apps.apple.com/us/app/the-palace-project/id1574359693"
     );
 
     const googleBadge = utils.getByRole("link", {

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -92,14 +92,12 @@ describe("book details page", () => {
     mockSwr({ data: fixtures.book });
     const utils = render(<BookDetails />);
 
-    expect(
-      utils.queryByText("Read Now. Read Everywhere.")
-    ).not.toBeInTheDocument();
+    expect(utils.queryByText("Download Palace")).not.toBeInTheDocument();
 
-    expect(utils.queryByText("SimplyE Logo")).not.toBeInTheDocument();
+    expect(utils.queryByText("Palace Logo")).not.toBeInTheDocument();
     expect(
       utils.queryByText(
-        "Browse and read our collection of eBooks and Audiobooks right from your phone."
+        "Browse and read our collection of ebooks and audiobooks right from your phone."
       )
     ).not.toBeInTheDocument();
   });
@@ -109,16 +107,16 @@ describe("book details page", () => {
     mockSwr({ data: fixtures.book });
     const utils = render(<BookDetails />);
 
-    expect(utils.getByText("Read Now. Read Everywhere.")).toBeInTheDocument();
-    expect(utils.getByLabelText("SimplyE Logo")).toBeInTheDocument();
+    expect(utils.getByText("Download Palace")).toBeInTheDocument();
+    expect(utils.getByLabelText("Palace Logo")).toBeInTheDocument();
     expect(
       utils.getByText(
-        "Browse and read our collection of eBooks and Audiobooks right from your phone."
+        "Browse and read our collection of ebooks and audiobooks right from your phone."
       )
     ).toBeInTheDocument();
 
     const iosBadge = utils.getByRole("link", {
-      name: "Download SimplyE on the Apple App Store",
+      name: "Download Palace on the Apple App Store",
       hidden: true // it is initially hidden by a media query, only displayed on desktop
     });
     expect(iosBadge).toBeInTheDocument();
@@ -128,7 +126,7 @@ describe("book details page", () => {
     );
 
     const googleBadge = utils.getByRole("link", {
-      name: "Get SimplyE on the Google Play Store",
+      name: "Get Palace on the Google Play Store",
       hidden: true // hidden initially on mobile
     });
     expect(googleBadge).toBeInTheDocument();

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -132,7 +132,7 @@ describe("book details page", () => {
     expect(googleBadge).toBeInTheDocument();
     expect(googleBadge).toHaveAttribute(
       "href",
-      "https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
+      "https://play.google.com/store/apps/details?id=org.thepalaceproject.palace&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
     );
   });
 

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -13,7 +13,7 @@ import ReportProblem from "./ReportProblem";
 import Head from "next/head";
 import { H1, H2, H3, Text } from "components/Text";
 import MediumIndicator from "components/MediumIndicator";
-import SimplyELogo from "components/SimplyELogo";
+import PalaceLogo from "components/PalaceLogo";
 import IosBadge from "components/storeBadges/IosBadge";
 import GooglePlayBadge from "components/storeBadges/GooglePlayBadge";
 import { useRouter } from "next/router";
@@ -120,7 +120,7 @@ const Summary: React.FC<{ book: AnyBook; className?: string }> = ({
 const SimplyECallout: React.FC<{ className?: "string" }> = ({ className }) => {
   return (
     <section
-      aria-label="Download the SimplyE Mobile App"
+      aria-label="Download the Palace Mobile App"
       sx={{
         mt: 4,
         bg: "ui.gray.lightWarm",
@@ -131,10 +131,10 @@ const SimplyECallout: React.FC<{ className?: "string" }> = ({ className }) => {
       }}
       className={className}
     >
-      <SimplyELogo sx={{ m: 3 }} />
-      <H3 sx={{ mt: 0 }}>Read Now. Read Everywhere.</H3>
+      <PalaceLogo sx={{ mt: 3, height: "120px" }} />
+      <H3 sx={{ mt: 0 }}>Download Palace</H3>
       <Text>
-        Browse and read our collection of eBooks and Audiobooks right from your
+        Browse and read our collection of ebooks and audiobooks right from your
         phone.
       </Text>
       <div sx={{ maxWidth: 140, mx: "auto", mt: 3 }}>

--- a/src/components/storeBadges/GooglePlayBadge.tsx
+++ b/src/components/storeBadges/GooglePlayBadge.tsx
@@ -7,7 +7,8 @@ const GooglePlayBadge = (props: React.ComponentProps<"a">) => {
     <a
       rel="noopener noreferrer"
       target="__blank"
-      aria-label="Get SimplyE on the Google Play Store"
+      aria-label="Get Palace on the Google Play Store"
+      // TODO: Replace with correct URL when Palace is in the Play Store.
       href="https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
       sx={{ display: "block" }}
       {...props}

--- a/src/components/storeBadges/GooglePlayBadge.tsx
+++ b/src/components/storeBadges/GooglePlayBadge.tsx
@@ -9,7 +9,7 @@ const GooglePlayBadge = (props: React.ComponentProps<"a">) => {
       target="__blank"
       aria-label="Get Palace on the Google Play Store"
       // TODO: Replace with correct URL when Palace is in the Play Store.
-      href="https://play.google.com/store/apps/details?id=org.nypl.simplified.simplye&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
+      href="https://play.google.com/store/apps/details?id=org.thepalaceproject.palace&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1"
       sx={{ display: "block" }}
       {...props}
     >

--- a/src/components/storeBadges/IosBadge.tsx
+++ b/src/components/storeBadges/IosBadge.tsx
@@ -8,8 +8,9 @@ const IosBadge = (props: React.ComponentProps<"a">) => {
     <a
       rel="noopener noreferrer"
       target="__blank"
+      // TODO: Replace with correct URL when Palace is in the App Store.
       href="https://apps.apple.com/us/app/simplye/id1046583900"
-      aria-label="Download SimplyE on the Apple App Store"
+      aria-label="Download Palace on the Apple App Store"
       sx={{ display: "block" }}
       {...props}
     >

--- a/src/components/storeBadges/IosBadge.tsx
+++ b/src/components/storeBadges/IosBadge.tsx
@@ -8,8 +8,7 @@ const IosBadge = (props: React.ComponentProps<"a">) => {
     <a
       rel="noopener noreferrer"
       target="__blank"
-      // TODO: Replace with correct URL when Palace is in the App Store.
-      href="https://apps.apple.com/us/app/simplye/id1046583900"
+      href="https://apps.apple.com/us/app/the-palace-project/id1574359693"
       aria-label="Download Palace on the Apple App Store"
       sx={{ display: "block" }}
       {...props}

--- a/src/css-overrides.css
+++ b/src/css-overrides.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;700&display=swap');
+
 /* this is to fix a problem in NYPL Design System setting global svg styles */
 svg {
   width: initial;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom";
 import { AppProps, NextWebVitalsMetric } from "next/app";
 import { IS_SERVER, REACT_AXE } from "../utils/env";
 import { ErrorBoundary } from "components/ErrorBoundary";
-import "system-font-css";
 import "@nypl/design-system-react-components/dist/styles.css";
 import "css-overrides.css";
 import track from "analytics/track";

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,7 +1,7 @@
 const typography = {
   fonts: {
-    body: "-apple-system, BlinkMacSystemFont, system-ui, sans-serif",
-    heading: "-apple-system, BlinkMacSystemFont, system-ui, sans-seri",
+    body: "'Open Sans',Helvetica,Arial,sans-serif",
+    heading: "'Open Sans',Helvetica,Arial,sans-serif",
     monospace: "Menlo, monospace"
   },
   fontSizes: {


### PR DESCRIPTION
## Description

This restores the Palace branding changes that were previously done (https://github.com/ThePalaceProject/web-patron/pull/4, https://github.com/ThePalaceProject/web-patron/pull/7, https://github.com/ThePalaceProject/web-patron/pull/9) and reverted (https://github.com/ThePalaceProject/web-patron/pull/14) so that we could publish some other changes.

It includes:
- Update logo/text in mobile app callouts.
- Update Google Play Store badge to link to Palace app.
- Update iOS App Store badge to link to Palace app.

There is also one new change:
- Change the font to Open Sans.

## Motivation and Context

This removes references to SimplyE, and aligns the web catalog with Palace branding guidelines.

Notion:
- https://www.notion.so/lyrasis/Update-CPW-Apps-Store-links-and-Logos-beddece52d5f44c687cb467b844d7921
- https://www.notion.so/lyrasis/Upate-CPW-with-Brand-guidance-8fe1399dae9949c89aa90d070d7764b7

## How Has This Been Tested?

@ray-lee checked that the download badges (in footer and book details) link to the Palace apps, and no longer refer to "SimplyE". I also clicked around, and verified that all text is rendered in Open Sans.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
