### PR TITLE
Log auth document URL when Catalog Root link missing. (PP-1209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### UNRELEASED CHANGES
 
+- Log auth document URL when Catalog Root link missing. (PP-1209)
 - Update default libraries config.
 - Remove no longer needed node option: -openssl-legacy-provider.
 - Fix a couple of vulnerable dependencies.

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -111,6 +111,34 @@ describe("buildLibraryData", () => {
     });
   });
 
+  test("throws ApplicationError with auth doc URL, if auth doc has no catalog root url", () => {
+    // Make sure that the error is actually thrown.
+    expect.assertions(2);
+
+    try {
+      buildLibraryData(fixtures.authDocNoCatalogRoot, "librarySlug");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApplicationError);
+      expect(error.message).toBe(
+        "Application Error: No Catalog Root URL present in Auth Document at /auth-doc."
+      );
+    }
+  });
+
+  test("throws ApplicationError without auth doc URL, if auth doc has no self url", () => {
+    // Make sure that the error is actually thrown.
+    expect.assertions(2);
+
+    try {
+      buildLibraryData(fixtures.authDocNoLinks, "librarySlug");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApplicationError);
+      expect(error.message).toBe(
+        "Application Error: No Catalog Root URL present in Auth Document at (unknown: missing auth doc 'self' link or href)."
+      );
+    }
+  });
+
   test("correctly parses web_color_scheme", () => {
     const library = buildLibraryData(
       {

--- a/src/dataflow/getLibraryData.ts
+++ b/src/dataflow/getLibraryData.ts
@@ -2,7 +2,6 @@ import { LibraryData, LibraryLinks, OPDS1 } from "interfaces";
 import ApplicationError, { PageNotFoundError, ServerError } from "errors";
 import { flattenSamlMethod } from "utils/auth";
 import { APP_CONFIG } from "utils/env";
-import { AuthDocumentLink } from "../types/opds1";
 
 /**
  * Interprets the app config to return the auth document url.
@@ -51,12 +50,14 @@ function getShelfUrl(authDoc: OPDS1.AuthDocument): string | null {
  * Extracts the catalog root url from an auth document
  */
 function getCatalogUrl(authDoc: OPDS1.AuthDocument): string {
-  const url: string | undefined =
-    authDoc.links?.find(link => link.rel === OPDS1.CatalogRootRel)?.href ?? null;
+  const url: string | undefined = authDoc.links?.find(
+    link => link.rel === OPDS1.CatalogRootRel
+  )?.href;
 
   if (!url) {
     const selfUrl =
-      authDoc.links?.find(link => link.rel === OPDS1.SelfRel)?.href ?? "(unknown: missing auth doc 'self' link or href)";
+      authDoc.links?.find(link => link.rel === OPDS1.SelfRel)?.href ??
+      "(unknown: missing auth doc 'self' link or href)";
     throw new ApplicationError({
       detail: `No Catalog Root URL present in Auth Document at ${selfUrl}.`
     });

--- a/src/dataflow/getLibraryData.ts
+++ b/src/dataflow/getLibraryData.ts
@@ -2,6 +2,7 @@ import { LibraryData, LibraryLinks, OPDS1 } from "interfaces";
 import ApplicationError, { PageNotFoundError, ServerError } from "errors";
 import { flattenSamlMethod } from "utils/auth";
 import { APP_CONFIG } from "utils/env";
+import { AuthDocumentLink } from "../types/opds1";
 
 /**
  * Interprets the app config to return the auth document url.
@@ -47,18 +48,19 @@ function getShelfUrl(authDoc: OPDS1.AuthDocument): string | null {
 }
 
 /**
- * Extracts the catalot root url from an auth document
+ * Extracts the catalog root url from an auth document
  */
 function getCatalogUrl(authDoc: OPDS1.AuthDocument): string {
-  const url =
-    authDoc.links?.find(link => {
-      return link.rel === OPDS1.CatalogRootRel;
-    })?.href ?? null;
+  const url: string | undefined =
+    authDoc.links?.find(link => link.rel === OPDS1.CatalogRootRel)?.href ?? null;
 
-  if (!url)
+  if (!url) {
+    const selfUrl =
+      authDoc.links?.find(link => link.rel === OPDS1.SelfRel)?.href ?? "(unknown: missing auth doc 'self' link or href)";
     throw new ApplicationError({
-      detail: "No Catalog Root Url present in Auth Document."
+      detail: `No Catalog Root URL present in Auth Document at ${selfUrl}.`
     });
+  }
 
   return url;
 }

--- a/src/test-utils/fixtures/auth-document.ts
+++ b/src/test-utils/fixtures/auth-document.ts
@@ -5,13 +5,13 @@ const baseAuthDoc: OPDS1.AuthDocument = {
   title: "auth doc title",
   description: "auth doc description",
   links: [],
-  authentication: [],
+  authentication: []
 };
 
 export const authDoc: OPDS1.AuthDocument = {
   ...baseAuthDoc,
   links: [
-    ...baseAuthDoc.links,
+    ...(baseAuthDoc.links ?? []),
     {
       rel: OPDS1.SelfRel,
       href: "/auth-doc"
@@ -20,7 +20,7 @@ export const authDoc: OPDS1.AuthDocument = {
       rel: OPDS1.CatalogRootRel,
       href: "/catalog-root"
     }
-  ],
+  ]
 };
 
 export const authDocNoLinks: OPDS1.AuthDocument = { ...baseAuthDoc };
@@ -28,10 +28,26 @@ export const authDocNoLinks: OPDS1.AuthDocument = { ...baseAuthDoc };
 export const authDocNoCatalogRoot: OPDS1.AuthDocument = {
   ...baseAuthDoc,
   links: [
-    ...baseAuthDoc.links,
+    ...(baseAuthDoc.links ?? []),
     {
       rel: OPDS1.SelfRel,
       href: "/auth-doc"
     }
   ]
 };
+
+// This is not a valid auth doc, since the `href` is missing for the catalog
+// root link. But we don't control these, so it could happen.
+export const authDocNoCatalogRootHref: OPDS1.AuthDocument = {
+  ...baseAuthDoc,
+  links: [
+    ...(baseAuthDoc.links ?? []),
+    {
+      rel: OPDS1.SelfRel,
+      href: "/auth-doc"
+    },
+    {
+      rel: OPDS1.CatalogRootRel
+    }
+  ]
+} as OPDS1.AuthDocument;

--- a/src/test-utils/fixtures/auth-document.ts
+++ b/src/test-utils/fixtures/auth-document.ts
@@ -1,14 +1,37 @@
 import { OPDS1 } from "interfaces";
 
-export const authDoc: OPDS1.AuthDocument = {
+const baseAuthDoc: OPDS1.AuthDocument = {
   id: "auth-doc-id",
   title: "auth doc title",
   description: "auth doc description",
+  links: [],
+  authentication: [],
+};
+
+export const authDoc: OPDS1.AuthDocument = {
+  ...baseAuthDoc,
   links: [
+    ...baseAuthDoc.links,
+    {
+      rel: OPDS1.SelfRel,
+      href: "/auth-doc"
+    },
     {
       rel: OPDS1.CatalogRootRel,
       href: "/catalog-root"
     }
   ],
-  authentication: []
+};
+
+export const authDocNoLinks: OPDS1.AuthDocument = { ...baseAuthDoc };
+
+export const authDocNoCatalogRoot: OPDS1.AuthDocument = {
+  ...baseAuthDoc,
+  links: [
+    ...baseAuthDoc.links,
+    {
+      rel: OPDS1.SelfRel,
+      href: "/auth-doc"
+    }
+  ]
 };

--- a/src/types/opds1.ts
+++ b/src/types/opds1.ts
@@ -10,6 +10,7 @@
 /**
  * Link Relations
  */
+export const SelfRel = "self";
 export const AuthDocLinkRelation = "http://opds-spec.org/auth/document";
 export const AcquisitionLinkRel = "http://opds-spec.org/acquisition";
 export const BorrowLinkRel = "http://opds-spec.org/acquisition/borrow";
@@ -17,6 +18,7 @@ export const RevokeLinkRel = "http://librarysimplified.org/terms/rel/revoke";
 export const TrackOpenBookRel =
   "http://librarysimplified.org/terms/rel/analytics/open-book";
 export type AnyLinkRelation =
+  | typeof SelfRel
   | typeof AuthDocLinkRelation
   | typeof AcquisitionLinkRel
   | typeof BorrowLinkRel
@@ -135,6 +137,7 @@ export interface Link {
 export const CatalogRootRel = "start";
 export const ShelfLinkRel = "http://opds-spec.org/shelf";
 type AuthDocLinkRelations =
+  | typeof SelfRel
   | typeof CatalogRootRel
   | typeof ShelfLinkRel
   | "navigation"


### PR DESCRIPTION
## Description

- Adds the OPDS authentication document's `self` URL (when present) to the application error message when the auth doc is missing the Catalog Root (`start`) URL.
  - If the auth doc has no `self` link or its `href` is missing, that is noted, too.
- Added some new tests.

## Motivation and Context

It was difficult to determine which OPDS server (library) was not working, since the error previously did not include the information needed to establish which of the configured libraries was causing the error.

[Jira [PP-1209](https://ebce-lyrasis.atlassian.net/browse/PP-1209)]

## How Has This Been Tested?

- Added new tests.
- All tests pass locally.
- [CI tests for associated branch](https://github.com/ThePalaceProject/web-patron/actions/runs/13018312762) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1209]: https://ebce-lyrasis.atlassian.net/browse/PP-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ