### PR TITLE
Grab book format from fulfillment link, if available (PP-2191)

### DIFF
--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -97,6 +97,13 @@ describe("book details page", () => {
     expect(screen.getByText("Distributed by:")).toBeInTheDocument();
   });
 
+  test("shows book format", () => {
+    mockSwr({ data: fixtures.book });
+    setup(<BookDetails />);
+    expect(screen.getByText("Book format:")).toBeInTheDocument();
+    expect(screen.getByText("ePub")).toBeInTheDocument();
+  });
+
   test("does not show simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'openebooks'", () => {
     mockConfig({ companionApp: "openebooks" });
     mockSwr({ data: fixtures.book });

--- a/src/dataflow/opds1/__tests__/parse.test.ts
+++ b/src/dataflow/opds1/__tests__/parse.test.ts
@@ -359,6 +359,23 @@ describe("FulfillableBook", () => {
     expect(book.status).toBe("fulfillable");
     expect(book.revokeUrl).toBe("/revoke");
   });
+
+  test("infers book format from fulfillable book acquisition link", () => {
+    mockConfig();
+    const fulfillmentLink = factory.acquisitionLink({
+      rel: OPDSAcquisitionLink.GENERIC_REL,
+      type: OPDS1.EpubMediaType,
+      href: "/epub"
+    });
+    const entry = factory.entry({
+      ...basicInfo,
+      links: [fulfillmentLink, detailLink]
+    });
+
+    const book = entryToBook(entry, "http://test-url.com");
+
+    expect(book.format).toBe("ePub");
+  });
 });
 
 test("includes open access links with fulfillable book", () => {
@@ -629,7 +646,7 @@ test("extracts top-level links", () => {
   expect(types).toEqual(["about", "terms-of-service"]);
 });
 
-test("extracts inferred eBook format from acquisition links", () => {
+test("extracts inferred eBook format from indirect acquisition links", () => {
   mockConfig();
   const borrowLink = factory.acquisitionLink({
     href: "http://example.com/borrow",
@@ -660,7 +677,7 @@ test("extracts inferred eBook format from acquisition links", () => {
   expect(book.format).toBe("ePub");
 });
 
-test("extracts inferred Audiobook format from acquisition links", () => {
+test("extracts inferred Audiobook format from indirect acquisition links", () => {
   mockConfig();
   const borrowLink = factory.acquisitionLink({
     href: "http://example.com/borrow",

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -126,7 +126,7 @@ const linearizeAcquisitions = ia =>
  * @see https://github.com/io7m/opds-acquisition-spec?tab=readme-ov-file#linearized-acquisitions
  *
  * If a book has been fulfilled in some way, then the mimetype can
- * be derived from there
+ * be derived from a book's aquisition links
  */
 function inferEBookFormat(
   fulfillmentLinks: FulfillmentLink[],

--- a/src/test-utils/fixtures/book.ts
+++ b/src/test-utils/fixtures/book.ts
@@ -82,6 +82,7 @@ export const book: Book = {
   published: "February 29, 2016",
   categories: ["Children", "10-12", "Fiction", "Adventure", "Fantasy"],
   providerName: "Overdrive",
+  format: "ePub",
   raw: {
     $: { "schema:additionalType": { value: "http://schema.org/EBook" } },
     category: [
@@ -151,6 +152,30 @@ export const book: Book = {
             value: "/related-url"
           }
         }
+      },
+      {
+        "opds:indirectAcquisition": [
+          {
+            $: {
+              type: {
+                local: "type",
+                name: "type",
+                value: "application/vnd.adobe.adept+xml"
+              }
+            },
+            "opds:indirectAcquisition": [
+              {
+                $: {
+                  type: {
+                    local: "type",
+                    name: "type",
+                    value: "application/epub+zip"
+                  }
+                }
+              }
+            ]
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Description

Grab book format from a book's list of fulfillment links, if list exists
<!--- Describe your changes -->

## Motivation and Context

While working on a separate ticket, I noticed that books that had been fulfilled would have their indirect acquisition links removed, and so the book format would be removed from the book detail page.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[Jira PP-2191]

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
