### PR TITLE
Use `exec` form for CMD in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE $PORT
 # In this case, we run build-and-start to 
 # build the app with our env vars, delete
 # unnecessary files, and start the app.
-CMD npm run build-and-start
+CMD ["npm", "run", "build-and-start"]


### PR DESCRIPTION
## Description

The Dockerfile's CMD instruction has been updated to use the `exec` form (JSON array). 

## Motivation and Context

- This is the preferred format as it avoids the need for a shell, improving signal handling and reducing potential for unexpected behavior. [[link](https://docs.docker.com/reference/build-checks/json-args-recommended/)]
- Addresses warning annotation previously present in test outputs:
  - JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals: Dockerfile#L27
JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals

## How Has This Been Tested?

- [CI tests](https://github.com/ThePalaceProject/web-patron/actions/runs/14342755933) pass.
- Warning annotation not present at end of test results.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
