### PR TITLE
Fix for redirect URLs incorrectly being identified as full URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
-- Fix check on redirect URL to make sure it doesn't start with http, instead of contain HTTP, since it was falsely matching some legitimate URLs.
+- Fix check on redirect URL to make sure it doesn't start with HTTP, instead of contain HTTP, since it was falsely matching some legitimate URLs.
 - Change font to Open Sans.
 - Update iOS App Store badge to link to Palace app.
 - Update Google Play Store badge to link to Palace app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CHANGELOG
 
 ### UNRELEASED CHANGES
+- Fix check on redirect URL to make sure it doesn't start with http, instead of contain HTTP, since it was falsely matching some legitimate URLs.
 - Change font to Open Sans.
 - Update iOS App Store badge to link to Palace app.
 - Update Google Play Store badge to link to Palace app.

--- a/src/auth/__tests__/LoginWrapper.test.tsx
+++ b/src/auth/__tests__/LoginWrapper.test.tsx
@@ -83,4 +83,46 @@ describe("redirects when user becomes authenticated", () => {
       shallow: true
     });
   });
+
+  test("uses homepage when nextUrl start with http", () => {
+    render(<LoginWrapper />, {
+      user: {
+        isAuthenticated: true
+      },
+      router: {
+        query: {
+          nextUrl: "http://test.com/test123"
+        }
+      }
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    // redirects to home page instead of nextUrl
+    expect(mockPush).toHaveBeenCalledWith("/testlib", undefined, {
+      shallow: true
+    });
+  });
+
+  test("uses nextUrl when url contains http", () => {
+    render(<LoginWrapper />, {
+      user: {
+        isAuthenticated: true
+      },
+      router: {
+        query: {
+          nextUrl: "/book/somewhere/http%3A%2F%2Ftest.com%2F123%2F456"
+        }
+      }
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    // redirects to home page instead of nextUrl
+    expect(mockPush).toHaveBeenCalledWith(
+      "/book/somewhere/http%3A%2F%2Ftest.com%2F123%2F456",
+      undefined,
+      {
+        shallow: true
+      }
+    );
+  });
 });

--- a/src/auth/__tests__/LoginWrapper.test.tsx
+++ b/src/auth/__tests__/LoginWrapper.test.tsx
@@ -84,7 +84,7 @@ describe("redirects when user becomes authenticated", () => {
     });
   });
 
-  test("uses homepage when nextUrl start with http", () => {
+  test("uses homepage when nextUrl starts with http", () => {
     render(<LoginWrapper />, {
       user: {
         isAuthenticated: true
@@ -103,7 +103,7 @@ describe("redirects when user becomes authenticated", () => {
     });
   });
 
-  test("uses nextUrl when url contains http", () => {
+  test("uses nextUrl when url contains, but does not start with, http", () => {
     render(<LoginWrapper />, {
       user: {
         isAuthenticated: true

--- a/src/auth/useLoginRedirect.tsx
+++ b/src/auth/useLoginRedirect.tsx
@@ -19,7 +19,7 @@ export default function useLoginRedirectUrl() {
   // if the redirect url is the login url, we would end up in a loop.
   const isLoginPath = nextPath?.includes("/login");
   // if it is a full url, it was invalidly set somehow
-  const isFullUrl = nextPath?.includes("http");
+  const isFullUrl = nextPath?.startsWith("http");
   // if the redirect url is the home page, choose the catalog root instead
   const isHomePage = nextPath === "/";
 


### PR DESCRIPTION
## Description

From this notion ticket:
https://www.notion.so/lyrasis/Correct-Columbia-CPW-configuration-to-match-the-QA-config-Borrow-Only-76e5c0578a0943f2bebbb07ac11909f6

In Columbia CPW instance users were not getting redirected properly when borrowing.

## Motivation and Context

When borrowing books, users aren't getting redirected after logging in. This is happening because of a new check added in the code, the does not redirect when a URL contains `http`, however some URLs in the Columbia instance have books with `http` in the identifier. So they were being detected as full URLs. 

For example a book with this identifier: 
`https%3A%2F%2Fcolumbia.edu.thepalaceproject.org%2F190150%2Fworks%2FURI%2Furn%3Ax-internet-archive%3Aebooks-app%3Aitem%3Aldpd_12584146_000`

## How Has This Been Tested?

- Tested locally, by pointing to Columbia CM 
- Added some tests for this case
