### PR TITLE
Add return button to My Books page for fulfillable books (PP-2283)

### DIFF
--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -243,19 +243,26 @@ const BookListCTA: React.FC<{ book: AnyBook }> = ({ book }) => {
     const singleFulfillment =
       showableFulfillments.length === 1 ? showableFulfillments[0] : undefined;
 
-    if (singleFulfillment && !shouldRedirectUser) {
-      return (
-        <FulfillmentButton
-          details={singleFulfillment}
-          book={book}
-          isPrimaryAction
-        />
-      );
-    }
     return (
-      <NavButton variant="link" bookUrl={book.url} iconRight={ArrowForward}>
-        View Book Details
-      </NavButton>
+      <>
+        <CancelOrReturn
+          url={book.revokeUrl}
+          loadingText="Returning..."
+          id={book.id}
+          text="Return"
+        />
+        {singleFulfillment && !shouldRedirectUser ? (
+          <FulfillmentButton
+            details={singleFulfillment}
+            book={book}
+            isPrimaryAction
+          />
+        ) : (
+          <NavButton variant="link" bookUrl={book.url} iconRight={ArrowForward}>
+            View Book Details
+          </NavButton>
+        )}
+      </>
     );
   }
 

--- a/src/components/__tests__/BookList.test.tsx
+++ b/src/components/__tests__/BookList.test.tsx
@@ -53,6 +53,12 @@ test("truncates authors", () => {
   expect(screen.queryByText("one, two, three")).toBeFalsy();
 });
 
+test("show return button for fulfillable book", () => {
+  setup(<BookList books={[fixtures.fulfillableBook]} />);
+  const button = screen.getByRole("button", { name: "Return" });
+  expect(button).toBeInTheDocument();
+});
+
 jest.mock("swr/infinite");
 const useSWRInfiniteMock = useSWRInfinite as jest.MockedFunction<
   typeof useSWRInfinite


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
When a user navigates to their "My Books" page, they will now see an option to return their book from that list if applicable. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change matches the actions a user can take from the book details page, allowing users to return a book without having to drill into the book details page itself.
<!--- If it fixes an open issue, please link to the issue here. -->

[Jira PP-2283](https://ebce-lyrasis.atlassian.net/jira/software/c/projects/BBL/boards/14?selectedIssue=PP-2283)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I added a test to expect the return button if a book is fulfillable
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
