### PR TITLE
PP-2463 : [bugfix] pressing enter from login barcode or password input would not initiate login

### DIFF
--- a/src/auth/BasicAuthHandler.tsx
+++ b/src/auth/BasicAuthHandler.tsx
@@ -57,9 +57,7 @@ const BasicAuthHandler: React.FC<{ method: ClientBasicMethod }> = ({
     method.inputs?.password?.keyboard !== Keyboard.NoInput;
 
   const [showPassword, setShowPassword] = React.useState(false);
-  const togglePasswordVisibility = event => {
-    event.preventDefault();
-    event.stopPropagation();
+  const togglePasswordVisibility = _event => {
     setShowPassword(!showPassword);
   };
 
@@ -106,6 +104,7 @@ const BasicAuthHandler: React.FC<{ method: ClientBasicMethod }> = ({
           endIcon={
             <InputIconButton
               aria-label={`${showPassword ? "hide" : "show"} password`}
+              type="button"
               onClick={togglePasswordVisibility}
             >
               <FontAwesomeIcon icon={showPassword ? faEyeSlash : faEye} />

--- a/src/auth/__tests__/BasicAuthForm.test.tsx
+++ b/src/auth/__tests__/BasicAuthForm.test.tsx
@@ -57,6 +57,7 @@ test("toggle password visibility", async () => {
   expect(input).toHaveAttribute("type", "password");
 
   const showPasswordIconButton = await screen.findByLabelText("show password");
+  expect(showPasswordIconButton).toHaveAttribute("type", "button");
   await user.click(showPasswordIconButton);
 
   // After toggle, input becomes text so password is visible
@@ -66,7 +67,7 @@ test("toggle password visibility", async () => {
   expect(hidePasswordIconButton).toBeInTheDocument();
 });
 
-test("submits", async () => {
+test("submit by clicking login button", async () => {
   // give the mock a delay to allow loading state to appear
   fetchMock.mockResponseOnce(
     () =>


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
The login screen has a button that toggles the visibility for a user's password. The type for this button has been explicitly set as `button`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Any buttons nested within a `<form/>` will have `type="submit"` by default if no type is specified. The original click handler for the password visibility toggle overrode the form's default behavior, so any submit event within the form would not work as intended and would only toggle password visibility. Adding `type="button"` to the password visibility button separated the button's behavior from the form and allows an `Enter` keydown to submit from anywhere within the form unless a user is focused on the password visibility button.
<!--- If it fixes an open issue, please link to the issue here. -->

[Jira PP-2463](https://ebce-lyrasis.atlassian.net/browse/PP-2463)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [N/A] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
