### PR TITLE
Allows configuration of media support default for unmatched content types (PP-2190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### UNRELEASED CHANGES
 
+- Allows configuration of media support default for unmatched content types. (PP-2190)
 - distributor added to book details page
 - Log auth document URL when Catalog Root link missing. (PP-1209)
 - Update default libraries config.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,7 +31,12 @@ export type OpenEbooksConfig = {
   defaultLibrary: string;
 };
 
-export type MediaSupportConfig = DirectMediaSupport & IndirectMediaSupport;
+export type MediaSupportConfig = Partial<DefaultMediaSupport> &
+  DirectMediaSupport &
+  IndirectMediaSupport;
+type DefaultMediaSupport = {
+  default: MediaSupportLevel;
+};
 export type DirectMediaSupport = Partial<
   Record<OPDS1.AnyBookMediaType, MediaSupportLevel>
 >;

--- a/src/utils/__tests__/fulfill.test.ts
+++ b/src/utils/__tests__/fulfill.test.ts
@@ -1,42 +1,78 @@
 import { describe, expect, test } from "@jest/globals";
 import fetchMock from "jest-fetch-mock";
 import { MediaSupportLevel, OPDS1 } from "../../interfaces";
-import { DownloadFulfillment, getFulfillmentFromLink } from "../fulfill";
+import {
+  DownloadFulfillment,
+  getAppSupportLevel,
+  getFulfillmentFromLink
+} from "../fulfill";
+import mockConfig from "test-utils/mockConfig";
 
-describe("getFulfillmentFromLink", () => {
-  describe("for an indirect bearer token link", () => {
-    const link = {
-      contentType: OPDS1.EpubMediaType as OPDS1.AnyBookMediaType,
-      url: "link-url",
-      indirectionType: OPDS1.BearerTokenMediaType as OPDS1.IndirectAcquisitionType,
-      supportLevel: "show" as MediaSupportLevel
-    };
+describe("fulfill", () => {
+  describe("getFulfillmentFromLink", () => {
+    describe("for an indirect bearer token link", () => {
+      const link = {
+        contentType: OPDS1.EpubMediaType as OPDS1.AnyBookMediaType,
+        url: "link-url",
+        indirectionType: OPDS1.BearerTokenMediaType as OPDS1.IndirectAcquisitionType,
+        supportLevel: "show" as MediaSupportLevel
+      };
 
-    test("should return a fulfillment that gets the download url and token by retrieving a bearer token propagation document", async () => {
-      const fulfillment = getFulfillmentFromLink(link) as DownloadFulfillment;
+      test("should return a fulfillment that gets the download url and token by retrieving a bearer token propagation document", async () => {
+        const fulfillment = getFulfillmentFromLink(link) as DownloadFulfillment;
 
-      fetchMock.mockResponseOnce(
-        /* eslint-disable camelcase */
-        JSON.stringify({
-          expires_in: 60,
-          token_type: "Token-type",
-          access_token: "download-token",
-          location: "download-url"
-        })
-        /* eslint-enable camelcase */
-      );
+        fetchMock.mockResponseOnce(
+          /* eslint-disable camelcase */
+          JSON.stringify({
+            expires_in: 60,
+            token_type: "Token-type",
+            access_token: "download-token",
+            location: "download-url"
+          })
+          /* eslint-enable camelcase */
+        );
 
-      const location = await fulfillment.getLocation("catalog-url", "token");
+        const location = await fulfillment.getLocation("catalog-url", "token");
 
-      expect(fetchMock).toHaveBeenCalledWith("link-url", {
-        headers: {
-          "X-Requested-With": "XMLHttpRequest",
-          Authorization: "token"
-        }
+        expect(fetchMock).toHaveBeenCalledWith("link-url", {
+          headers: {
+            "X-Requested-With": "XMLHttpRequest",
+            Authorization: "token"
+          }
+        });
+
+        expect(location.url).toBe("download-url");
+        expect(location.token).toBe("Token-type download-token");
       });
+    });
+  });
 
-      expect(location.url).toBe("download-url");
-      expect(location.token).toBe("Token-type download-token");
+  describe("getAppSupportLevel", () => {
+    const testIndirectionType =
+      "application/atom+xml;type=entry;profile=opds-catalog";
+    const testContentType =
+      'text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"';
+
+    it("support level is 'unsupported', when no default and no media type matches", () => {
+      mockConfig({ mediaSupport: {} });
+      const supportLevel = getAppSupportLevel(
+        testContentType,
+        testIndirectionType
+      );
+      expect(supportLevel).toBe("unsupported");
+    });
+
+    it("support level is the specified default, when no media type matches", () => {
+      mockConfig({ mediaSupport: { default: "unsupported" } });
+      let supportLevel = getAppSupportLevel(
+        testContentType,
+        testIndirectionType
+      );
+      expect(supportLevel).toBe("unsupported");
+
+      mockConfig({ mediaSupport: { default: "redirect" } });
+      supportLevel = getAppSupportLevel(testContentType, testIndirectionType);
+      expect(supportLevel).toBe("redirect");
     });
   });
 });

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -207,17 +207,19 @@ export function dedupeLinks(links: readonly FulfillmentLink[]) {
 export function getAppSupportLevel(
   contentType: OPDS1.AnyBookMediaType,
   indirectionType: OPDS1.IndirectAcquisitionType | undefined
-): MediaSupportLevel | "unsupported" {
-  const mediaSupport = APP_CONFIG.mediaSupport;
+): MediaSupportLevel {
+  const { mediaSupport } = APP_CONFIG;
+  const defaultSupportLevel: MediaSupportLevel =
+    mediaSupport?.default ?? "unsupported";
 
   // if there is indirection, we search through the dictionary nested inside the
   // indirectionType
   if (indirectionType) {
     const supportLevel = mediaSupport[indirectionType]?.[contentType];
-    return supportLevel ?? "unsupported";
+    return supportLevel ?? defaultSupportLevel;
   }
 
-  return mediaSupport[contentType] ?? "unsupported";
+  return mediaSupport[contentType] ?? defaultSupportLevel;
 }
 
 /**


### PR DESCRIPTION
## Description

Allows configuration of a default media support value to be used when the `content type` or `indirect link type`/`content type` pair do not match an entry in the configuration. This is set in the `media_support.default` property in the configuration file. For example:

```
...
media_support:
  default: show

  application/audiobook+json: redirect

  application/vnd.readium.lcp.license.v1.0+json:
    application/epub+zip: redirect
...
```

The behavior will be as follows:
- If the the `content type` or `indirect link type`/`content type` pair match, then the value specified for the `content type` will be used.
- Else, if a `default` is specified, that default value will be used.
- Else, "unsupported" will be used.

## Motivation and Context

As we experiment with different configurations, it will be easier to reconfigure defaults, if we can do it through configuration, rather than code, changes.

[Jira [PP-2190](https://ebce-lyrasis.atlassian.net/browse/PP-2190)]

## How Has This Been Tested?

- Added new test cases.
- All tests pass locally.
- Review CI tests.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.


[PP-2190]: https://ebce-lyrasis.atlassian.net/browse/PP-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ