### PR TITLE
Add token authentication (PP-2240)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14885,6 +14885,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
       "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
       }
@@ -15610,11 +15611,12 @@
       "license": "SAX-PD"
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util": {

--- a/src/auth/AuthenticationHandler.tsx
+++ b/src/auth/AuthenticationHandler.tsx
@@ -62,7 +62,6 @@ const AuthenticationHandler: React.ComponentType<AuthHandlerWrapperProps> = ({
 }) => {
   const _AuthHandler = authHandlers[method.type];
 
-  // Prioritize Basic Token over Basic
   if (method.type === BasicTokenAuthType && typeof method !== "string") {
     return <_AuthHandler method={method as ClientBasicTokenMethod} />;
   } else if (method.type === BasicAuthType && typeof method !== "string") {

--- a/src/auth/AuthenticationHandler.tsx
+++ b/src/auth/AuthenticationHandler.tsx
@@ -1,25 +1,34 @@
 import React from "react";
 import BasicAuthHandler from "./BasicAuthHandler";
+import BasicTokenAuthHandler from "./BasicTokenAuthHandler";
 import CleverAuthHandler from "./CleverAuthHandler";
 import SamlAuthHandler from "./SamlAuthHandler";
-import { ClientBasicMethod, ClientSamlMethod } from "interfaces";
+import {
+  ClientBasicMethod,
+  ClientBasicTokenMethod,
+  ClientSamlMethod
+} from "interfaces";
 import {
   BasicAuthType,
   CleverAuthType,
   CleverAuthMethod,
-  SamlAuthType
+  SamlAuthType,
+  BasicTokenAuthType
 } from "../types/opds1";
 import track from "../analytics/track";
 import ApplicationError from "../errors";
 
 type SupportedAuthTypes =
   | typeof BasicAuthType
+  | typeof BasicTokenAuthType
   | typeof SamlAuthType
   | typeof CleverAuthType;
 
 type SupportedAuthHandlerProps = {
   [key in SupportedAuthTypes]: key extends typeof BasicAuthType
     ? ClientBasicMethod
+    : key extends typeof BasicTokenAuthType
+    ? ClientBasicTokenMethod
     : key extends typeof SamlAuthType
     ? ClientSamlMethod
     : key extends typeof CleverAuthType
@@ -36,6 +45,7 @@ export const authHandlers: {
   }>;
 } = {
   [BasicAuthType]: BasicAuthHandler,
+  [BasicTokenAuthType]: BasicTokenAuthHandler,
   [SamlAuthType]: SamlAuthHandler,
   [CleverAuthType]: CleverAuthHandler
 };
@@ -52,7 +62,10 @@ const AuthenticationHandler: React.ComponentType<AuthHandlerWrapperProps> = ({
 }) => {
   const _AuthHandler = authHandlers[method.type];
 
-  if (method.type === BasicAuthType && typeof method !== "string") {
+  // Prioritize Basic Token over Basic
+  if (method.type === BasicTokenAuthType && typeof method !== "string") {
+    return <_AuthHandler method={method as ClientBasicTokenMethod} />;
+  } else if (method.type === BasicAuthType && typeof method !== "string") {
     return <_AuthHandler method={method as ClientBasicMethod} />;
   } else if (method.type === SamlAuthType && typeof method !== "string") {
     return <_AuthHandler method={method as ClientSamlMethod} />;

--- a/src/auth/BasicTokenAuthHandler.tsx
+++ b/src/auth/BasicTokenAuthHandler.tsx
@@ -15,7 +15,7 @@ import useUser from "components/context/UserContext";
 import ApplicationError, { ServerError } from "errors";
 import useLogin from "auth/useLogin";
 import useLibraryContext from "components/context/LibraryContext";
-import { BasicAuthType, Keyboard } from "types/opds1";
+import { Keyboard } from "types/opds1";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
 import { fetchAuthToken } from "auth/fetch";
@@ -58,7 +58,7 @@ const BasicTokenAuthHandler: React.FC<{
       });
     }
 
-    // generate Basic token to send to circuation manager
+    // generate Basic Token to send to circuation manager for Bearer Token
     const basicToken = generateToken(login, password);
     const { accessToken } = await fetchAuthToken(authenticationUrl, basicToken);
     signIn(
@@ -73,9 +73,6 @@ const BasicTokenAuthHandler: React.FC<{
 
   const serverError = error instanceof ServerError ? error : undefined;
 
-  // remove Basic auth
-  //   const hasMultipleMethods =
-  //     authMethods.filter(method => method.type !== BasicAuthType).length > 1;
   const hasMultipleMethods = authMethods.length > 1;
 
   const hasPasswordInput =

--- a/src/auth/LoginPicker.tsx
+++ b/src/auth/LoginPicker.tsx
@@ -20,6 +20,9 @@ export default function LoginPicker(): React.ReactElement {
   // Here we filter out any methods from the auth document that we don't support.
   // We're aliasing the `authMethods` variable here so that we can end up with
   // the same variable name after filtering.
+  // [Tyler] For now, we are leaving both Basic and Basic Token auth as options,
+  // even if both are present. We may filter out Basic in favor of Basic Token
+  // in the future
   const { authMethods: methodsFromAuthDocument } = useLibraryContext();
   const authMethods = methodsFromAuthDocument.filter(m =>
     isSupportedAuthType(m.type)

--- a/src/auth/__tests__/BasicAuthForm.test.tsx
+++ b/src/auth/__tests__/BasicAuthForm.test.tsx
@@ -117,7 +117,8 @@ test("submit by clicking login button", async () => {
         Authorization: token,
         "X-Requested-With": "XMLHttpRequest",
         "Accept-Language": "*"
-      }
+      },
+      method: "GET"
     });
   });
 });
@@ -160,7 +161,8 @@ test("displays server error", async () => {
       Authorization: "token",
       "X-Requested-With": "XMLHttpRequest",
       "Accept-Language": "*"
-    }
+    },
+    method: "GET"
   });
   const serverError = await screen.findByText(
     "Invalid Credentials: Wrong username."
@@ -241,7 +243,8 @@ test("submits with no password input", async () => {
         Authorization: token,
         "X-Requested-With": "XMLHttpRequest",
         "Accept-Language": "*"
-      }
+      },
+      method: "GET"
     });
   });
 });

--- a/src/auth/__tests__/BasicTokenAuthForm.test.tsx
+++ b/src/auth/__tests__/BasicTokenAuthForm.test.tsx
@@ -1,0 +1,146 @@
+import BasicTokenAuthHandler from "auth/BasicTokenAuthHandler";
+import { UserProvider } from "components/context/UserContext";
+import { OPDS1 } from "interfaces";
+import Cookie from "js-cookie";
+import * as React from "react";
+import { fixtures, screen, setup, waitFor } from "test-utils";
+import {
+  basicTokenAuthenticationUrl,
+  basicTokenAuthMethod
+} from "test-utils/fixtures";
+import { generateCredentials } from "utils/auth";
+
+const accessToken = "IaMaBeArErToKeN";
+
+beforeEach(() => fetchMock.resetMocks());
+
+test("displays form", async () => {
+  const { user } = setup(
+    <BasicTokenAuthHandler method={basicTokenAuthMethod} />
+  );
+
+  const barcode = await screen.findByLabelText("Barcode input");
+  const pin = await screen.findByLabelText("Pin input");
+  expect(barcode).toBeInTheDocument();
+  expect(pin).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
+
+  await user.type(barcode, "1234");
+  await user.type(pin, "pinpin");
+
+  expect(barcode).toHaveValue("1234");
+  expect(pin).toHaveValue("pinpin");
+});
+
+test("toggle password visibility", async () => {
+  const { user } = setup(
+    <BasicTokenAuthHandler method={basicTokenAuthMethod} />
+  );
+
+  // Input initially renders as password input
+  const input = await screen.findByLabelText("Pin input");
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveAttribute("type", "password");
+
+  const showPasswordIconButton = await screen.findByLabelText("show password");
+  expect(showPasswordIconButton).toHaveAttribute("type", "button");
+  await user.click(showPasswordIconButton);
+
+  // After toggle, input becomes text so password is visible
+  const hidePasswordIconButton = await screen.findByLabelText("hide password");
+  expect(input).toBeInTheDocument();
+  expect(input).toHaveAttribute("type", "text");
+  expect(hidePasswordIconButton).toBeInTheDocument();
+});
+
+test("submit by clicking login button", async () => {
+  // give the mock a delay to allow loading state to appear
+
+  fetchMock
+    // Receive token from auth
+    .once(
+      () =>
+        new Promise(resolve =>
+          setTimeout(
+            () =>
+              resolve(
+                JSON.stringify({
+                  accessToken: accessToken,
+                  expiresIn: 3600,
+                  tokenType: "Bearer"
+                })
+              ),
+            100
+          )
+        )
+    )
+    .once(
+      // Get loans using token
+      () =>
+        new Promise(resolve =>
+          setTimeout(() => resolve(JSON.stringify(fixtures.loans)), 100)
+        )
+    );
+
+  const { user } = setup(
+    <UserProvider>
+      <BasicTokenAuthHandler method={basicTokenAuthMethod} />
+    </UserProvider>
+  );
+
+  // act
+  const barcode = await screen.findByLabelText("Barcode input");
+  const pin = await screen.findByLabelText("Pin input");
+  await user.type(barcode, "1234");
+  await user.type(pin, "pinpin");
+  const loginButton = screen.getByRole("button", { name: "Login" });
+  await user.click(loginButton);
+
+  const basicToken = generateCredentials("1234", "pinpin");
+
+  // shows a loading state
+  const loadingButton = await screen.findByLabelText("Signing in...");
+  expect(loadingButton).toBeInTheDocument();
+  expect(loadingButton).toBeDisabled();
+
+  // assert
+  // we wrap this in waitFor because the handleSubmit from react-hook-form has
+  // async code in it
+  await waitFor(() => {
+    // we set the cookie
+    expect(Cookie.set).toHaveBeenCalledTimes(1);
+    expect(Cookie.set).toHaveBeenCalledWith(
+      // the library slug is null because we are only running with one library
+      "CPW_AUTH_COOKIE/testlib",
+      JSON.stringify({
+        token: {
+          basicToken: basicToken,
+          bearerToken: `Bearer ${accessToken}`
+        },
+        authenticationUrl: basicTokenAuthenticationUrl,
+        methodType: OPDS1.BasicTokenAuthType
+      })
+    );
+
+    // First call grabs token from /patrons/me/token using username and password
+    expect(fetchMock.mock.calls[0][0]).toEqual(basicTokenAuthenticationUrl);
+    expect(fetchMock.mock.calls[0][1]).toEqual({
+      headers: {
+        Authorization: basicToken,
+        "X-Requested-With": "XMLHttpRequest"
+      },
+      method: "POST"
+    });
+
+    // Second call to get loans with Bearer Token
+    expect(fetchMock.mock.calls[1][0]).toEqual("/shelf-url");
+    expect(fetchMock.mock.calls[1][1]).toEqual({
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "X-Requested-With": "XMLHttpRequest",
+        "Accept-Language": "*"
+      },
+      method: "GET"
+    });
+  });
+});

--- a/src/auth/__tests__/BasicTokenAuthForm.test.tsx
+++ b/src/auth/__tests__/BasicTokenAuthForm.test.tsx
@@ -122,9 +122,10 @@ test("submit by clicking login button", async () => {
       })
     );
 
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
     // First call grabs token from /patrons/me/token using username and password
-    expect(fetchMock.mock.calls[0][0]).toEqual(basicTokenAuthenticationUrl);
-    expect(fetchMock.mock.calls[0][1]).toEqual({
+    expect(fetchMock).toHaveBeenNthCalledWith(1, basicTokenAuthenticationUrl, {
       headers: {
         Authorization: basicToken,
         "X-Requested-With": "XMLHttpRequest"
@@ -133,8 +134,7 @@ test("submit by clicking login button", async () => {
     });
 
     // Second call to get loans with Bearer Token
-    expect(fetchMock.mock.calls[1][0]).toEqual("/shelf-url");
-    expect(fetchMock.mock.calls[1][1]).toEqual({
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/shelf-url", {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         "X-Requested-With": "XMLHttpRequest",

--- a/src/auth/fetch.ts
+++ b/src/auth/fetch.ts
@@ -1,0 +1,12 @@
+import { ServerError } from "errors";
+import fetchWithHeaders from "../dataflow/fetch";
+
+export async function fetchAuthToken(url: string, token: string) {
+  const response = await fetchWithHeaders(url, token, {}, "POST");
+  const json = await response.json();
+
+  if (!response.ok) {
+    throw new ServerError(url, response.status, json);
+  }
+  return json;
+}

--- a/src/auth/fetch.ts
+++ b/src/auth/fetch.ts
@@ -1,12 +1,27 @@
-import { ServerError } from "errors";
+import ApplicationError, { ServerError } from "errors";
+import { AuthCredentialsToken } from "interfaces";
 import fetchWithHeaders from "../dataflow/fetch";
 
-export async function fetchAuthToken(url: string, token: string) {
+/**
+ * Fetch bearer token for authenticating user
+ */
+export async function fetchAuthToken(
+  url: string | undefined,
+  token: string | undefined
+) {
+  if (!url || !token) {
+    throw new ApplicationError({
+      title: "Incomplete Authentication Info",
+      detail: "No URL or Token was provided for authentication"
+    });
+  }
+
   const response = await fetchWithHeaders(url, token, {}, "POST");
   const json = await response.json();
 
   if (!response.ok) {
     throw new ServerError(url, response.status, json);
   }
+
   return json;
 }

--- a/src/auth/fetch.ts
+++ b/src/auth/fetch.ts
@@ -1,5 +1,4 @@
 import ApplicationError, { ServerError } from "errors";
-import { AuthCredentialsToken } from "interfaces";
 import fetchWithHeaders from "../dataflow/fetch";
 
 /**

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -3,7 +3,7 @@
 import { jsx } from "theme-ui";
 import * as React from "react";
 
-//Ensures grouped elements have internal margins, but not external margins
+// Ensures grouped elements have internal margins, but not external margins
 // Does not work with flex-wrap
 
 type StackProps = {

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -486,7 +486,8 @@ describe("FulfillableBook", () => {
       headers: {
         Authorization: "user-token",
         "X-Requested-With": "XMLHttpRequest"
-      }
+      },
+      method: "GET"
     });
   });
 
@@ -516,7 +517,8 @@ describe("FulfillableBook", () => {
       headers: {
         Authorization: "user-token",
         "X-Requested-With": "XMLHttpRequest"
-      }
+      },
+      method: "GET"
     });
 
     // some error will be shown because we didn't mock fetch for this,
@@ -562,7 +564,8 @@ describe("FulfillableBook", () => {
       headers: {
         Authorization: "user-token",
         "X-Requested-With": "XMLHttpRequest"
-      }
+      },
+      method: "GET"
     });
 
     // we try the rejected url without headers

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -60,6 +60,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
       revalidateOnFocus: credentials?.methodType === BasicTokenAuthType,
       revalidateOnReconnect: false,
       errorRetryCount: credentials?.methodType === BasicTokenAuthType ? 1 : 0,
+      // Try and fetch new token once old token has expired
       onErrorRetry: async (err, _key, _config, revalidate) => {
         if (err instanceof ServerError && err?.info.status === 401) {
           if (credentials?.methodType === BasicTokenAuthType) {
@@ -85,7 +86,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
         }
       },
       // clear credentials whenever we receive a 401, but save the error so it sticks around.
-      // however, BasicTokenAuthType methods are retried in onErrorRetry
+      // however, BasicTokenAuthType methods are retried in onErrorRetry to get new token
       onError: err => {
         if (err instanceof ServerError && err?.info.status === 401) {
           if (credentials?.methodType !== BasicTokenAuthType) {

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -56,7 +56,6 @@ export const UserProvider = ({ children }: UserProviderProps) => {
     fetchLoans,
     {
       shouldRetryOnError: credentials?.methodType === BasicTokenAuthType,
-      // [Tyler] should I revalidate on an hour interval instead?
       revalidateOnFocus: credentials?.methodType === BasicTokenAuthType,
       revalidateOnReconnect: false,
       errorRetryCount: credentials?.methodType === BasicTokenAuthType ? 1 : 0,

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -2,9 +2,10 @@ import useCredentials from "auth/useCredentials";
 import useLibraryContext from "components/context/LibraryContext";
 import { fetchCollection } from "dataflow/opds1/fetch";
 import { ServerError } from "errors";
-import { AppAuthMethod, AnyBook } from "interfaces";
+import { AppAuthMethod, AnyBook, AuthCredentials } from "interfaces";
 import * as React from "react";
 import useSWR from "swr";
+import { BasicTokenAuthType } from "types/opds1";
 
 type Status = "authenticated" | "loading" | "unauthenticated";
 export type UserState = {

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -172,8 +172,12 @@ function stringifyToken(
     credentials?.methodType === BasicTokenAuthType &&
     typeof credentials?.token === "object"
   ) {
-    return credentials?.token?.[tokenType] ?? undefined;
+    return credentials?.token?.[tokenType];
   }
 
-  return typeof credentials?.token === "string" ? credentials.token : undefined;
+  if (typeof credentials?.token === "string") {
+    return credentials.token;
+  }
+
+  return undefined;
 }

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -56,11 +56,11 @@ export const UserProvider = ({ children }: UserProviderProps) => {
     fetchLoans,
     {
       shouldRetryOnError: credentials?.methodType === BasicTokenAuthType,
+      // [Tyler] should I revalidate on an hour interval instead?
       revalidateOnFocus: credentials?.methodType === BasicTokenAuthType,
       revalidateOnReconnect: false,
-      // clear credentials whenever we receive a 401, but save the error so it sticks around.
       errorRetryCount: credentials?.methodType === BasicTokenAuthType ? 1 : 0,
-      onErrorRetry: async (err, key, config, revalidate) => {
+      onErrorRetry: async (err, _key, _config, revalidate) => {
         if (err instanceof ServerError && err?.info.status === 401) {
           if (credentials?.methodType === BasicTokenAuthType) {
             try {
@@ -84,7 +84,8 @@ export const UserProvider = ({ children }: UserProviderProps) => {
           }
         }
       },
-      // try refreshing token
+      // clear credentials whenever we receive a 401, but save the error so it sticks around.
+      // however, BasicTokenAuthType methods are retried in onErrorRetry
       onError: err => {
         if (err instanceof ServerError && err?.info.status === 401) {
           if (credentials?.methodType !== BasicTokenAuthType) {

--- a/src/components/context/__tests__/UserContext.test.tsx
+++ b/src/components/context/__tests__/UserContext.test.tsx
@@ -7,14 +7,9 @@ import { act, fixtures, setup } from "test-utils";
 import Cookie from "js-cookie";
 import * as router from "next/router";
 import useUser, { UserProvider } from "components/context/UserContext";
-import mockAuthenticatedOnce, {
-  tokenCreds,
-  tokenCreds1,
-  tokenCreds2
-} from "test-utils/mockAuthState";
+import mockAuthenticatedOnce from "test-utils/mockAuthState";
 import * as swr from "swr";
 import { makeSwrResponse } from "test-utils/mockSwr";
-import { basicTokenAuthenticationUrl } from "test-utils/fixtures";
 
 const mockSWR = jest.spyOn(swr, "default");
 
@@ -211,24 +206,6 @@ test("sign in sets cookie", async () => {
 
   expect(mockSWR).toHaveBeenCalledWith(
     ["/shelf-url", "a-token", "type"],
-    expect.anything(),
-    expect.anything()
-  );
-});
-
-test("refreshes expired basic token whenever focus returns to window", async () => {
-  mockAuthenticatedOnce(tokenCreds1);
-  renderUserContext();
-
-  expect(mockSWR).toHaveBeenCalledWith(
-    ["/shelf-url", `Bearer IaMaBeArErToKeN`, OPDS1.BasicTokenAuthType],
-    expect.anything(),
-    expect.anything()
-  );
-
-  mockAuthenticatedOnce(tokenCreds2);
-  expect(mockSWR).toHaveBeenCalledWith(
-    ["/shelf-url", `Bearer IaMaBeArErToKeN2`, OPDS1.BasicTokenAuthType],
     expect.anything(),
     expect.anything()
   );

--- a/src/components/context/__tests__/UserContext.test.tsx
+++ b/src/components/context/__tests__/UserContext.test.tsx
@@ -7,9 +7,14 @@ import { act, fixtures, setup } from "test-utils";
 import Cookie from "js-cookie";
 import * as router from "next/router";
 import useUser, { UserProvider } from "components/context/UserContext";
-import mockAuthenticatedOnce from "test-utils/mockAuthState";
+import mockAuthenticatedOnce, {
+  tokenCreds,
+  tokenCreds1,
+  tokenCreds2
+} from "test-utils/mockAuthState";
 import * as swr from "swr";
 import { makeSwrResponse } from "test-utils/mockSwr";
+import { basicTokenAuthenticationUrl } from "test-utils/fixtures";
 
 const mockSWR = jest.spyOn(swr, "default");
 
@@ -206,6 +211,24 @@ test("sign in sets cookie", async () => {
 
   expect(mockSWR).toHaveBeenCalledWith(
     ["/shelf-url", "a-token", "type"],
+    expect.anything(),
+    expect.anything()
+  );
+});
+
+test("refreshes expired basic token whenever focus returns to window", async () => {
+  mockAuthenticatedOnce(tokenCreds1);
+  renderUserContext();
+
+  expect(mockSWR).toHaveBeenCalledWith(
+    ["/shelf-url", `Bearer IaMaBeArErToKeN`, OPDS1.BasicTokenAuthType],
+    expect.anything(),
+    expect.anything()
+  );
+
+  mockAuthenticatedOnce(tokenCreds2);
+  expect(mockSWR).toHaveBeenCalledWith(
+    ["/shelf-url", `Bearer IaMaBeArErToKeN2`, OPDS1.BasicTokenAuthType],
     expect.anything(),
     expect.anything()
   );

--- a/src/dataflow/__tests__/download.test.ts
+++ b/src/dataflow/__tests__/download.test.ts
@@ -17,7 +17,8 @@ describe("downloadFile", () => {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
         Authorization: "this token"
-      }
+      },
+      method: "GET"
     });
   });
 
@@ -38,13 +39,15 @@ describe("downloadFile", () => {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
         Authorization: "this token"
-      }
+      },
+      method: "GET"
     });
 
     expect(fetchMock).toHaveBeenNthCalledWith(2, "some-url", {
       headers: {
         Authorization: "this token"
-      }
+      },
+      method: "GET"
     });
   });
 
@@ -73,7 +76,8 @@ describe("downloadFile", () => {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
         Authorization: "this token"
-      }
+      },
+      method: "GET"
     });
 
     expect(fetchMock).toHaveBeenNthCalledWith(2, "redirected-url");

--- a/src/dataflow/__tests__/fetch.test.ts
+++ b/src/dataflow/__tests__/fetch.test.ts
@@ -11,7 +11,8 @@ describe("fetchWithHeaders", () => {
     expect(fetchMock).toHaveBeenCalledWith("some-url", {
       headers: {
         "X-Requested-With": "XMLHttpRequest"
-      }
+      },
+      method: "GET"
     });
   });
 
@@ -24,7 +25,8 @@ describe("fetchWithHeaders", () => {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
         Authorization: "some token"
-      }
+      },
+      method: "GET"
     });
   });
 
@@ -42,7 +44,8 @@ describe("fetchWithHeaders", () => {
         Authorization: "some token",
         "Accept-Language": "us-en",
         "X-Something-Else": "what?"
-      }
+      },
+      method: "GET"
     });
   });
 
@@ -57,7 +60,8 @@ describe("fetchWithHeaders", () => {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
         "X-Something-Else": "what?"
-      }
+      },
+      method: "GET"
     });
   });
 
@@ -72,7 +76,8 @@ describe("fetchWithHeaders", () => {
       headers: {
         "X-Requested-With": "I changed it",
         Authorization: "some token"
-      }
+      },
+      method: "GET"
     });
   });
 
@@ -87,7 +92,8 @@ describe("fetchWithHeaders", () => {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
         Authorization: "some token"
-      }
+      },
+      method: "GET"
     });
   });
 
@@ -102,7 +108,8 @@ describe("fetchWithHeaders", () => {
     expect(fetchMock).toHaveBeenCalledWith("some-url", {
       headers: {
         Authorization: "some token"
-      }
+      },
+      method: "GET"
     });
   });
 });

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -21,7 +21,8 @@ describe("fetching catalog", () => {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
         "Accept-Language": "*"
-      }
+      },
+      method: "GET"
     });
   });
 

--- a/src/dataflow/fetch.ts
+++ b/src/dataflow/fetch.ts
@@ -5,10 +5,13 @@
 
 import { FetchError } from "errors";
 
+type HttpMethod = "GET" | "DELTE" | "POST" | "PUT";
+
 export default async function fetchWithHeaders(
   url: string,
   token?: string,
-  additionalHeaders?: { [key: string]: string | undefined }
+  additionalHeaders?: { [key: string]: string | undefined },
+  method: HttpMethod = "GET"
 ) {
   const headers = prepareHeaders(token, additionalHeaders);
 
@@ -18,7 +21,7 @@ export default async function fetchWithHeaders(
    * CORS issues. We catch and rethrow a wrapped error in those cases to give more info.
    */
   try {
-    return await fetch(url, { headers });
+    return await fetch(url, { method, headers });
   } catch (e) {
     throw new FetchError(url, e);
   }

--- a/src/dataflow/fetch.ts
+++ b/src/dataflow/fetch.ts
@@ -5,7 +5,7 @@
 
 import { FetchError } from "errors";
 
-type HttpMethod = "GET" | "DELTE" | "POST" | "PUT";
+type HttpMethod = "GET" | "DELETE" | "POST" | "PUT";
 
 export default async function fetchWithHeaders(
   url: string,

--- a/src/dataflow/opds1/__tests__/fetch.test.ts
+++ b/src/dataflow/opds1/__tests__/fetch.test.ts
@@ -22,7 +22,8 @@ describe("fetchOPDS", () => {
     fetchMock.once(rawOpdsEntry);
     await fetchOPDS("/some-url");
     expect(fetchMock).toHaveBeenCalledWith("/some-url", {
-      headers: { "X-Requested-With": "XMLHttpRequest" }
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      method: "GET"
     });
 
     fetchMock.once(rawOpdsEntry);
@@ -31,7 +32,8 @@ describe("fetchOPDS", () => {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
         Authorization: "some-token"
-      }
+      },
+      method: "GET"
     });
   });
 

--- a/src/dataflow/opds1/fetch.ts
+++ b/src/dataflow/opds1/fetch.ts
@@ -1,6 +1,6 @@
 import OPDSParser, { OPDSFeed, OPDSEntry } from "opds-feed-parser";
 import ApplicationError, { ServerError } from "errors";
-import { AnyBook, CollectionData, OPDS1 } from "interfaces";
+import { AnyBook, CollectionData, OPDS1, Token } from "interfaces";
 import { entryToBook, feedToCollection } from "dataflow/opds1/parse";
 import fetchWithHeaders from "dataflow/fetch";
 import parseSearchData from "dataflow/opds1/parseSearchData";

--- a/src/dataflow/opds1/fetch.ts
+++ b/src/dataflow/opds1/fetch.ts
@@ -1,6 +1,6 @@
 import OPDSParser, { OPDSFeed, OPDSEntry } from "opds-feed-parser";
 import ApplicationError, { ServerError } from "errors";
-import { AnyBook, CollectionData, OPDS1, Token } from "interfaces";
+import { AnyBook, CollectionData, OPDS1 } from "interfaces";
 import { entryToBook, feedToCollection } from "dataflow/opds1/parse";
 import fetchWithHeaders from "dataflow/fetch";
 import parseSearchData from "dataflow/opds1/parseSearchData";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -98,9 +98,17 @@ export type AppAuthMethod =
   | ClientBasicTokenMethod
   | ClientSamlMethod;
 
+export type Token = {
+  basicToken: string | undefined;
+  bearerToken: string | null;
+};
+
+export type AuthCredentialsToken = string | Token | undefined;
+
 export interface AuthCredentials {
   methodType: AppAuthMethod["type"];
-  token: string;
+  token: AuthCredentialsToken;
+  authenticationUrl?: string | undefined;
 }
 
 export interface LibraryData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -108,7 +108,7 @@ export type AuthCredentialsToken = string | Token | undefined;
 export interface AuthCredentials {
   methodType: AppAuthMethod["type"];
   token: AuthCredentialsToken;
-  authenticationUrl?: string | undefined;
+  authenticationUrl?: string;
 }
 
 export interface LibraryData {

--- a/src/test-utils/fixtures/auth.ts
+++ b/src/test-utils/fixtures/auth.ts
@@ -1,5 +1,6 @@
 import {
   ClientBasicMethod,
+  ClientBasicTokenMethod,
   ClientCleverMethod,
   ClientSamlMethod,
   CollectionData
@@ -8,7 +9,12 @@ import { OPDS1 } from "interfaces";
 import { makeFulfillableBooks } from "test-utils/fixtures/book";
 
 export const basicAuthId = "http://opds-spec.org/auth/basic";
+export const basicTokenAuthId =
+  "http://thepalaceproject.org/authtype/basic-token";
 export const samlAuthId = "http://librarysimplified.org/authtype/SAML-2.0";
+
+export const basicTokenAuthenticationUrl =
+  "https://exmple.com/patrons/me/token/";
 
 export const basicAuthMethod: ClientBasicMethod = {
   id: "client-basic",
@@ -18,11 +24,27 @@ export const basicAuthMethod: ClientBasicMethod = {
   },
   type: basicAuthId,
   description: "Library Barcode",
-  // inputs: {
-  //   login: { keyboard: "Default" },
-  //   password: { keyboard: "Default" }
-  // },
   links: [
+    {
+      href: "https://example.com/LoginButton280.png",
+      rel: "logo"
+    }
+  ]
+};
+
+export const basicTokenAuthMethod: ClientBasicTokenMethod = {
+  id: "client-basic-token",
+  labels: {
+    login: "Barcode",
+    password: "Pin"
+  },
+  type: basicTokenAuthId,
+  description: "Library Barcode",
+  links: [
+    {
+      rel: "authenticate",
+      href: basicTokenAuthenticationUrl
+    },
     {
       href: "https://example.com/LoginButton280.png",
       rel: "logo"

--- a/src/test-utils/mockAuthState.ts
+++ b/src/test-utils/mockAuthState.ts
@@ -10,19 +10,22 @@ export const creds: AuthCredentials = {
   methodType: OPDS1.BasicAuthType
 };
 
+export const persistentUserCredentials = generateCredentials("1234", "pinpin");
+export const firstToken = "IaMaBeArErToKeN";
 export const tokenCreds1: AuthCredentials = {
   token: {
-    basicToken: generateCredentials("1234", "pinpin"),
-    bearerToken: `Bearer IaMaBeArErToKeN`
+    basicToken: persistentUserCredentials,
+    bearerToken: firstToken
   },
   authenticationUrl: basicTokenAuthenticationUrl,
   methodType: OPDS1.BasicTokenAuthType
 };
 
+export const newToken = "IaMaBeArErToKeN2";
 export const tokenCreds2: AuthCredentials = {
   token: {
-    basicToken: generateCredentials("1234", "pinpin"),
-    bearerToken: `Bearer IaMaBeArErToKeN2`
+    basicToken: persistentUserCredentials,
+    bearerToken: newToken
   },
   authenticationUrl: basicTokenAuthenticationUrl,
   methodType: OPDS1.BasicTokenAuthType

--- a/src/test-utils/mockAuthState.ts
+++ b/src/test-utils/mockAuthState.ts
@@ -1,11 +1,31 @@
 import { AuthCredentials, OPDS1 } from "interfaces";
 import Cookie from "js-cookie";
+import { generateCredentials } from "utils/auth";
+import { basicTokenAuthenticationUrl } from "./fixtures";
 
 const mockCookie = Cookie as any;
 
 export const creds: AuthCredentials = {
   token: "some-token",
   methodType: OPDS1.BasicAuthType
+};
+
+export const tokenCreds1: AuthCredentials = {
+  token: {
+    basicToken: generateCredentials("1234", "pinpin"),
+    bearerToken: `Bearer IaMaBeArErToKeN`
+  },
+  authenticationUrl: basicTokenAuthenticationUrl,
+  methodType: OPDS1.BasicTokenAuthType
+};
+
+export const tokenCreds2: AuthCredentials = {
+  token: {
+    basicToken: generateCredentials("1234", "pinpin"),
+    bearerToken: `Bearer IaMaBeArErToKeN2`
+  },
+  authenticationUrl: basicTokenAuthenticationUrl,
+  methodType: OPDS1.BasicTokenAuthType
 };
 
 const str = JSON.stringify;

--- a/src/utils/__tests__/fulfill.test.ts
+++ b/src/utils/__tests__/fulfill.test.ts
@@ -38,7 +38,8 @@ describe("fulfill", () => {
           headers: {
             "X-Requested-With": "XMLHttpRequest",
             Authorization: "token"
-          }
+          },
+          method: "GET"
         });
 
         expect(location.url).toBe("download-url");


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Basic token authentication has been added as one of the supported methods for authenticating users. On a successful login, the user's credentials are saved. The stored credentials are used to refresh a token once it has expired. This all happens in the background; once a user has logged in with a token, they will be logged in without interruption unless the user signs themselves out.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Palace's mobile clients all have implemented token auth. This gets the CPW more up to date.
<!--- If it fixes an open issue, please link to the issue here. -->

[Jira PP-2240](https://ebce-lyrasis.atlassian.net/browse/PP-2240)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
Added tests mock fetching a token from circulation manager using test credentials and grabbing a new token if a 401 was returned and credentials had previously been saved.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
