### PR TITLE
Don't include Basic Token auth in available auth mechanisms. (PP-2188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### UNRELEASED CHANGES
 
+- Don't include not yet implemented Basic Token auth as available auth mechanisms. (PP-2188)
 - distributor added to book details page
 - Log auth document URL when Catalog Root link missing. (PP-1209)
 - Update default libraries config.

--- a/src/auth/LoginPicker.tsx
+++ b/src/auth/LoginPicker.tsx
@@ -7,15 +7,23 @@ import AuthButton from "auth/AuthButton";
 import ExternalLink from "components/ExternalLink";
 import FormLabel from "components/form/FormLabel";
 import Stack from "components/Stack";
-import { AppAuthMethod } from "interfaces";
+import { AppAuthMethod, OPDS1 } from "interfaces";
 import { Select } from "theme-ui";
 import { Text } from "components/Text";
 import LoadingIndicator from "components/LoadingIndicator";
 import useLogin from "auth/useLogin";
 
-export default function LoginPicker(): JSX.Element {
-  const { authMethods } = useLibraryContext();
+export default function LoginPicker(): React.ReactElement {
   const { initLogin } = useLogin();
+
+  // TODO: This is a temporary hack to filter out BasicTokenAuth.
+  //  We can remove it once we actually implement support for BasicTokenAuth.
+  //  We're aliasing the `authMethods` variable here so that we can end up with
+  //  the same variable name after filtering.
+  const { authMethods: auth1MethodsFromAuthDocument } = useLibraryContext();
+  const authMethods = auth1MethodsFromAuthDocument.filter(
+    m => m.type !== OPDS1.BasicTokenAuthType
+  );
 
   /**
    * The options:
@@ -33,7 +41,7 @@ export default function LoginPicker(): JSX.Element {
       ? "buttons"
       : "combobox";
 
-  // redirect user automatically to apropriate method if there is
+  // Redirect user automatically to appropriate method if there is
   // only one auth method
   React.useEffect(() => {
     if (authMethods.length === 1) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -82,10 +82,15 @@ export interface ClientBasicMethod extends OPDS1.BasicAuthMethod {
   id: string;
 }
 
+export interface ClientBasicTokenMethod extends OPDS1.BasicTokenAuthMethod {
+  id: string;
+}
+
 // auth methods once they have been processed for the app
 export type AppAuthMethod =
   | ClientCleverMethod
   | ClientBasicMethod
+  | ClientBasicTokenMethod
   | ClientSamlMethod;
 
 export interface AuthCredentials {

--- a/src/types/opds1.ts
+++ b/src/types/opds1.ts
@@ -155,6 +155,8 @@ export interface AuthDocumentLink extends Link {
 }
 
 export const BasicAuthType = "http://opds-spec.org/auth/basic";
+export const BasicTokenAuthType =
+  "http://thepalaceproject.org/authtype/basic-token";
 export const SamlAuthType = "http://librarysimplified.org/authtype/SAML-2.0";
 export const CleverAuthType =
   "http://librarysimplified.org/authtype/OAuth-with-intermediary";
@@ -164,6 +166,7 @@ export const PasswordCredentialsAuthType =
 
 export type AnyAuthType =
   | typeof BasicAuthType
+  | typeof BasicTokenAuthType
   | typeof SamlAuthType
   | typeof CleverAuthType
   | typeof ImplicitGrantAuthType
@@ -193,6 +196,12 @@ export interface BasicAuthMethod extends AuthMethod<typeof BasicAuthType> {
   };
 }
 
+// TODO: This may need adjustment when we actually implement BasicTokenAuth.
+//  In the mean time, we'll borrow some properties from BasicAuthMethod.
+export interface BasicTokenAuthMethod
+  extends Omit<BasicAuthMethod, "type">,
+    AuthMethod<typeof BasicTokenAuthType> {}
+
 export interface AuthInput {
   keyboard?: Keyboard;
 }
@@ -207,6 +216,7 @@ export enum Keyboard {
 export type ServerAuthMethod =
   | CleverAuthMethod
   | BasicAuthMethod
+  | BasicTokenAuthMethod
   | ServerSamlMethod;
 
 export interface Announcement {


### PR DESCRIPTION
## Description

- Don't treat Basic Token auth (type: `http://thepalaceproject.org/authtype/basic-token`) as a valid authentication mechanism, even when it appears in the authentication document.

## Motivation and Context

"Basic Token" auth is not yet implemented, so treating it as a valid mechanism causes confusing behavior, including (1) an extra layer of interaction when another auth mechanism is also specified, and (2) eventually being unable to authenticate anyway.

[Jira PP-2188]

## How Has This Been Tested?

- Manual testing in local development environment.
- All tests pass locally.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
