### PR TITLE
Adopt new GH actions environment files and prep for Node 12 deprecation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dangoslen/changelog-enforcer@v1.4.0
+      - uses: dangoslen/changelog-enforcer@v3
         with:
           changeLogPath: "CHANGELOG.md"
           skipLabel: "no-changelog"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         with: { node-version: "${{ steps.nvmrc.outputs.NODE_VERSION }}" }
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -70,7 +70,7 @@ jobs:
         with: { node-version: "${{ steps.nvmrc.outputs.NODE_VERSION }}" }
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -103,7 +103,7 @@ jobs:
         with: { node-version: "${{ steps.nvmrc.outputs.NODE_VERSION }}" }
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Use Node Version from nvmrc
         uses: actions/setup-node@v1
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Use Node Version from nvmrc
         uses: actions/setup-node@v1
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Use Node Version from nvmrc
         uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Updates Changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dangoslen/changelog-enforcer@v1.4.0
         with:
           changeLogPath: "CHANGELOG.md"
@@ -28,7 +28,7 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: nvmrc
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
@@ -61,7 +61,7 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: nvmrc
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
@@ -94,7 +94,7 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: nvmrc
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Use Node Version from nvmrc
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with: { node-version: "${{ steps.nvmrc.outputs.NODE_VERSION }}" }
 
       - name: Cache node modules
@@ -66,7 +66,7 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Use Node Version from nvmrc
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with: { node-version: "${{ steps.nvmrc.outputs.NODE_VERSION }}" }
 
       - name: Cache node modules
@@ -99,7 +99,7 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Use Node Version from nvmrc
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with: { node-version: "${{ steps.nvmrc.outputs.NODE_VERSION }}" }
 
       - name: Cache node modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: dangoslen/changelog-enforcer@v3
         with:
           changeLogPath: "CHANGELOG.md"
-          skipLabel: "no-changelog"
+          skipLabels: "no-changelog"
 
   lint:
     name: Lint

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Trigger test with webhook
         uses: joelwmale/webhook-action@aed4f319dce44a4f73cdf0480b94df9e6dfc6cae
         # based on the following curl command from A1QA

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Use Node Version from nvmrc
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with: { node-version: "${{ steps.nvmrc.outputs.NODE_VERSION }}" }
 
       - name: Set up QEMU

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - id: nvmrc
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT
 
       - name: Use Node Version from nvmrc
         uses: actions/setup-node@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - id: nvmrc
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_OUTPUT

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout repo to sync
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: code
 
       - name: Checkout CI scripts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'ThePalaceProject/ci-scripts'
           path: ci


### PR DESCRIPTION
## Description

- Locally adopt the new `$GITHUB_OUTPUT` environment file, instead of the deprecated `set-output`, for GH actions.
- Update `actions/checkout` from V2 to V3, since V2 relies on deprecated Node 12.
- Update `actions/setup-node` from V1 to V3.
- Update `actions/caqche` from V1 to V3.
- Update `dangoslen/changelog-enforcer` to V3.

NB: The `coverallsapp/github-action@master` action used in `.github/workflows/ci.yml` has not been updated and will fail, if not updated before the switch to Node 16.

## Motivation and Context

- The `save-state` and `set-output` workflow commands have been deprecated. [[GitHub post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)] [[Notion](https://www.notion.so/lyrasis/Use-new-GitHub-Actions-environment-files-816e94f3abfb4e73ad6bd75645f07249)]
- Node 12 is being deprecated for Node 16 in GitHub Actions. [[GitHub post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)]

## How Has This Been Tested?

Will review CI logs from the associated PR.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.