### PR TITLE
Render modals in center of screen by default (PP-2243)

### DIFF
--- a/src/components/BookCover.tsx
+++ b/src/components/BookCover.tsx
@@ -76,7 +76,6 @@ const BookCover: React.FC<{
           book={book}
           sx={{
             position: "absolute",
-            zIndex: 200,
             bottom: 0,
             left: 0,
             borderTopRightRadius: 1,

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -2,8 +2,6 @@
 /** @jsx jsx */
 import { jsx } from "theme-ui";
 import * as React from "react";
-// import { DialogStateReturn, DialogBackdrop, Dialog } from "@ariakit/react";
-// import { Dialog } from "@ariakit/react/cjs/dialog";
 import { Dialog } from "@ariakit/react/dialog";
 import { Icon, IconNames } from "@nypl/design-system-react-components";
 import Button from "components/Button";
@@ -36,7 +34,6 @@ type ModalProps = {
 
 const Modal: React.FC<ModalProps> = ({
   dialog,
-  // isVisible,
   hide,
   children,
   label,
@@ -51,6 +48,15 @@ const Modal: React.FC<ModalProps> = ({
       role={role}
       className={className}
       hideOnInteractOutside={hideOnClickOutside}
+      backdrop={
+        <div
+          sx={{
+            backgroundColor: "rgb(0 0 0 / 0.1)",
+            "-webkit-backdrop-filter": "blur(4px)",
+            backdropFilter: "blur(4px)"
+          }}
+        ></div>
+      }
       sx={{
         background: "white",
         borderRadius: 2,
@@ -58,7 +64,11 @@ const Modal: React.FC<ModalProps> = ({
         px: 4,
         py: 3,
         m: 2,
-        position: "relative"
+        position: "fixed",
+        height: "fit-content",
+        maxWidth: "400px",
+        inset: "0.75rem",
+        margin: "auto"
       }}
       aria-label={label}
     >
@@ -80,9 +90,5 @@ const Modal: React.FC<ModalProps> = ({
     </Dialog>
   );
 };
-
-// const DialogClose: React.FC = () => {
-
-// }
 
 export default Modal;

--- a/src/components/SignOut.tsx
+++ b/src/components/SignOut.tsx
@@ -27,9 +27,9 @@ export const SignOut: React.FC<SignOutProps> = ({
         Sign Out
       </DialogDisclosure>
       <Modal
+        hideOnClickOutside
         dialog={dialog}
         role="alertdialog"
-        hideOnClickOutside
         label="Sign Out"
         showClose={false}
       >

--- a/src/components/__tests__/SignOut.test.tsx
+++ b/src/components/__tests__/SignOut.test.tsx
@@ -20,8 +20,16 @@ test("Shows modal on click", async () => {
   await user.click(signOut);
 
   const modal = await screen.findByLabelText("Sign Out");
+  screen.debug(modal);
 
-  expect(modal).toHaveStyle("display: block");
+  expect(modal).toHaveStyle({
+    display: "block",
+    position: "fixed",
+    height: "fit-content",
+    maxWidth: "400px",
+    inset: "0.75rem",
+    margin: "auto"
+  });
   expect(modal).toBeVisible();
 
   expect(screen.getByText("Are you sure you want to sign out?")).toBeVisible();

--- a/src/components/__tests__/SignOut.test.tsx
+++ b/src/components/__tests__/SignOut.test.tsx
@@ -20,7 +20,6 @@ test("Shows modal on click", async () => {
   await user.click(signOut);
 
   const modal = await screen.findByLabelText("Sign Out");
-  screen.debug(modal);
 
   expect(modal).toHaveStyle({
     display: "block",

--- a/src/components/bookDetails/ReportProblem.tsx
+++ b/src/components/bookDetails/ReportProblem.tsx
@@ -55,7 +55,7 @@ const ReportProblem: React.FC<{ book: AnyBook }> = ({ book }) => {
         dialog={dialog}
         label="Report a problem"
         hide={cancel}
-        sx={{ maxWidth: 600 }}
+        sx={{ maxWidth: "600px" }}
       >
         {state.success ? (
           <div sx={{ display: "flex", flexDirection: "column" }}>

--- a/src/components/bookDetails/ReportProblem.tsx
+++ b/src/components/bookDetails/ReportProblem.tsx
@@ -55,7 +55,7 @@ const ReportProblem: React.FC<{ book: AnyBook }> = ({ book }) => {
         dialog={dialog}
         label="Report a problem"
         hide={cancel}
-        sx={{ width: "100%", maxWidth: 600 }}
+        sx={{ maxWidth: 600 }}
       >
         {state.success ? (
           <div sx={{ display: "flex", flexDirection: "column" }}>


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Updated custom Modal component to render in the middle of the screen. Before, the modal was rendering at the bottom of the page. This might have been an unintended change after updating to ariakit from reakit.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Separating the modal so far from the event origin was bad UX.
<!--- If it fixes an open issue, please link to the issue here. -->

[Jira PP-2243](https://ebce-lyrasis.atlassian.net/browse/PP-2243)

## How Has This Been Tested?

Updated the sign out modal test to expect the new styling changes whenever the modal is visible.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
