### PR TITLE
Upgrade to changelog enforcer v3 (>= v3.3.2).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Updates Changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: dangoslen/changelog-enforcer@v3.3.0
+      - uses: dangoslen/changelog-enforcer@v3.3.2
         with:
           changeLogPath: "CHANGELOG.md"
           skipLabels: "no-changelog"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Updates Changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: dangoslen/changelog-enforcer@v3.3.2
+      - uses: dangoslen/changelog-enforcer@release/v3.3.2
         with:
           changeLogPath: "CHANGELOG.md"
           skipLabels: "no-changelog"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
     name: Updates Changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dangoslen/changelog-enforcer@v3
+      - uses: dangoslen/changelog-enforcer@v3.3.0
         with:
           changeLogPath: "CHANGELOG.md"
           skipLabels: "no-changelog"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Updates Changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: dangoslen/changelog-enforcer@releases/v3.3.2
+      - uses: dangoslen/changelog-enforcer@v3.3.2
         with:
           changeLogPath: "CHANGELOG.md"
           skipLabels: "no-changelog"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Updates Changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: dangoslen/changelog-enforcer@v3.3.2
+      - uses: dangoslen/changelog-enforcer@v3
         with:
           changeLogPath: "CHANGELOG.md"
           skipLabels: "no-changelog"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Updates Changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: dangoslen/changelog-enforcer@release/v3.3.2
+      - uses: dangoslen/changelog-enforcer@releases/v3.3.2
         with:
           changeLogPath: "CHANGELOG.md"
           skipLabels: "no-changelog"


### PR DESCRIPTION
## Description

- Upgrades the `dangoslen/changelog-enforcer` GitHub action to (at least) v3.3.2 via the v3 major release designation.
- Removes the use of `actions/checkout` GH action in support of the changelog enforcer action, since the action no longer relies on it as of [v3.0.0](https://github.com/dangoslen/changelog-enforcer/releases/tag/v3.0.0). 

## Motivation and Context

We are moving to new GitHub Actions environment files and were seeing deprecation warnings for V3 of the action. [[Notion](https://www.notion.so/lyrasis/Use-new-GitHub-Actions-environment-files-816e94f3abfb4e73ad6bd75645f07249?pvs=4)]

## How Has This Been Tested?

The CI workflow runs at pull request time, so will review CI output to verify that this is working as expected.

## Checklist:

- N/A I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
