### PR TITLE
Add SAML logout support (PP-3453)

### DIFF
--- a/src/components/SignOut.tsx
+++ b/src/components/SignOut.tsx
@@ -5,8 +5,8 @@ import Button from "./Button";
 import Stack from "./Stack";
 import useUser from "components/context/UserContext";
 import { styleProps } from "./Button/styles";
-import { OPDS1, ClientOidcMethod } from "interfaces";
-import { normalizeLink, UriTemplateTerms } from "utils/opds";
+import { OPDS1, ClientOidcMethod, ClientSamlMethod } from "interfaces";
+import { normalizeLink, UriTemplateTerms, TemplatedLink } from "utils/opds";
 import { useRouter } from "next/router";
 import useLinkUtils from "hooks/useLinkUtils";
 import useLibraryContext from "./context/LibraryContext";
@@ -19,6 +19,40 @@ const SIGNOUT_URI_TEMPLATE_FALLBACK_VARIABLES = [
   "post_logout_redirect_uri",
   "redirect_uri"
 ] as const;
+
+/*
+ * Calls the server-side logout endpoint (with Authorization header and URI
+ * template expansion), then navigates to signedOutUrl. Swallows any server
+ * error because credentials have already been cleared locally before this
+ * is called.
+ */
+async function performLogoutRequest(
+  logoutLink: TemplatedLink,
+  token: string,
+  signedOutUrl: string
+): Promise<void> {
+  try {
+    const { href: logoutUrl } = normalizeLink(logoutLink, {
+      termValues: { [UriTemplateTerms.REDIRECT_URI]: signedOutUrl },
+      fallbacks: Object.fromEntries(
+        SIGNOUT_URI_TEMPLATE_FALLBACK_VARIABLES.map(v => [v, signedOutUrl])
+      )
+    });
+    const response = await fetch(logoutUrl, {
+      headers: { Authorization: token },
+      redirect: "manual"
+    });
+    if (!response.ok && response.type !== "opaqueredirect") {
+      throw new Error(`Logout endpoint returned ${response.status}`);
+    }
+  } catch {
+    // TODO: For now, we swallow the server-side logout failure, since
+    //  the browser has already dropped its local Palace credentials. In
+    //  the future, we can report the error here.
+  } finally {
+    window.location.href = signedOutUrl;
+  }
+}
 
 export const SignOut: React.FC<SignOutProps> = ({
   color = "ui.black"
@@ -45,65 +79,30 @@ export const SignOut: React.FC<SignOutProps> = ({
 
     dialog.hide();
 
-    // For OIDC auth with logout support, redirect to the logout endpoint
+    // For OIDC or SAML auth with a server-side logout endpoint, call it before
+    // navigating to the signed-out page.
     if (methodType === OPDS1.OidcAuthType) {
       const oidcMethod = authMethods.find(
         m => m.type === OPDS1.OidcAuthType
       ) as ClientOidcMethod | undefined;
 
       if (oidcMethod?.logoutLink && token) {
-        // Local credentials are cleared eagerly before the server-side request.
         signOut();
-
         const signedOutUrl = `${window.location.origin}${buildMultiLibraryLink("/signed-out")}`;
+        await performLogoutRequest(oidcMethod.logoutLink, token, signedOutUrl);
+        return;
+      }
+    }
 
-        try {
-          /*
-           * Resolve the logout URL, expanding any URI template. The term value
-           * map handles servers that use uri_template_variables to declare the
-           * redirect-URI variable's semantic type; the fallback covers servers
-           * that omit that map but still use the conventional variable name.
-           * normalizeLink throws when a required template variable has no value,
-           * so it must be inside the try block to be handled like any other
-           * logout failure.
-           */
-          const { href: logoutUrl } = normalizeLink(oidcMethod.logoutLink, {
-            termValues: { [UriTemplateTerms.REDIRECT_URI]: signedOutUrl },
-            fallbacks: Object.fromEntries(
-              SIGNOUT_URI_TEMPLATE_FALLBACK_VARIABLES.map(v => [
-                v,
-                signedOutUrl
-              ])
-            )
-          });
-          /**
-           * The Authorization header lets the backend identify and invalidate
-           * the token. redirect: "manual" captures the first redirect without
-           * following the full chain — the chain may include the IdP's
-           * end_session endpoint, which requires a real browser navigation
-           * (with cookies) to terminate the IdP session. For cross-origin
-           * redirects the browser returns an opaque response and the Location
-           * header is unreadable, so we always navigate to our own signed-out
-           * page regardless of the redirect destination.
-           *
-           * redirect: "manual" also prevents fetch from throwing on non-2xx
-           * status codes, so we check response.ok explicitly and throw to
-           * reach the catch block on HTTP errors (e.g. 500).
-           */
-          const response = await fetch(logoutUrl, {
-            headers: { Authorization: token },
-            redirect: "manual"
-          });
-          if (!response.ok && response.type !== "opaqueredirect") {
-            throw new Error(`Logout endpoint returned ${response.status}`);
-          }
-        } catch {
-          // TODO: For now, we swallow the server-side logout failure, since
-          //  the browser has already dropped its local Palace credentials. In
-          //  the future, we can report the error here.
-        } finally {
-          window.location.href = signedOutUrl;
-        }
+    if (methodType === OPDS1.SamlAuthType) {
+      const samlMethod = authMethods.find(
+        m => m.type === OPDS1.SamlAuthType
+      ) as ClientSamlMethod | undefined;
+
+      if (samlMethod?.logoutLink && token) {
+        signOut();
+        const signedOutUrl = `${window.location.origin}${buildMultiLibraryLink("/signed-out")}`;
+        await performLogoutRequest(samlMethod.logoutLink, token, signedOutUrl);
         return;
       }
     }

--- a/src/components/__tests__/SignOut.test.tsx
+++ b/src/components/__tests__/SignOut.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { fixtures, screen, setup, waitFor } from "../../test-utils";
 import { SignOut } from "components/SignOut";
-import { OPDS1, ClientOidcMethod } from "interfaces";
+import { OPDS1, ClientOidcMethod, ClientSamlMethod } from "interfaces";
 import { mockPush } from "../../test-utils/mockNextRouter";
 import fetchMock from "jest-fetch-mock";
 
@@ -260,6 +260,135 @@ describe("OIDC logout with logout endpoint", () => {
   });
 });
 
+describe("SAML logout with logout endpoint", () => {
+  /* eslint-disable camelcase */
+  const logoutLink: OPDS1.SamlIdp = {
+    href: "http://example.com/saml/logout?provider=Test{&redirect_uri}",
+    rel: "logout",
+    templated: true,
+    display_names: [{ language: "en", value: "Test SAML" }],
+    descriptions: [{ language: "en", value: "Test SAML" }],
+    privacy_statement_urls: [],
+    logo_urls: [],
+    information_urls: []
+  };
+  /* eslint-enable camelcase */
+  const samlMethod: ClientSamlMethod = {
+    type: OPDS1.SamlAuthType,
+    id: "http://example.com/saml/authenticate",
+    href: "http://example.com/saml/authenticate",
+    logoutLink,
+    description: "Test SAML"
+  };
+  const samlUserSetup = {
+    user: {
+      token: "Bearer test-token",
+      credentials: {
+        token: "Bearer test-token",
+        methodType: OPDS1.SamlAuthType
+      } as const
+    },
+    library: {
+      ...fixtures.libraryData,
+      authMethods: [samlMethod]
+    }
+  };
+
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    delete (window as any).location;
+    window.location = { ...originalLocation, href: "" } as any;
+  });
+
+  afterEach(() => {
+    (window as any).location = originalLocation;
+  });
+
+  test("clears local credentials immediately before fetching logout endpoint", async () => {
+    fetchMock.mockResponseOnce("", { status: 200 });
+
+    const { user } = setup(<SignOut />, samlUserSetup);
+
+    const signOutBtn = await screen.findByRole("button", { name: "Sign Out" });
+    await user.click(signOutBtn);
+
+    const signOutForReal = await screen.findByRole("button", {
+      name: "Confirm Sign Out"
+    });
+    await user.click(signOutForReal);
+
+    await waitFor(() => {
+      expect(fixtures.mockSignOut).toHaveBeenCalled();
+    });
+  });
+
+  test("uses SAML logout endpoint and navigates to signed-out page", async () => {
+    fetchMock.mockResponseOnce("", { status: 200 });
+
+    const { user } = setup(<SignOut />, samlUserSetup);
+
+    const signOutBtn = await screen.findByRole("button", { name: "Sign Out" });
+    await user.click(signOutBtn);
+
+    const signOutForReal = await screen.findByRole("button", {
+      name: "Confirm Sign Out"
+    });
+    await user.click(signOutForReal);
+
+    await waitFor(() => {
+      const [fetchedUrl, fetchOptions] = fetchMock.mock.calls[0];
+      expect(fetchedUrl).toContain("http://example.com/saml/logout");
+      expect(fetchedUrl).toContain("redirect_uri=");
+      expect(
+        (fetchOptions?.headers as Record<string, string>)?.Authorization
+      ).toBe("Bearer test-token");
+    });
+
+    expect(window.location.href).toContain("/signed-out");
+  });
+
+  test("navigates to signed-out page when logout request fails", async () => {
+    fetchMock.mockRejectOnce(new Error("Network error"));
+
+    const { user } = setup(<SignOut />, samlUserSetup);
+
+    const signOutBtn = await screen.findByRole("button", { name: "Sign Out" });
+    await user.click(signOutBtn);
+
+    const signOutForReal = await screen.findByRole("button", {
+      name: "Confirm Sign Out"
+    });
+    await user.click(signOutForReal);
+
+    await waitFor(() => {
+      expect(window.location.href).toContain("/signed-out");
+    });
+
+    expect(fixtures.mockSignOut).toHaveBeenCalled();
+  });
+
+  test("navigates to signed-out page when logout endpoint returns HTTP error", async () => {
+    fetchMock.mockResponseOnce("", { status: 500 });
+
+    const { user } = setup(<SignOut />, samlUserSetup);
+
+    const signOutBtn = await screen.findByRole("button", { name: "Sign Out" });
+    await user.click(signOutBtn);
+
+    const signOutForReal = await screen.findByRole("button", {
+      name: "Confirm Sign Out"
+    });
+    await user.click(signOutForReal);
+
+    await waitFor(() => {
+      expect(window.location.href).toContain("/signed-out");
+    });
+    expect(fixtures.mockSignOut).toHaveBeenCalled();
+  });
+});
+
 test("falls back to local signout for OIDC without logout link", async () => {
   const oidcMethod: ClientOidcMethod = {
     type: OPDS1.OidcAuthType,
@@ -292,6 +421,42 @@ test("falls back to local signout for OIDC without logout link", async () => {
 
   // Should use the redirect-based signout flow (navigate with performSignOut=true)
   // The router mock will have been called
+  await waitFor(() => {
+    expect(mockPush).toHaveBeenCalled();
+  });
+});
+
+test("falls back to redirect-based signout for SAML without logout link", async () => {
+  const samlMethod: ClientSamlMethod = {
+    type: OPDS1.SamlAuthType,
+    id: "http://example.com/saml/authenticate",
+    href: "http://example.com/saml/authenticate",
+    // No logoutLink
+    description: "Test SAML"
+  };
+
+  const { user } = setup(<SignOut />, {
+    user: {
+      credentials: {
+        token: "Bearer test-token",
+        methodType: OPDS1.SamlAuthType
+      } as const
+    },
+    library: {
+      ...fixtures.libraryData,
+      authMethods: [samlMethod]
+    }
+  });
+
+  const signOut = await screen.findByRole("button", { name: "Sign Out" });
+  await user.click(signOut);
+
+  const signOutForReal = await screen.findByRole("button", {
+    name: "Confirm Sign Out"
+  });
+  await user.click(signOutForReal);
+
+  // Should use the redirect-based signout flow (navigate with performSignOut=true)
   await waitFor(() => {
     expect(mockPush).toHaveBeenCalled();
   });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -91,6 +91,7 @@ export interface ClientSamlMethod extends OPDS1.AuthMethod<
 > {
   href: string;
   id: string;
+  logoutLink?: OPDS1.SamlIdp;
 }
 export interface ClientOidcMethod extends OPDS1.AuthMethod<
   typeof OPDS1.OidcAuthType

--- a/src/utils/__tests__/auth.test.ts
+++ b/src/utils/__tests__/auth.test.ts
@@ -377,7 +377,12 @@ describe("normalizeAuthMethods", () => {
     expect(result[0].description).toBe("OIDC Provider");
   });
 
-  test("normalizeAuthMethods uses only the 'authenticate' link", () => {
+  test("includes logout link from SAML method", () => {
+    const logoutLink = {
+      href: "https://saml-sp.example.com/saml/logout{?redirect_uri}",
+      rel: "logout" as const,
+      templated: true
+    };
     const authDoc: OPDS1.AuthDocument = {
       id: "test-auth-doc",
       title: "Test Library",
@@ -395,11 +400,7 @@ describe("normalizeAuthMethods", () => {
               privacy_statement_urls: [],
               information_urls: []
             },
-            {
-              href: "https://saml-sp.example.com/saml/logout{?redirect_uri}",
-              rel: "logout",
-              templated: true
-            }
+            logoutLink
           ]
         }
       ]
@@ -412,8 +413,89 @@ describe("normalizeAuthMethods", () => {
       id: "https://saml-sp.example.com/saml/authenticate",
       href: "https://saml-sp.example.com/saml/authenticate",
       type: OPDS1.SamlAuthType,
-      description: "Identity Provider"
+      description: "Identity Provider",
+      logoutLink
     });
+  });
+
+  test("preserves full SAML logoutLink including template metadata", () => {
+    const logoutLink: OPDS1.SamlIdp = {
+      href: "https://saml-sp.example.com/saml/logout{?redirect_uri}",
+      rel: "logout",
+      templated: true
+    };
+    const authDoc: OPDS1.AuthDocument = {
+      id: "test-auth-doc",
+      title: "Test Library",
+      authentication: [
+        {
+          type: OPDS1.SamlAuthType,
+          description: "SAML Provider",
+          links: [
+            {
+              href: "https://saml-sp.example.com/saml/authenticate",
+              rel: "authenticate",
+              display_names: [{ language: "en", value: "Identity Provider" }],
+              descriptions: [],
+              logo_urls: [],
+              privacy_statement_urls: [],
+              information_urls: []
+            },
+            logoutLink
+          ]
+        }
+      ]
+    };
+
+    const result = normalizeAuthMethods(authDoc);
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).logoutLink).toEqual(logoutLink);
+  });
+
+  test("SAML logout link is shared across multiple IdPs in the same method", () => {
+    const logoutLink = {
+      href: "https://saml-sp.example.com/saml/logout{?redirect_uri}",
+      rel: "logout" as const,
+      templated: true
+    };
+    const authDoc: OPDS1.AuthDocument = {
+      id: "test-auth-doc",
+      title: "Test Library",
+      authentication: [
+        {
+          type: OPDS1.SamlAuthType,
+          description: "SAML Provider",
+          links: [
+            {
+              href: "https://idp1.example.com",
+              rel: "authenticate",
+              display_names: [{ language: "en", value: "IDP 1" }],
+              descriptions: [],
+              logo_urls: [],
+              privacy_statement_urls: [],
+              information_urls: []
+            },
+            {
+              href: "https://idp2.example.com",
+              rel: "authenticate",
+              display_names: [{ language: "en", value: "IDP 2" }],
+              descriptions: [],
+              logo_urls: [],
+              privacy_statement_urls: [],
+              information_urls: []
+            },
+            logoutLink
+          ]
+        }
+      ]
+    };
+
+    const result = normalizeAuthMethods(authDoc);
+
+    expect(result).toHaveLength(2);
+    expect((result[0] as any).logoutLink).toEqual(logoutLink);
+    expect((result[1] as any).logoutLink).toEqual(logoutLink);
   });
 
   test("expands multiple SAML IdPs into separate methods", () => {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -43,6 +43,8 @@ function serverToClientSamlMethods(
   samlMethod: OPDS1.ServerSamlMethod
 ): ClientSamlMethod[] {
   if (!samlMethod.links) return [];
+  // The logout link is SP-level and shared across all IdPs in this method.
+  const logoutLink = samlMethod.links.find(link => link.rel === "logout");
   return samlMethod.links
     .filter(link => link.rel === "authenticate")
     .map(idp => ({
@@ -50,7 +52,9 @@ function serverToClientSamlMethods(
       id: idp.href,
       href: idp.href,
       type: samlMethod.type,
-      description: getEnglishValue(idp.display_names) ?? "Unknown SAML Provider"
+      description:
+        getEnglishValue(idp.display_names) ?? "Unknown SAML Provider",
+      ...(logoutLink ? { logoutLink } : {})
     }));
 }
 


### PR DESCRIPTION
## Description

SAML logout support with a supporting refactor:

- **SAML logout flow** — Now detects a SAML logout link on the auth method, calls the server-side logout endpoint, then navigates to `/signed-out`. Falls back to the existing redirect-to-sign-out-page-based flow if no logout link is present.
- **`performLogoutRequest` helper** — extracted from the OIDC logout path so both OIDC and SAML share the same endpoint-call-and-navigate logic.

## Motivation and Context

Enables this application to interact with the SAML logout capabilities in the Palace Manager,
following the same pattern as the OpenID Connect logout support introduced in #106.

[Jira PP-3453]

## How Has This Been Tested?

- Manual testing in a local development environment.
- New and updated tests for this new support.
- All tests pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/24036393446) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.