### PR TITLE
Dynamic runtime registry fetch support (PP-3114)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   overrides: [
     {
-      files: ["**/__tests__/**/*.{ts,tsx}", "src/test-utils/**/*.{ts,tsx}"],
+      files: ["**/__tests__/**/*.{ts,tsx}", "tests/**/*.{ts,tsx}", "src/test-utils/**/*.{ts,tsx}"],
       rules: { "react/display-name": "off" }
     },
     {

--- a/jest.config.js
+++ b/jest.config.js
@@ -163,7 +163,8 @@ module.exports = {
     "/.next/",
     // These run separately with jest.config.node.js (via test:ci)
     "/src/config/__tests__/",
-    "/src/pages/api/__tests__/"
+    "/src/pages/api/__tests__/",
+    "/src/server/__tests__/"
   ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files

--- a/jest.config.js
+++ b/jest.config.js
@@ -163,8 +163,8 @@ module.exports = {
     "/.next/",
     // These run separately with jest.config.node.js (via test:ci)
     "/src/config/__tests__/",
-    "/src/pages/api/__tests__/",
-    "/src/server/__tests__/"
+    "/src/server/__tests__/",
+    "/tests/pages/"
   ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files

--- a/jest.config.node.js
+++ b/jest.config.node.js
@@ -15,7 +15,8 @@ module.exports = {
   testEnvironment: "node",
   testMatch: [
     "**/config/**/?(*.)+(spec|test).[tj]s?(x)",
-    "**/pages/api/**/?(*.)+(spec|test).[tj]s?(x)"
+    "**/pages/api/**/?(*.)+(spec|test).[tj]s?(x)",
+    "**/server/**/?(*.)+(spec|test).[tj]s?(x)"
   ],
   testPathIgnorePatterns: ["/node_modules/", "/.next/"],
   // No setup files for Node.js tests - these are browser-specific

--- a/jest.config.node.js
+++ b/jest.config.node.js
@@ -15,7 +15,7 @@ module.exports = {
   testEnvironment: "node",
   testMatch: [
     "**/config/**/?(*.)+(spec|test).[tj]s?(x)",
-    "**/pages/api/**/?(*.)+(spec|test).[tj]s?(x)",
+    "**/tests/pages/**/?(*.)+(spec|test).[tj]s?(x)",
     "**/server/**/?(*.)+(spec|test).[tj]s?(x)"
   ],
   testPathIgnorePatterns: ["/node_modules/", "/.next/"],

--- a/src/components/MultiLibraryHome.tsx
+++ b/src/components/MultiLibraryHome.tsx
@@ -2,19 +2,34 @@
 import { ThemeUIProvider } from "theme-ui";
 import { Themed } from "@theme-ui/mdx";
 import * as React from "react";
+import useSWR from "swr";
 import { APP_CONFIG } from "utils/env";
 import theme from "theme/theme";
 import LibraryHomeLink from "./LibraryHomeLink";
+import type { ClientLibrary, LibrariesResponse } from "pages/api/libraries";
+
+async function fetchLibraries(url: string): Promise<LibrariesResponse> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error("Failed to fetch libraries");
+  return res.json();
+}
 
 const MultiLibraryHome: React.FC = () => {
-  const { libraries, instanceName } = APP_CONFIG;
-  const slugs = Object.keys(libraries).sort((a, b) => {
-    const titleA = libraries[a]?.title || a;
-    const titleB = libraries[b]?.title || b;
+  const { instanceName } = APP_CONFIG;
+  const { data, error } = useSWR<LibrariesResponse>(
+    "/api/libraries",
+    fetchLibraries
+  );
+
+  if (!data || error) return null;
+
+  const sorted = [...data.libraries].sort((a: ClientLibrary, b: ClientLibrary) => {
+    const titleA = a.title || a.slug;
+    const titleB = b.title || b.slug;
     return titleA.localeCompare(titleB);
   });
 
-  if (!libraries || slugs.length === 0) return null;
+  if (sorted.length === 0) return null;
 
   return (
     <ThemeUIProvider theme={theme}>
@@ -29,9 +44,9 @@ const MultiLibraryHome: React.FC = () => {
         <h1>{instanceName} Home</h1>
         <h3>Choose a library:</h3>
         <ul>
-          {slugs.map(slug => (
-            <li key={slug}>
-              <LibraryHomeLink slug={slug} title={libraries[slug]?.title} />
+          {sorted.map(lib => (
+            <li key={lib.slug}>
+              <LibraryHomeLink slug={lib.slug} title={lib.title} />
             </li>
           ))}
         </ul>

--- a/src/components/MultiLibraryHome.tsx
+++ b/src/components/MultiLibraryHome.tsx
@@ -23,11 +23,13 @@ const MultiLibraryHome: React.FC = () => {
 
   if (!data || error) return null;
 
-  const sorted = [...data.libraries].sort((a: ClientLibrary, b: ClientLibrary) => {
-    const titleA = a.title || a.slug;
-    const titleB = b.title || b.slug;
-    return titleA.localeCompare(titleB);
-  });
+  const sorted = [...data.libraries].sort(
+    (a: ClientLibrary, b: ClientLibrary) => {
+      const titleA = a.title || a.slug;
+      const titleB = b.title || b.slug;
+      return titleA.localeCompare(titleB);
+    }
+  );
 
   if (sorted.length === 0) return null;
 

--- a/src/components/__tests__/MultiLibraryHome.test.tsx
+++ b/src/components/__tests__/MultiLibraryHome.test.tsx
@@ -12,13 +12,16 @@ jest.mock("utils/env");
 const mockedSWR = useSWR as jest.MockedFunction<typeof useSWR>;
 
 function mockLibraries(libraries: LibrariesResponse["libraries"]) {
-  mockedSWR.mockReturnValue(
-    makeSwrResponse<any>({ data: { libraries } })
-  );
+  mockedSWR.mockReturnValue(makeSwrResponse<any>({ data: { libraries } }));
 }
 
 function lib(slug: string, title?: string) {
-  return { id: `urn:${slug}`, slug, title: title ?? slug, authDocUrl: `https://example.com/${slug}/auth` };
+  return {
+    id: `urn:${slug}`,
+    slug,
+    title: title ?? slug,
+    authDocUrl: `https://example.com/${slug}/auth`
+  };
 }
 
 describe("MultiLibraryHome", () => {
@@ -46,11 +49,7 @@ describe("MultiLibraryHome", () => {
   });
 
   it("displays libraries sorted by slug when no title is provided", () => {
-    mockLibraries([
-      lib("zebra"),
-      lib("alpha"),
-      lib("middle")
-    ]);
+    mockLibraries([lib("zebra"), lib("alpha"), lib("middle")]);
 
     render(<MultiLibraryHome />);
 
@@ -78,12 +77,7 @@ describe("MultiLibraryHome", () => {
   });
 
   it("handles quoted numeric slugs with leading zeros correctly", () => {
-    mockLibraries([
-      lib("020"),
-      lib("003"),
-      lib("001"),
-      lib("100")
-    ]);
+    mockLibraries([lib("020"), lib("003"), lib("001"), lib("100")]);
 
     render(<MultiLibraryHome />);
 
@@ -110,7 +104,10 @@ describe("MultiLibraryHome", () => {
 
   it("returns null on fetch error", () => {
     mockedSWR.mockReturnValue(
-      makeSwrResponse<any>({ data: undefined, error: new Error("fetch failed") })
+      makeSwrResponse<any>({
+        data: undefined,
+        error: new Error("fetch failed")
+      })
     );
 
     const { container } = render(<MultiLibraryHome />);

--- a/src/components/__tests__/MultiLibraryHome.test.tsx
+++ b/src/components/__tests__/MultiLibraryHome.test.tsx
@@ -2,40 +2,40 @@ import * as React from "react";
 import { render, screen } from "test-utils";
 import MultiLibraryHome from "../MultiLibraryHome";
 import * as envModule from "utils/env";
+import useSWR from "swr";
+import { makeSwrResponse } from "test-utils/mockSwr";
+import type { LibrariesResponse } from "pages/api/libraries";
 
-// Mock the entire module
+jest.mock("swr");
 jest.mock("utils/env");
 
+const mockedSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+
+function mockLibraries(libraries: LibrariesResponse["libraries"]) {
+  mockedSWR.mockReturnValue(
+    makeSwrResponse<any>({ data: { libraries } })
+  );
+}
+
+function lib(slug: string, title?: string) {
+  return { id: `urn:${slug}`, slug, title: title ?? slug, authDocUrl: `https://example.com/${slug}/auth` };
+}
+
 describe("MultiLibraryHome", () => {
+  beforeEach(() => {
+    (envModule.APP_CONFIG as any) = { instanceName: "Test Instance" };
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it("displays libraries sorted by title in ascending order", () => {
-    (envModule.APP_CONFIG as any) = {
-      instanceName: "Test Instance",
-      libraries: {
-        zebra: {
-          title: "Zebra Library",
-          authDocUrl: "https://example.com/zebra/auth"
-        },
-        alpha: {
-          title: "Alpha Library",
-          authDocUrl: "https://example.com/alpha/auth"
-        },
-        middle: {
-          title: "Middle Library",
-          authDocUrl: "https://example.com/middle/auth"
-        }
-      },
-      mediaSupport: {},
-      bugsnagApiKey: null,
-      gtmId: null,
-      companionApp: "simplye",
-      showMedium: true,
-      openebooks: null,
-      registries: []
-    };
+    mockLibraries([
+      lib("zebra", "Zebra Library"),
+      lib("alpha", "Alpha Library"),
+      lib("middle", "Middle Library")
+    ]);
 
     render(<MultiLibraryHome />);
 
@@ -46,28 +46,11 @@ describe("MultiLibraryHome", () => {
   });
 
   it("displays libraries sorted by slug when no title is provided", () => {
-    (envModule.APP_CONFIG as any) = {
-      instanceName: "Test Instance",
-      libraries: {
-        zebra: {
-          authDocUrl: "https://example.com/zebra/auth"
-        },
-        alpha: {
-          authDocUrl: "https://example.com/alpha/auth"
-        },
-        middle: {
-          title: "middle",
-          authDocUrl: "https://example.com/middle/auth"
-        }
-      },
-      mediaSupport: {},
-      bugsnagApiKey: null,
-      gtmId: null,
-      companionApp: "simplye",
-      showMedium: true,
-      openebooks: null,
-      registries: []
-    };
+    mockLibraries([
+      lib("zebra"),
+      lib("alpha"),
+      lib("middle")
+    ]);
 
     render(<MultiLibraryHome />);
 
@@ -78,32 +61,12 @@ describe("MultiLibraryHome", () => {
   });
 
   it("displays libraries sorted by effective title (mix of custom titles and slugs)", () => {
-    (envModule.APP_CONFIG as any) = {
-      instanceName: "Test Instance",
-      libraries: {
-        "003": {
-          authDocUrl: "https://example.com/003/auth"
-        },
-        beta: {
-          title: "Charlie Library",
-          authDocUrl: "https://example.com/beta/auth"
-        },
-        alpha: {
-          title: "Bravo Library",
-          authDocUrl: "https://example.com/alpha/auth"
-        },
-        "001": {
-          authDocUrl: "https://example.com/001/auth"
-        }
-      },
-      mediaSupport: {},
-      bugsnagApiKey: null,
-      gtmId: null,
-      companionApp: "simplye",
-      showMedium: true,
-      openebooks: null,
-      registries: []
-    };
+    mockLibraries([
+      lib("003"),
+      lib("beta", "Charlie Library"),
+      lib("alpha", "Bravo Library"),
+      lib("001")
+    ]);
 
     render(<MultiLibraryHome />);
 
@@ -115,34 +78,12 @@ describe("MultiLibraryHome", () => {
   });
 
   it("handles quoted numeric slugs with leading zeros correctly", () => {
-    (envModule.APP_CONFIG as any) = {
-      instanceName: "Test Instance",
-      libraries: {
-        "020": {
-          title: "020",
-          authDocUrl: "https://example.com/020/auth"
-        },
-        "003": {
-          title: "003",
-          authDocUrl: "https://example.com/003/auth"
-        },
-        "001": {
-          title: "001",
-          authDocUrl: "https://example.com/001/auth"
-        },
-        "100": {
-          title: "100",
-          authDocUrl: "https://example.com/100/auth"
-        }
-      },
-      mediaSupport: {},
-      bugsnagApiKey: null,
-      gtmId: null,
-      companionApp: "simplye",
-      showMedium: true,
-      openebooks: null,
-      registries: []
-    };
+    mockLibraries([
+      lib("020"),
+      lib("003"),
+      lib("001"),
+      lib("100")
+    ]);
 
     render(<MultiLibraryHome />);
 
@@ -154,39 +95,31 @@ describe("MultiLibraryHome", () => {
   });
 
   it("returns null when there are no libraries", () => {
-    (envModule.APP_CONFIG as any) = {
-      instanceName: "Test Instance",
-      libraries: {},
-      mediaSupport: {},
-      bugsnagApiKey: null,
-      gtmId: null,
-      companionApp: "simplye",
-      showMedium: true,
-      openebooks: null,
-      registries: []
-    };
+    mockLibraries([]);
+
+    const { container } = render(<MultiLibraryHome />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null while loading", () => {
+    mockedSWR.mockReturnValue(makeSwrResponse<any>({ data: undefined }));
+
+    const { container } = render(<MultiLibraryHome />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null on fetch error", () => {
+    mockedSWR.mockReturnValue(
+      makeSwrResponse<any>({ data: undefined, error: new Error("fetch failed") })
+    );
 
     const { container } = render(<MultiLibraryHome />);
     expect(container.firstChild).toBeNull();
   });
 
   it("displays instance name in heading", () => {
-    (envModule.APP_CONFIG as any) = {
-      instanceName: "My Custom Instance",
-      libraries: {
-        test: {
-          title: "Test Library",
-          authDocUrl: "https://example.com/test/auth"
-        }
-      },
-      mediaSupport: {},
-      bugsnagApiKey: null,
-      gtmId: null,
-      companionApp: "simplye",
-      showMedium: true,
-      openebooks: null,
-      registries: []
-    };
+    (envModule.APP_CONFIG as any) = { instanceName: "My Custom Instance" };
+    mockLibraries([lib("test", "Test Library")]);
 
     render(<MultiLibraryHome />);
 

--- a/src/config/__tests__/fetch-config.test.js
+++ b/src/config/__tests__/fetch-config.test.js
@@ -350,11 +350,6 @@ registries:
 media_support: {}
       `;
 
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ catalogs: [] })
-      });
-
       const config = await parseConfig(yamlConfig);
 
       expect(config.registries).toEqual([
@@ -364,6 +359,7 @@ media_support: {}
           refreshMaxInterval: 600
         }
       ]);
+      expect(fetch).not.toHaveBeenCalled();
     });
 
     test("applies default intervals when not specified", async () => {
@@ -375,11 +371,6 @@ registries:
 media_support: {}
       `;
 
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ catalogs: [] })
-      });
-
       const config = await parseConfig(yamlConfig);
 
       expect(config.registries).toEqual([
@@ -389,6 +380,7 @@ media_support: {}
           refreshMaxInterval: 300
         }
       ]);
+      expect(fetch).not.toHaveBeenCalled();
     });
 
     test("parses multiple registries", async () => {
@@ -405,16 +397,6 @@ registries:
 media_support: {}
       `;
 
-      fetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ catalogs: [] })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ catalogs: [] })
-        });
-
       const config = await parseConfig(yamlConfig);
 
       expect(config.registries).toHaveLength(2);
@@ -424,6 +406,7 @@ media_support: {}
       expect(config.registries[1].url).toBe(
         "https://registry2.example.com/libraries"
       );
+      expect(fetch).not.toHaveBeenCalled();
     });
 
     test("throws error if registries is not an array", async () => {
@@ -483,7 +466,7 @@ media_support: {}
   });
 
   describe("hybrid config (static libraries + registries)", () => {
-    test("fetches from registries and includes libraries", async () => {
+    test("registries are stored in config; no build-time fetch occurs", async () => {
       const yamlConfig = `
 instance_name: Test Instance
 libraries: {}
@@ -492,53 +475,20 @@ registries:
 media_support: {}
       `;
 
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          catalogs: [
-            {
-              metadata: {
-                id: "registry-lib-1",
-                title: "Registry Library 1"
-              },
-              links: [
-                {
-                  type: "application/vnd.opds.authentication.v1.0+json",
-                  href: "https://example.com/registry-lib-1/auth"
-                }
-              ]
-            },
-            {
-              metadata: {
-                id: "registry-lib-2",
-                title: "Registry Library 2"
-              },
-              links: [
-                {
-                  type: "application/vnd.opds.authentication.v1.0+json",
-                  href: "https://example.com/registry-lib-2/auth"
-                }
-              ]
-            }
-          ]
-        })
-      });
-
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toEqual({
-        "registry-lib-1": {
-          title: "Registry Library 1",
-          authDocUrl: "https://example.com/registry-lib-1/auth"
-        },
-        "registry-lib-2": {
-          title: "Registry Library 2",
-          authDocUrl: "https://example.com/registry-lib-2/auth"
+      expect(config.libraries).toEqual({});
+      expect(config.registries).toEqual([
+        {
+          url: "https://registry.example.com/libraries",
+          refreshMinInterval: 60,
+          refreshMaxInterval: 300
         }
-      });
+      ]);
+      expect(fetch).not.toHaveBeenCalled();
     });
 
-    test("static libraries override registry libraries with same slug", async () => {
+    test("static libraries are present at build time; registry libraries are runtime-only", async () => {
       const yamlConfig = `
 instance_name: Test Instance
 libraries:
@@ -550,156 +500,12 @@ registries:
 media_support: {}
       `;
 
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          catalogs: [
-            {
-              metadata: {
-                id: "shared-slug",
-                title: "Registry Library"
-              },
-              links: [
-                {
-                  type: "application/vnd.opds.authentication.v1.0+json",
-                  href: "https://example.com/registry/auth"
-                }
-              ]
-            },
-            {
-              metadata: {
-                id: "registry-only",
-                title: "Registry Only Library"
-              },
-              links: [
-                {
-                  type: "application/vnd.opds.authentication.v1.0+json",
-                  href: "https://example.com/registry-only/auth"
-                }
-              ]
-            }
-          ]
-        })
-      });
-
       const config = await parseConfig(yamlConfig);
 
       expect(config.libraries).toEqual({
         "shared-slug": {
           title: "Static Override Library",
           authDocUrl: "https://example.com/static-override/auth"
-        },
-        "registry-only": {
-          title: "Registry Only Library",
-          authDocUrl: "https://example.com/registry-only/auth"
-        }
-      });
-    });
-
-    test("combines libraries from multiple registries", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries: {}
-registries:
-  - url: https://registry1.example.com/libraries
-  - url: https://registry2.example.com/libraries
-media_support: {}
-      `;
-
-      fetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            catalogs: [
-              {
-                metadata: {
-                  id: "lib-from-reg1",
-                  title: "Library from Registry 1"
-                },
-                links: [
-                  {
-                    type: "application/vnd.opds.authentication.v1.0+json",
-                    href: "https://example.com/reg1-lib/auth"
-                  }
-                ]
-              }
-            ]
-          })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            catalogs: [
-              {
-                metadata: {
-                  id: "lib-from-reg2",
-                  title: "Library from Registry 2"
-                },
-                links: [
-                  {
-                    type: "application/vnd.opds.authentication.v1.0+json",
-                    href: "https://example.com/reg2-lib/auth"
-                  }
-                ]
-              }
-            ]
-          })
-        });
-
-      const config = await parseConfig(yamlConfig);
-
-      expect(config.libraries).toEqual({
-        "lib-from-reg1": {
-          title: "Library from Registry 1",
-          authDocUrl: "https://example.com/reg1-lib/auth"
-        },
-        "lib-from-reg2": {
-          title: "Library from Registry 2",
-          authDocUrl: "https://example.com/reg2-lib/auth"
-        }
-      });
-    });
-
-    test("combines registries and static libraries", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  static-lib: https://example.com/static/auth
-registries:
-  - url: https://registry.example.com/libraries
-media_support: {}
-      `;
-
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          catalogs: [
-            {
-              metadata: {
-                id: "registry-lib",
-                title: "Registry Library"
-              },
-              links: [
-                {
-                  type: "application/vnd.opds.authentication.v1.0+json",
-                  href: "https://example.com/registry/auth"
-                }
-              ]
-            }
-          ]
-        })
-      });
-
-      const config = await parseConfig(yamlConfig);
-
-      expect(config.libraries).toEqual({
-        "static-lib": {
-          title: "static-lib",
-          authDocUrl: "https://example.com/static/auth"
-        },
-        "registry-lib": {
-          title: "Registry Library",
-          authDocUrl: "https://example.com/registry/auth"
         }
       });
       expect(config.registries).toEqual([
@@ -709,6 +515,58 @@ media_support: {}
           refreshMaxInterval: 300
         }
       ]);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test("multiple registries are all stored in config", async () => {
+      const yamlConfig = `
+instance_name: Test Instance
+libraries: {}
+registries:
+  - url: https://registry1.example.com/libraries
+  - url: https://registry2.example.com/libraries
+media_support: {}
+      `;
+
+      const config = await parseConfig(yamlConfig);
+
+      expect(config.libraries).toEqual({});
+      expect(config.registries).toHaveLength(2);
+      expect(config.registries[0].url).toBe(
+        "https://registry1.example.com/libraries"
+      );
+      expect(config.registries[1].url).toBe(
+        "https://registry2.example.com/libraries"
+      );
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test("combines static libraries with registries config", async () => {
+      const yamlConfig = `
+instance_name: Test Instance
+libraries:
+  static-lib: https://example.com/static/auth
+registries:
+  - url: https://registry.example.com/libraries
+media_support: {}
+      `;
+
+      const config = await parseConfig(yamlConfig);
+
+      expect(config.libraries).toEqual({
+        "static-lib": {
+          title: "static-lib",
+          authDocUrl: "https://example.com/static/auth"
+        }
+      });
+      expect(config.registries).toEqual([
+        {
+          url: "https://registry.example.com/libraries",
+          refreshMinInterval: 60,
+          refreshMaxInterval: 300
+        }
+      ]);
+      expect(fetch).not.toHaveBeenCalled();
     });
   });
 
@@ -719,26 +577,6 @@ instance_name: Test Instance
 libraries: https://registry.example.com/libraries
 media_support: {}
       `;
-
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          catalogs: [
-            {
-              metadata: {
-                id: "test-lib",
-                title: "Test Library"
-              },
-              links: [
-                {
-                  type: "application/vnd.opds.authentication.v1.0+json",
-                  href: "https://example.com/test-lib/auth"
-                }
-              ]
-            }
-          ]
-        })
-      });
 
       await parseConfig(yamlConfig);
 
@@ -754,42 +592,51 @@ media_support: {}
       );
     });
 
-    test("fetches libraries from registry when using string format", async () => {
+    test("treats string libraries URL as a runtime registry entry; no build-time fetch", async () => {
       const yamlConfig = `
 instance_name: Test Instance
 libraries: https://registry.example.com/libraries
 media_support: {}
       `;
 
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          catalogs: [
-            {
-              metadata: {
-                id: "test-lib",
-                title: "Test Library"
-              },
-              links: [
-                {
-                  type: "application/vnd.opds.authentication.v1.0+json",
-                  href: "https://example.com/test-lib/auth"
-                }
-              ]
-            }
-          ]
-        })
-      });
+      const config = await parseConfig(yamlConfig);
+
+      expect(config.libraries).toEqual({});
+      expect(config.registries).toEqual([
+        {
+          url: "https://registry.example.com/libraries",
+          refreshMinInterval: 60,
+          refreshMaxInterval: 300
+        }
+      ]);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    test("deprecated URL is appended after any explicit registries entries", async () => {
+      const yamlConfig = `
+instance_name: Test Instance
+libraries: https://deprecated.example.com/libraries
+registries:
+  - url: https://explicit.example.com/libraries
+    refreshMinInterval: 120
+    refreshMaxInterval: 600
+media_support: {}
+      `;
 
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toEqual({
-        "test-lib": {
-          title: "Test Library",
-          authDocUrl: "https://example.com/test-lib/auth"
+      expect(config.registries).toEqual([
+        {
+          url: "https://explicit.example.com/libraries",
+          refreshMinInterval: 120,
+          refreshMaxInterval: 600
+        },
+        {
+          url: "https://deprecated.example.com/libraries",
+          refreshMinInterval: 60,
+          refreshMaxInterval: 300
         }
-      });
-      expect(config.registries).toEqual([]);
+      ]);
     });
   });
 
@@ -816,15 +663,11 @@ registries:
 media_support: {}
       `;
 
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ catalogs: [] })
-      });
-
       const config = await parseConfig(yamlConfig);
 
       expect(config.libraries).toEqual({});
       expect(config.registries).toHaveLength(1);
+      expect(fetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/config/fetch-config.js
+++ b/src/config/fetch-config.js
@@ -55,7 +55,6 @@ async function fetchConfigFile(configFileUrl) {
   }
 }
 
-
 /**
  * Creates a LibrariesConfig from the object in the config file.
  * Supports two formats:
@@ -196,7 +195,11 @@ async function parseConfig(raw) {
     );
     registries = [
       ...registries,
-      { url: unparsed.libraries, refreshMinInterval: 60, refreshMaxInterval: 300 }
+      {
+        url: unparsed.libraries,
+        refreshMinInterval: 60,
+        refreshMaxInterval: 300
+      }
     ];
   }
 

--- a/src/config/fetch-config.js
+++ b/src/config/fetch-config.js
@@ -55,51 +55,6 @@ async function fetchConfigFile(configFileUrl) {
   }
 }
 
-/**
- * Computes a URL-safe slug from a library catalog id.
- * Mirrors the logic in src/utils/librarySlug.ts — keep in sync with that file.
- */
-function computeSlug(id) {
-  let slug = id;
-  if (slug.startsWith("urn:")) {
-    slug = slug.slice(4).replace(/:/g, "-");
-  }
-  return slug;
-}
-
-/**
- * Fetches an object of libraries from a library registry
- */
-async function fetchLibrariesFromRegistry(registryBase) {
-  const response = await fetch(registryBase);
-  if (!response.ok) {
-    throw new Error("Could not fetch registry base at: " + registryBase);
-  }
-  const registryFeed = await response.json();
-  if (!registryFeed.catalogs) {
-    throw new Error(
-      "Registry feed did not contain any catalogs at url: " + registryBase
-    );
-  }
-
-  return registryFeed.catalogs.reduce((record, catalog) => {
-    const authDocLink = catalog.links.find(
-      link => link.type === "application/vnd.opds.authentication.v1.0+json"
-    );
-    if (!authDocLink) {
-      throw new AppSetupError(
-        `Invalid Registry Feed: Catalog ${catalog.metadata.title} is missing an auth document link at registry url: ${registryBase}`
-      );
-    }
-    const authDocUrl = authDocLink.href;
-    const slug = computeSlug(catalog.metadata.id);
-    const library = { title: catalog.metadata.title, authDocUrl };
-    return {
-      ...record,
-      [slug]: library
-    };
-  }, {});
-}
 
 /**
  * Creates a LibrariesConfig from the object in the config file.
@@ -224,44 +179,31 @@ async function parseConfig(raw) {
   const openebooks = unparsed.openebooks;
   const defaultLibrary = openebooks ? openebooks.default_library : undefined;
 
-  // Parse registries array configuration
-  const registries = unparsed.registries
+  // Parse registries array configuration.
+  let registries = unparsed.registries
     ? parseRegistriesConfig(unparsed.registries)
     : [];
 
-  // Build libraries from multiple sources
-  let libraries = {};
-
-  // 1. First, fetch from registries array (if present)
-  if (registries.length > 0) {
-    for (const registry of registries) {
-      const registryLibraries = await fetchLibrariesFromRegistry(registry.url);
-      // Merge registry libraries - later registries don't override earlier ones
-      libraries = { ...registryLibraries, ...libraries };
-    }
-  }
-
-  // 2. Handle deprecated string format for libraries (for backward compatibility)
+  // Handle deprecated string format: treat the URL as a runtime registry entry.
+  // Libraries are no longer fetched at build time; they are fetched at runtime
+  // via the same path as the registries array.
   if (typeof unparsed.libraries === "string") {
-    // DEPRECATED: String format for libraries is deprecated in favor of registries array
     console.warn(
       "WARNING: Using a string for 'libraries' in config is deprecated. " +
         "Please migrate to the 'registries' array format. " +
         "See community-config.yml for migration instructions. " +
-        "String format will continue to work but fetches at build-time only."
+        "The URL is treated as a runtime registry; libraries are fetched at runtime, not build time."
     );
-    const deprecatedRegistryLibraries = await fetchLibrariesFromRegistry(
-      unparsed.libraries
-    );
-    // Merge with existing libraries - deprecated format doesn't override registries
-    libraries = { ...libraries, ...deprecatedRegistryLibraries };
+    registries = [
+      ...registries,
+      { url: unparsed.libraries, refreshMinInterval: 60, refreshMaxInterval: 300 }
+    ];
   }
 
-  // 3. Finally, overlay static libraries (these take precedence)
+  // Apply static libraries (these take precedence over registry libraries at runtime).
+  let libraries = {};
   if (unparsed.libraries && typeof unparsed.libraries === "object") {
-    const staticLibraries = makeLibrariesConfig(unparsed.libraries);
-    // Static libraries override registry libraries
-    libraries = { ...libraries, ...staticLibraries };
+    libraries = makeLibrariesConfig(unparsed.libraries);
   }
 
   // otherwise assume the file is properly structured.

--- a/src/config/fetch-config.js
+++ b/src/config/fetch-config.js
@@ -56,6 +56,18 @@ async function fetchConfigFile(configFileUrl) {
 }
 
 /**
+ * Computes a URL-safe slug from a library catalog id.
+ * Mirrors the logic in src/utils/librarySlug.ts — keep in sync with that file.
+ */
+function computeSlug(id) {
+  let slug = id;
+  if (slug.startsWith("urn:")) {
+    slug = slug.slice(4).replace(/:/g, "-");
+  }
+  return slug;
+}
+
+/**
  * Fetches an object of libraries from a library registry
  */
 async function fetchLibrariesFromRegistry(registryBase) {
@@ -80,10 +92,11 @@ async function fetchLibrariesFromRegistry(registryBase) {
       );
     }
     const authDocUrl = authDocLink.href;
+    const slug = computeSlug(catalog.metadata.id);
     const library = { title: catalog.metadata.title, authDocUrl };
     return {
       ...record,
-      [catalog.metadata.id]: library
+      [slug]: library
     };
   }, {});
 }

--- a/src/constants/registry.ts
+++ b/src/constants/registry.ts
@@ -19,3 +19,6 @@ export const REGISTRY_CRAWLABLE_PAGE_SIZE = 100;
  * Default: 24 hours.
  */
 export const DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL = 86400;
+
+/** Seconds before an individual registry page fetch is aborted. */
+export const DEFAULT_REGISTRY_FETCH_TIMEOUT = 10;

--- a/src/constants/registry.ts
+++ b/src/constants/registry.ts
@@ -9,3 +9,13 @@ export const CREDENTIAL_EXPIRATION_DAYS = 30;
 
 /** Maximum number of previous slugs to track per library. */
 export const HISTORICAL_SLUG_LIMIT = 5;
+
+/** Items per page when fetching a crawlable registry feed. */
+export const REGISTRY_CRAWLABLE_PAGE_SIZE = 100;
+
+/**
+ * Seconds between complete (all-pages) crawls of the registry.
+ * Complete crawls detect library deletions that incremental crawls miss.
+ * Default: 24 hours.
+ */
+export const DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL = 86400;

--- a/src/constants/registry.ts
+++ b/src/constants/registry.ts
@@ -1,0 +1,11 @@
+/** Minimum seconds between registry fetch attempts. */
+export const DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL = 60;
+
+/** Maximum seconds since last successful fetch before triggering a refresh. */
+export const DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL = 300;
+
+/** Days before persisted auth credentials expire. */
+export const CREDENTIAL_EXPIRATION_DAYS = 30;
+
+/** Maximum number of previous slugs to track per library. */
+export const HISTORICAL_SLUG_LIMIT = 5;

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -10,7 +10,6 @@ import ApplicationError, { PageNotFoundError } from "errors";
 import rawCatalog from "test-utils/fixtures/raw-opds-feed";
 import { fixtures } from "test-utils";
 import { OPDS1 } from "interfaces";
-import mockConfig from "test-utils/mockConfig";
 import { fetchFeed } from "dataflow/opds1/fetch";
 import { getLibraries } from "server/libraryRegistry";
 
@@ -18,7 +17,9 @@ jest.mock("server/libraryRegistry", () => ({
   getLibraries: jest.fn()
 }));
 
-const mockGetLibraries = getLibraries as jest.MockedFunction<typeof getLibraries>;
+const mockGetLibraries = getLibraries as jest.MockedFunction<
+  typeof getLibraries
+>;
 
 describe("fetching catalog", () => {
   test("calls fetch with catalog url", async () => {

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -12,6 +12,13 @@ import { fixtures } from "test-utils";
 import { OPDS1 } from "interfaces";
 import mockConfig from "test-utils/mockConfig";
 import { fetchFeed } from "dataflow/opds1/fetch";
+import { getLibraries } from "server/libraryRegistry";
+
+jest.mock("server/libraryRegistry", () => ({
+  getLibraries: jest.fn()
+}));
+
+const mockGetLibraries = getLibraries as jest.MockedFunction<typeof getLibraries>;
 
 describe("fetching catalog", () => {
   test("calls fetch with catalog url", async () => {
@@ -52,8 +59,8 @@ describe("fetching catalog", () => {
 });
 
 describe("getAuthDocUrl", () => {
-  test("throws PageNotFoundError if no entry found in config file for library", async () => {
-    mockConfig({ libraries: {} });
+  test("throws PageNotFoundError if library is not found", async () => {
+    mockGetLibraries.mockResolvedValueOnce({});
     const promise = getAuthDocUrl("not there slug");
     await expect(promise).rejects.toThrow(PageNotFoundError);
     await expect(promise).rejects.toMatchInlineSnapshot(
@@ -61,13 +68,24 @@ describe("getAuthDocUrl", () => {
     );
   });
 
-  test("returns url for existing library in config file", async () => {
-    mockConfig({
-      libraries: { hello: { title: "hello", authDocUrl: "http://library.com" } }
+  test("returns url for a static library", async () => {
+    mockGetLibraries.mockResolvedValueOnce({
+      hello: { title: "hello", authDocUrl: "http://library.com" }
     });
-
     const promise = getAuthDocUrl("hello");
     await expect(promise).resolves.toBe("http://library.com");
+  });
+
+  test("returns url for a library sourced from a registry", async () => {
+    mockGetLibraries.mockResolvedValueOnce({
+      "uuid-abc": {
+        id: "urn:uuid:abc",
+        title: "Registry Lib",
+        authDocUrl: "https://reg.example.com/auth"
+      }
+    });
+    const url = await getAuthDocUrl("uuid-abc");
+    expect(url).toBe("https://reg.example.com/auth");
   });
 });
 

--- a/src/dataflow/getLibraryData.ts
+++ b/src/dataflow/getLibraryData.ts
@@ -2,12 +2,15 @@ import { LibraryData, LibraryLinks, OPDS1 } from "interfaces";
 import ApplicationError, { PageNotFoundError, ServerError } from "errors";
 import { normalizeAuthMethods } from "utils/auth";
 import { APP_CONFIG } from "utils/env";
+import { getLibraries } from "server/libraryRegistry";
 
 /**
  * Interprets the app config to return the auth document url.
+ * Uses getLibraries so registry-sourced libraries (not present in the static
+ * build-time config) are included in the lookup.
  */
 export async function getAuthDocUrl(librarySlug: string): Promise<string> {
-  const libraries = APP_CONFIG.libraries;
+  const libraries = await getLibraries(APP_CONFIG);
 
   const authDocUrl =
     librarySlug in libraries ? libraries[librarySlug]?.authDocUrl : undefined;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -60,10 +60,10 @@ export type LibrariesConfig = Record<
 /** Per-registry configuration for runtime library fetching. */
 export interface RegistryConfig {
   url: string;
-  refreshMinInterval?: number;  // seconds, default 60
-  refreshMaxInterval?: number;  // seconds, default 300
+  refreshMinInterval?: number; // seconds, default 60
+  refreshMaxInterval?: number; // seconds, default 300
   fullRefreshInterval?: number; // seconds, default 86400 (24 h)
-  timeout?: number;             // seconds, default 10
+  timeout?: number; // seconds, default 10
 }
 
 export interface ComplaintData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -63,8 +63,9 @@ export type LibrariesConfig = Record<
  */
 export interface RegistryConfig {
   url: string;
-  refreshMinInterval?: number; // seconds, default 60
-  refreshMaxInterval?: number; // seconds, default 300
+  refreshMinInterval?: number;  // seconds, default 60
+  refreshMaxInterval?: number;  // seconds, default 300
+  fullRefreshInterval?: number; // seconds, default 86400 (24 h)
 }
 
 export interface ComplaintData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,7 +20,7 @@ export type AppConfig = {
   instanceName: string;
   mediaSupport: MediaSupportConfig;
   libraries: LibrariesConfig;
-  registries?: RegistryConfig[]; // Added in Release 0 for runtime registry fetching
+  registries?: RegistryConfig[];
   companionApp: "simplye" | "openebooks";
   showMedium: boolean;
   gtmId: string | null;
@@ -57,10 +57,7 @@ export type LibrariesConfig = Record<
   { title: string; authDocUrl: string } | undefined
 >;
 
-/**
- * Registry configuration for runtime library fetching
- * Introduced in Release 0 for config migration support
- */
+/** Per-registry configuration for runtime library fetching. */
 export interface RegistryConfig {
   url: string;
   refreshMinInterval?: number;  // seconds, default 60

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -54,7 +54,7 @@ export type MediaSupportLevel =
 export type LibraryRegistryBase = string;
 export type LibrariesConfig = Record<
   string,
-  { title: string; authDocUrl: string } | undefined
+  { id?: string; title: string; authDocUrl: string } | undefined
 >;
 
 /** Per-registry configuration for runtime library fetching. */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -63,6 +63,7 @@ export interface RegistryConfig {
   refreshMinInterval?: number;  // seconds, default 60
   refreshMaxInterval?: number;  // seconds, default 300
   fullRefreshInterval?: number; // seconds, default 86400 (24 h)
+  timeout?: number;             // seconds, default 10
 }
 
 export interface ComplaintData {

--- a/src/pages/api/__tests__/libraries.test.ts
+++ b/src/pages/api/__tests__/libraries.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the GET /api/libraries route.
+ * Run under jest.config.node.js.
+ */
+
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { LibrariesResponse, LibrariesErrorResponse } from "../libraries";
+
+// Mock the registry module so we can control what getLibraries returns.
+jest.mock("server/libraryRegistry", () => ({
+  getLibraries: jest.fn()
+}));
+
+import { getLibraries } from "server/libraryRegistry";
+import handler from "../libraries";
+
+const mockGetLibraries = getLibraries as jest.MockedFunction<
+  typeof getLibraries
+>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_APP_CONFIG = JSON.stringify({
+  instanceName: "Test",
+  gtmId: null,
+  bugsnagApiKey: null,
+  companionApp: "simplye",
+  showMedium: true,
+  openebooks: null,
+  mediaSupport: {},
+  libraries: {}
+});
+
+function makeRes() {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  return { status, json } as unknown as NextApiResponse<
+    LibrariesResponse | LibrariesErrorResponse
+  >;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/libraries", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, APP_CONFIG: VALID_APP_CONFIG };
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns 200 with an array of client-safe library objects", async () => {
+    mockGetLibraries.mockResolvedValue({
+      "urn:uuid:abc": {
+        title: "Library A",
+        authDocUrl: "https://a.example.com/auth"
+      },
+      "urn:uuid:def": {
+        title: "Library B",
+        authDocUrl: "https://b.example.com/auth"
+      }
+    });
+
+    const res = makeRes();
+    await handler({} as NextApiRequest, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      libraries: expect.arrayContaining([
+        {
+          id: "urn:uuid:abc",
+          slug: "urn:uuid:abc",
+          title: "Library A",
+          authDocUrl: "https://a.example.com/auth"
+        },
+        {
+          id: "urn:uuid:def",
+          slug: "urn:uuid:def",
+          title: "Library B",
+          authDocUrl: "https://b.example.com/auth"
+        }
+      ])
+    });
+  });
+
+  it("returns an empty array when there are no libraries", async () => {
+    mockGetLibraries.mockResolvedValue({});
+
+    const res = makeRes();
+    await handler({} as NextApiRequest, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ libraries: [] });
+  });
+
+  it("returns 500 when APP_CONFIG is not set", async () => {
+    delete process.env.APP_CONFIG;
+
+    const res = makeRes();
+    await handler({} as NextApiRequest, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({
+      error: expect.stringContaining("APP_CONFIG")
+    });
+  });
+
+  it("returns 500 when APP_CONFIG is invalid JSON", async () => {
+    process.env.APP_CONFIG = "not-valid-json{{{";
+
+    const res = makeRes();
+    await handler({} as NextApiRequest, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({
+      error: expect.stringContaining("parsed")
+    });
+  });
+
+  it("returns 500 when getLibraries throws", async () => {
+    mockGetLibraries.mockRejectedValue(new Error("Registry unavailable"));
+
+    const res = makeRes();
+    await handler({} as NextApiRequest, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({
+      error: expect.any(String)
+    });
+  });
+
+  it("filters out undefined library entries", async () => {
+    mockGetLibraries.mockResolvedValue({
+      "urn:uuid:valid": {
+        title: "Valid",
+        authDocUrl: "https://v.example.com/auth"
+      },
+      "urn:uuid:missing": undefined
+    });
+
+    const res = makeRes();
+    await handler({} as NextApiRequest, res);
+
+    const { libraries } = (res.json as jest.Mock).mock
+      .calls[0][0] as LibrariesResponse;
+    expect(libraries).toHaveLength(1);
+    expect(libraries[0].id).toBe("urn:uuid:valid");
+  });
+});

--- a/src/pages/api/__tests__/libraries.test.ts
+++ b/src/pages/api/__tests__/libraries.test.ts
@@ -62,11 +62,13 @@ describe("GET /api/libraries", () => {
 
   it("returns 200 with an array of client-safe library objects", async () => {
     mockGetLibraries.mockResolvedValue({
-      "urn:uuid:abc": {
+      "uuid-abc": {
+        id: "urn:uuid:abc",
         title: "Library A",
         authDocUrl: "https://a.example.com/auth"
       },
-      "urn:uuid:def": {
+      "uuid-def": {
+        id: "urn:uuid:def",
         title: "Library B",
         authDocUrl: "https://b.example.com/auth"
       }
@@ -80,13 +82,13 @@ describe("GET /api/libraries", () => {
       libraries: expect.arrayContaining([
         {
           id: "urn:uuid:abc",
-          slug: "urn:uuid:abc",
+          slug: "uuid-abc",
           title: "Library A",
           authDocUrl: "https://a.example.com/auth"
         },
         {
           id: "urn:uuid:def",
-          slug: "urn:uuid:def",
+          slug: "uuid-def",
           title: "Library B",
           authDocUrl: "https://b.example.com/auth"
         }
@@ -142,11 +144,12 @@ describe("GET /api/libraries", () => {
 
   it("filters out undefined library entries", async () => {
     mockGetLibraries.mockResolvedValue({
-      "urn:uuid:valid": {
+      "uuid-valid": {
+        id: "urn:uuid:valid",
         title: "Valid",
         authDocUrl: "https://v.example.com/auth"
       },
-      "urn:uuid:missing": undefined
+      "uuid-missing": undefined
     });
 
     const { res, json } = makeRes();
@@ -155,5 +158,6 @@ describe("GET /api/libraries", () => {
     const { libraries } = json.mock.calls[0][0] as LibrariesResponse;
     expect(libraries).toHaveLength(1);
     expect(libraries[0].id).toBe("urn:uuid:valid");
+    expect(libraries[0].slug).toBe("uuid-valid");
   });
 });

--- a/src/pages/api/__tests__/libraries.test.ts
+++ b/src/pages/api/__tests__/libraries.test.ts
@@ -38,9 +38,10 @@ const VALID_APP_CONFIG = JSON.stringify({
 function makeRes() {
   const json = jest.fn();
   const status = jest.fn(() => ({ json }));
-  return { status, json } as unknown as NextApiResponse<
+  const res = { status } as unknown as NextApiResponse<
     LibrariesResponse | LibrariesErrorResponse
   >;
+  return { res, json };
 }
 
 // ---------------------------------------------------------------------------
@@ -71,11 +72,11 @@ describe("GET /api/libraries", () => {
       }
     });
 
-    const res = makeRes();
+    const { res, json } = makeRes();
     await handler({} as NextApiRequest, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({
+    expect(json).toHaveBeenCalledWith({
       libraries: expect.arrayContaining([
         {
           id: "urn:uuid:abc",
@@ -96,21 +97,21 @@ describe("GET /api/libraries", () => {
   it("returns an empty array when there are no libraries", async () => {
     mockGetLibraries.mockResolvedValue({});
 
-    const res = makeRes();
+    const { res, json } = makeRes();
     await handler({} as NextApiRequest, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ libraries: [] });
+    expect(json).toHaveBeenCalledWith({ libraries: [] });
   });
 
   it("returns 500 when APP_CONFIG is not set", async () => {
     delete process.env.APP_CONFIG;
 
-    const res = makeRes();
+    const { res, json } = makeRes();
     await handler({} as NextApiRequest, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
-    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({
+    expect(json.mock.calls[0][0]).toMatchObject({
       error: expect.stringContaining("APP_CONFIG")
     });
   });
@@ -118,11 +119,11 @@ describe("GET /api/libraries", () => {
   it("returns 500 when APP_CONFIG is invalid JSON", async () => {
     process.env.APP_CONFIG = "not-valid-json{{{";
 
-    const res = makeRes();
+    const { res, json } = makeRes();
     await handler({} as NextApiRequest, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
-    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({
+    expect(json.mock.calls[0][0]).toMatchObject({
       error: expect.stringContaining("parsed")
     });
   });
@@ -130,11 +131,11 @@ describe("GET /api/libraries", () => {
   it("returns 500 when getLibraries throws", async () => {
     mockGetLibraries.mockRejectedValue(new Error("Registry unavailable"));
 
-    const res = makeRes();
+    const { res, json } = makeRes();
     await handler({} as NextApiRequest, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
-    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({
+    expect(json.mock.calls[0][0]).toMatchObject({
       error: expect.any(String)
     });
   });
@@ -148,11 +149,10 @@ describe("GET /api/libraries", () => {
       "urn:uuid:missing": undefined
     });
 
-    const res = makeRes();
+    const { res, json } = makeRes();
     await handler({} as NextApiRequest, res);
 
-    const { libraries } = (res.json as jest.Mock).mock
-      .calls[0][0] as LibrariesResponse;
+    const { libraries } = json.mock.calls[0][0] as LibrariesResponse;
     expect(libraries).toHaveLength(1);
     expect(libraries[0].id).toBe("urn:uuid:valid");
   });

--- a/src/pages/api/libraries.ts
+++ b/src/pages/api/libraries.ts
@@ -54,9 +54,9 @@ export default async function handler(
         (entry): entry is [string, NonNullable<(typeof entry)[1]>] =>
           entry[1] != null
       )
-      .map(([id, lib]) => ({
-        id,
-        slug: id,
+      .map(([slug, lib]) => ({
+        id: lib.id ?? slug,
+        slug,
         title: lib.title,
         authDocUrl: lib.authDocUrl
       }));

--- a/src/pages/api/libraries.ts
+++ b/src/pages/api/libraries.ts
@@ -56,7 +56,7 @@ export default async function handler(
       )
       .map(([id, lib]) => ({
         id,
-        slug: id, // In Release 1, slug === id; later releases may differ.
+        slug: id,
         title: lib.title,
         authDocUrl: lib.authDocUrl
       }));

--- a/src/pages/api/libraries.ts
+++ b/src/pages/api/libraries.ts
@@ -1,0 +1,69 @@
+/**
+ * GET /api/libraries
+ *
+ * Returns the current list of available libraries. For configs that specify
+ * a `registries` array, libraries are fetched at runtime and cached
+ * server-side. For configs with only static `libraries`, the build-time
+ * list is returned directly.
+ *
+ * Only client-safe fields are included in the response; full registry
+ * metadata remains server-side.
+ */
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { AppConfig } from "interfaces";
+import { getLibraries } from "server/libraryRegistry";
+
+export interface ClientLibrary {
+  id: string;
+  slug: string;
+  title: string;
+  authDocUrl: string;
+}
+
+export interface LibrariesResponse {
+  libraries: ClientLibrary[];
+}
+
+export interface LibrariesErrorResponse {
+  error: string;
+}
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse<LibrariesResponse | LibrariesErrorResponse>
+): Promise<void> {
+  const appConfigStr = process.env.APP_CONFIG;
+  if (!appConfigStr) {
+    res.status(500).json({ error: "APP_CONFIG is not configured." });
+    return;
+  }
+
+  let appConfig: AppConfig;
+  try {
+    appConfig = JSON.parse(appConfigStr) as AppConfig;
+  } catch {
+    res.status(500).json({ error: "APP_CONFIG could not be parsed." });
+    return;
+  }
+
+  try {
+    const libraries = await getLibraries(appConfig);
+
+    const clientLibraries: ClientLibrary[] = Object.entries(libraries)
+      .filter(
+        (entry): entry is [string, NonNullable<(typeof entry)[1]>] =>
+          entry[1] != null
+      )
+      .map(([id, lib]) => ({
+        id,
+        slug: id, // In Release 1, slug === id; later releases may differ.
+        title: lib.title,
+        authDocUrl: lib.authDocUrl
+      }));
+
+    res.status(200).json({ libraries: clientLibraries });
+  } catch (err) {
+    console.error("GET /api/libraries failed:", err);
+    res.status(500).json({ error: "Failed to retrieve libraries." });
+  }
+}

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -11,45 +11,81 @@ import {
   getLibraries,
   resetRegistryCaches
 } from "../libraryRegistry";
-import type { AppConfig, RegistryConfig } from "interfaces";
+import type { AppConfig, LibrariesConfig, RegistryConfig } from "interfaces";
 import {
   DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL,
   DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL
 } from "constants/registry";
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Test infrastructure
 // ---------------------------------------------------------------------------
 
-const REGISTRY_URL = "https://registry.example.com/libraries";
+const REGISTRY_URL   = "https://registry.example.com/libraries";
+const REGISTRY_URL_2 = "https://registry2.example.com/libraries";
+const INCREMENTAL_URL = `${REGISTRY_URL}?order=modified`;
 
+/** Minimal AppConfig for test use. */
 function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {
-    instanceName: "Test",
-    gtmId: null,
+    instanceName:  "Test",
+    gtmId:         null,
     bugsnagApiKey: null,
-    companionApp: "simplye",
-    showMedium: true,
-    openebooks: null,
-    mediaSupport: {},
-    libraries: {},
+    companionApp:  "simplye",
+    showMedium:    true,
+    openebooks:    null,
+    mediaSupport:  {},
+    libraries:     {},
     ...overrides
   };
 }
 
-function makeRegistryConfig(
-  overrides: Partial<RegistryConfig> = {}
-): RegistryConfig {
+function makeRegistryConfig(overrides: Partial<RegistryConfig> = {}): RegistryConfig {
   return { url: REGISTRY_URL, ...overrides };
 }
 
-/** Builds a minimal valid OPDS2 LibraryRegistryFeed JSON. */
-function makeRegistryFeed(
-  catalogs: Array<{ id: string; title: string; authDocUrl?: string }>
+/** Builds a minimal OPDS2 LibraryRegistryFeed for testing. */
+function makePagedFeed(
+  catalogs: Array<{
+    id: string;
+    title: string;
+    authDocUrl?: string;
+    updated?: string;
+  }>,
+  options: {
+    nextHref?: string;
+    incrementalFacetHref?: string;
+  } = {}
 ) {
+  const links: object[] = [];
+  if (options.nextHref) {
+    links.push({ rel: "next", href: options.nextHref, type: "application/opds+json" });
+  }
+
+  const facets: object[] = [];
+  if (options.incrementalFacetHref) {
+    facets.push({
+      metadata: {
+        title: "Sort",
+        "@type": "http://palaceproject.io/terms/rel/sort"
+      },
+      links: [
+        {
+          href: options.incrementalFacetHref,
+          rel: "self",
+          type: "application/opds+json",
+          title: "Recently Modified"
+        }
+      ]
+    });
+  }
+
   return {
-    catalogs: catalogs.map(({ id, title, authDocUrl }) => ({
-      metadata: { id, title, updated: "", description: "" },
+    metadata: { adobe_vendor_id: "", title: "Registry", numberOfItems: catalogs.length },
+    links,
+    facets,
+    catalogs: catalogs.map(({ id, title, authDocUrl, updated }) => ({
+      metadata: { id, title, updated: updated ?? "", description: "" },
       links: authDocUrl
         ? [
             {
@@ -63,8 +99,42 @@ function makeRegistryFeed(
   };
 }
 
-/** Returns a jest mock that resolves with a successful JSON response. */
-function mockFetchSuccess(body: unknown) {
+/** Routes fetch calls by URL — useful for multi-page tests. */
+function mockFetchByUrl(urlMap: Record<string, unknown>): jest.Mock {
+  return jest.fn().mockImplementation((url: string) => {
+    const body = urlMap[url];
+    if (body === undefined) {
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        json: async () => ({})
+      });
+    }
+    if (
+      body !== null &&
+      typeof body === "object" &&
+      "status" in body &&
+      !(body as { ok?: boolean }).ok
+    ) {
+      const err = body as { status: number; statusText: string };
+      return Promise.resolve({
+        ok: false,
+        status: err.status,
+        statusText: err.statusText,
+        json: async () => ({})
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => body
+    });
+  });
+}
+
+function mockFetchSuccess(body: unknown): jest.Mock {
   return jest.fn().mockResolvedValue({
     ok: true,
     status: 200,
@@ -73,8 +143,7 @@ function mockFetchSuccess(body: unknown) {
   });
 }
 
-/** Returns a jest mock that resolves with an HTTP error response. */
-function mockFetchError(status = 500, statusText = "Internal Server Error") {
+function mockFetchError(status = 500, statusText = "Internal Server Error"): jest.Mock {
   return jest.fn().mockResolvedValue({
     ok: false,
     status,
@@ -90,63 +159,59 @@ function mockFetchError(status = 500, statusText = "Internal Server Error") {
 describe("shouldRefresh", () => {
   const NOW = 1_000_000;
 
+  function makeState(overrides: {
+    lastSuccessfulFetch?: number | null;
+    lastAttemptedFetch?: number | null;
+  } = {}) {
+    return {
+      libraries: {},
+      lastSuccessfulFetch: null,
+      lastAttemptedFetch: null,
+      lastFullFetch: null,
+      incrementalUrl: null,
+      ...overrides
+    };
+  }
+
   it("returns true when state is undefined (never fetched)", () => {
     expect(shouldRefresh(undefined, makeRegistryConfig(), NOW)).toBe(true);
   });
 
   it("returns true when no successful fetch has occurred", () => {
-    const state = {
-      libraries: {},
-      lastSuccessfulFetch: null,
-      lastAttemptedFetch: null
-    };
-    expect(shouldRefresh(state, makeRegistryConfig(), NOW)).toBe(true);
+    expect(shouldRefresh(makeState(), makeRegistryConfig(), NOW)).toBe(true);
   });
 
   it("returns false when last attempt was within min interval", () => {
-    const state = {
-      libraries: {},
+    const state = makeState({
       lastSuccessfulFetch: NOW - DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL - 1,
       lastAttemptedFetch: NOW - (DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL - 1)
-    };
+    });
     expect(shouldRefresh(state, makeRegistryConfig(), NOW)).toBe(false);
   });
 
   it("returns false when data is fresh (within max interval)", () => {
-    const state = {
-      libraries: {},
+    const state = makeState({
       lastSuccessfulFetch: NOW - (DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL - 1),
       lastAttemptedFetch: NOW - DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL
-    };
+    });
     expect(shouldRefresh(state, makeRegistryConfig(), NOW)).toBe(false);
   });
 
-  it("returns true when data is stale (beyond max interval) and min interval respected", () => {
-    const state = {
-      libraries: {},
+  it("returns true when data is stale and min interval respected", () => {
+    const state = makeState({
       lastSuccessfulFetch: NOW - DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL - 1,
       lastAttemptedFetch: NOW - DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL - 1
-    };
+    });
     expect(shouldRefresh(state, makeRegistryConfig(), NOW)).toBe(true);
   });
 
   it("respects custom min and max intervals from config", () => {
-    const config = makeRegistryConfig({
-      refreshMinInterval: 10,
-      refreshMaxInterval: 30
-    });
-    const freshState = {
-      libraries: {},
-      lastSuccessfulFetch: NOW - 29,
-      lastAttemptedFetch: NOW - 11
-    };
+    const config = makeRegistryConfig({ refreshMinInterval: 10, refreshMaxInterval: 30 });
+
+    const freshState = makeState({ lastSuccessfulFetch: NOW - 29, lastAttemptedFetch: NOW - 11 });
     expect(shouldRefresh(freshState, config, NOW)).toBe(false);
 
-    const staleState = {
-      libraries: {},
-      lastSuccessfulFetch: NOW - 31,
-      lastAttemptedFetch: NOW - 11
-    };
+    const staleState = makeState({ lastSuccessfulFetch: NOW - 31, lastAttemptedFetch: NOW - 11 });
     expect(shouldRefresh(staleState, config, NOW)).toBe(true);
   });
 });
@@ -156,46 +221,46 @@ describe("shouldRefresh", () => {
 // ---------------------------------------------------------------------------
 
 describe("fetchRegistryLibraries", () => {
-  beforeEach(() => {
-    resetRegistryCaches();
-  });
+  beforeEach(() => resetRegistryCaches());
 
-  it("returns a LibrariesConfig from a valid feed", async () => {
-    const feed = makeRegistryFeed([
-      {
-        id: "urn:uuid:abc",
-        title: "Library A",
-        authDocUrl: "https://a.example.com/auth"
-      },
-      {
-        id: "urn:uuid:def",
-        title: "Library B",
-        authDocUrl: "https://b.example.com/auth"
-      }
+  it("returns a LibrariesConfig from a valid single-page feed", async () => {
+    const feed = makePagedFeed([
+      { id: "urn:uuid:abc", title: "Library A", authDocUrl: "https://a.example.com/auth" },
+      { id: "urn:uuid:def", title: "Library B", authDocUrl: "https://b.example.com/auth" }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
     const result = await fetchRegistryLibraries(REGISTRY_URL);
 
     expect(result).toEqual({
-      "urn:uuid:abc": {
-        title: "Library A",
-        authDocUrl: "https://a.example.com/auth"
-      },
-      "urn:uuid:def": {
-        title: "Library B",
-        authDocUrl: "https://b.example.com/auth"
-      }
+      "urn:uuid:abc": { title: "Library A", authDocUrl: "https://a.example.com/auth" },
+      "urn:uuid:def": { title: "Library B", authDocUrl: "https://b.example.com/auth" }
     });
   });
 
+  it("follows rel=next links to collect entries across multiple pages", async () => {
+    const PAGE_2_URL = `${REGISTRY_URL}?offset=100`;
+    global.fetch = mockFetchByUrl({
+      [REGISTRY_URL]: makePagedFeed(
+        [{ id: "urn:uuid:p1", title: "Page 1 Lib", authDocUrl: "https://p1.example.com/auth" }],
+        { nextHref: PAGE_2_URL }
+      ),
+      [PAGE_2_URL]: makePagedFeed([
+        { id: "urn:uuid:p2", title: "Page 2 Lib", authDocUrl: "https://p2.example.com/auth" }
+      ])
+    }) as unknown as typeof fetch;
+
+    const result = await fetchRegistryLibraries(REGISTRY_URL);
+
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result["urn:uuid:p1"]).toBeDefined();
+    expect(result["urn:uuid:p2"]).toBeDefined();
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
   it("skips catalogs missing an auth document link", async () => {
-    const feed = makeRegistryFeed([
-      {
-        id: "urn:uuid:abc",
-        title: "Library A",
-        authDocUrl: "https://a.example.com/auth"
-      },
+    const feed = makePagedFeed([
+      { id: "urn:uuid:abc", title: "Library A", authDocUrl: "https://a.example.com/auth" },
       { id: "urn:uuid:no-auth", title: "No Auth Library" }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
@@ -205,198 +270,346 @@ describe("fetchRegistryLibraries", () => {
     expect(Object.keys(result)).toEqual(["urn:uuid:abc"]);
   });
 
-  it("throws when the response is not ok", async () => {
-    global.fetch = mockFetchError(
-      503,
-      "Service Unavailable"
-    ) as unknown as typeof fetch;
+  it("returns empty result for a feed with no catalogs", async () => {
+    const feed = makePagedFeed([]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
-    await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow("503");
+    const result = await fetchRegistryLibraries(REGISTRY_URL);
+
+    expect(result).toEqual({});
   });
 
-  it("throws when the feed has no catalogs field", async () => {
-    global.fetch = mockFetchSuccess({
-      metadata: { title: "Registry" }
-    }) as unknown as typeof fetch;
-
-    await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow(
-      "catalogs"
-    );
+  it("throws when the response is not ok", async () => {
+    global.fetch = mockFetchError(503, "Service Unavailable") as unknown as typeof fetch;
+    await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow("503");
   });
 });
 
 // ---------------------------------------------------------------------------
-// getLibraries
+// crawlRegistryFeed (tested via fetchRegistryLibraries and getLibraries)
 // ---------------------------------------------------------------------------
 
-describe("getLibraries", () => {
+describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
+  const NOW_SECONDS = 2_000_000;
+  const OLD_TIMESTAMP = new Date((NOW_SECONDS - 1000) * 1000).toISOString();
+  const NEW_TIMESTAMP = new Date((NOW_SECONDS + 1000) * 1000).toISOString();
+
   beforeEach(() => {
     resetRegistryCaches();
+    jest.spyOn(Date, "now").mockReturnValue(NOW_SECONDS * 1000);
   });
 
-  it("returns static libraries when no registries are configured", async () => {
-    const config = makeConfig({
-      libraries: {
-        "my-lib": { title: "My Lib", authDocUrl: "https://my.lib/auth" }
-      }
+  afterEach(() => jest.restoreAllMocks());
+
+  function makeIncrementalConfig(overrides: Partial<RegistryConfig> = {}): RegistryConfig {
+    return makeRegistryConfig({
+      refreshMinInterval: 1,
+      refreshMaxInterval: 1,
+      fullRefreshInterval: 86400,
+      ...overrides
     });
+  }
 
-    const result = await getLibraries(config);
+  async function doFirstFetch(feedWithFacet: object) {
+    global.fetch = mockFetchSuccess(feedWithFacet) as unknown as typeof fetch;
+    await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
+  }
 
-    expect(result).toEqual(config.libraries);
-    // fetch should never be called.
-    expect(global.fetch).not.toHaveBeenCalled?.();
-  });
-
-  it("fetches from registry and returns merged libraries", async () => {
-    const feed = makeRegistryFeed([
-      {
-        id: "urn:uuid:reg",
-        title: "Registry Lib",
-        authDocUrl: "https://r.example.com/auth"
-      }
-    ]);
+  it("single-page full crawl sets reachedEnd, incrementalUrl from facets", async () => {
+    const feed = makePagedFeed(
+      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
-    const config = makeConfig({
-      registries: [{ url: REGISTRY_URL }]
-    });
+    const result = await getLibraries(
+      makeConfig({ registries: [makeIncrementalConfig()] })
+    );
 
-    const result = await getLibraries(config);
-
-    expect(result["urn:uuid:reg"]).toEqual({
-      title: "Registry Lib",
-      authDocUrl: "https://r.example.com/auth"
-    });
+    expect(result["urn:uuid:a"]).toBeDefined();
   });
 
-  it("static libraries override registry libraries with the same key", async () => {
-    const feed = makeRegistryFeed([
-      {
-        id: "urn:uuid:shared",
-        title: "Registry Version",
-        authDocUrl: "https://r.example.com/auth"
-      }
-    ]);
+  it("incremental crawl stops mid-page when an entry is old", async () => {
+    const initialFeed = makePagedFeed(
+      [
+        { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP },
+        { id: "urn:uuid:b", title: "B", authDocUrl: "https://b.example.com/auth", updated: NEW_TIMESTAMP }
+      ],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
+    await doFirstFetch(initialFeed);
+
+    // Advance time past maxInterval so a refresh triggers.
+    jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 2) * 1000);
+
+    const incrementalFeed = makePagedFeed(
+      [
+        { id: "urn:uuid:c", title: "C (new)", authDocUrl: "https://c.example.com/auth", updated: NEW_TIMESTAMP },
+        { id: "urn:uuid:a", title: "A (old)", authDocUrl: "https://a.example.com/auth", updated: OLD_TIMESTAMP }
+      ],
+      { incrementalFacetHref: INCREMENTAL_URL, nextHref: `${INCREMENTAL_URL}&offset=100` }
+    );
+    global.fetch = mockFetchByUrl({
+      [INCREMENTAL_URL]: incrementalFeed
+    }) as unknown as typeof fetch;
+
+    const result = await getLibraries(
+      makeConfig({ registries: [makeIncrementalConfig()] })
+    );
+
+    // C is new and should be present; A (old) stops the crawl on the page.
+    expect(result["urn:uuid:c"]).toBeDefined();
+    // B was cached from the first fetch and not seen in incremental (not replaced).
+    expect(result["urn:uuid:b"]).toBeDefined();
+  });
+
+  it("incremental that reaches end of feed replaces cache (deletions applied)", async () => {
+    const initialFeed = makePagedFeed(
+      [
+        { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP },
+        { id: "urn:uuid:b", title: "B", authDocUrl: "https://b.example.com/auth", updated: NEW_TIMESTAMP }
+      ],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
+    await doFirstFetch(initialFeed);
+
+    jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 2) * 1000);
+
+    // Incremental feed: A is old (triggers stop), but no next link → reachedEnd.
+    const incrementalFeed = makePagedFeed(
+      [
+        { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: OLD_TIMESTAMP }
+      ],
+      { incrementalFacetHref: INCREMENTAL_URL } // no nextHref
+    );
+    global.fetch = mockFetchByUrl({
+      [INCREMENTAL_URL]: incrementalFeed
+    }) as unknown as typeof fetch;
+
+    const result = await getLibraries(
+      makeConfig({ registries: [makeIncrementalConfig()] })
+    );
+
+    // reachedEnd = true (no next link), so cache is replaced.
+    // A triggered the stop (not accumulated), so both A and B are gone.
+    expect(result["urn:uuid:a"]).toBeUndefined();
+    expect(result["urn:uuid:b"]).toBeUndefined();
+  });
+
+  it("full crawl after fullRefreshInterval replaces cache", async () => {
+    const initialFeed = makePagedFeed(
+      [
+        { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP },
+        { id: "urn:uuid:b", title: "B", authDocUrl: "https://b.example.com/auth", updated: NEW_TIMESTAMP }
+      ],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
+    await doFirstFetch(initialFeed);
+
+    // Advance past fullRefreshInterval.
+    const config = makeIncrementalConfig({ fullRefreshInterval: 10 });
+    jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 11) * 1000);
+
+    // Full refresh feed: only A.
+    const fullFeed = makePagedFeed(
+      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
+    global.fetch = mockFetchByUrl({ [REGISTRY_URL]: fullFeed }) as unknown as typeof fetch;
+
+    const result = await getLibraries(makeConfig({ registries: [config] }));
+
+    expect(result["urn:uuid:a"]).toBeDefined();
+    expect(result["urn:uuid:b"]).toBeUndefined();
+  });
+
+  it("second fetch within fullRefreshInterval uses incrementalUrl", async () => {
+    const initialFeed = makePagedFeed(
+      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
+    await doFirstFetch(initialFeed);
+
+    jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 2) * 1000);
+
+    const fetchMock = mockFetchByUrl({
+      [INCREMENTAL_URL]: makePagedFeed([], { incrementalFacetHref: INCREMENTAL_URL })
+    }) as unknown as typeof fetch;
+    global.fetch = fetchMock;
+
+    await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
+
+    expect((fetchMock as jest.Mock).mock.calls[0][0]).toBe(INCREMENTAL_URL);
+  });
+
+  it("first fetch always uses registryConfig.url regardless of incrementalUrl", async () => {
+    const feed = makePagedFeed(
+      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
+    const fetchMock = mockFetchSuccess(feed) as unknown as typeof fetch;
+    global.fetch = fetchMock;
+
+    await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
+
+    expect((fetchMock as jest.Mock).mock.calls[0][0]).toBe(REGISTRY_URL);
+  });
+
+  it("logs warning on first fetch when no order=modified facet found", async () => {
+    const feed = makePagedFeed(
+      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth" }]
+      // no incrementalFacetHref
+    );
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
 
-    const config = makeConfig({
-      libraries: {
-        "urn:uuid:shared": {
-          title: "Static Version",
-          authDocUrl: "https://static.example.com/auth"
-        }
-      },
-      registries: [{ url: REGISTRY_URL }]
-    });
+    await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
 
-    const result = await getLibraries(config);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("order=modified facet")
+    );
+  });
 
-    expect(result["urn:uuid:shared"]?.title).toBe("Static Version");
+  it("entry with empty updated string is not treated as a stop signal", async () => {
+    const initialFeed = makePagedFeed(
+      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
+    await doFirstFetch(initialFeed);
+
+    jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 2) * 1000);
+
+    const incrementalFeed = makePagedFeed(
+      [
+        { id: "urn:uuid:b", title: "B (no date)", authDocUrl: "https://b.example.com/auth", updated: "" },
+        { id: "urn:uuid:c", title: "C (new)", authDocUrl: "https://c.example.com/auth", updated: NEW_TIMESTAMP }
+      ],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
+    global.fetch = mockFetchByUrl({ [INCREMENTAL_URL]: incrementalFeed }) as unknown as typeof fetch;
+
+    const result = await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
+
+    // Both B (empty date) and C (new) should be collected.
+    expect(result["urn:uuid:b"]).toBeDefined();
+    expect(result["urn:uuid:c"]).toBeDefined();
   });
 
   it("retains cached state when registry fetch fails", async () => {
-    // First call succeeds and populates the cache.
-    const feed = makeRegistryFeed([
-      {
-        id: "urn:uuid:cached",
-        title: "Cached Lib",
-        authDocUrl: "https://cached.example.com/auth"
-      }
+    const initialFeed = makePagedFeed(
+      [{ id: "urn:uuid:cached", title: "Cached", authDocUrl: "https://cached.example.com/auth", updated: NEW_TIMESTAMP }],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
+    await doFirstFetch(initialFeed);
+
+    jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 2) * 1000);
+    global.fetch = mockFetchError() as unknown as typeof fetch;
+
+    const result = await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
+
+    expect(result["urn:uuid:cached"]).toBeDefined();
+  });
+
+  it("retains incrementalUrl in state after a failed fetch", async () => {
+    const initialFeed = makePagedFeed(
+      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      { incrementalFacetHref: INCREMENTAL_URL }
+    );
+    await doFirstFetch(initialFeed);
+
+    jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 2) * 1000);
+    global.fetch = mockFetchError() as unknown as typeof fetch;
+    await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
+
+    // The next successful fetch should still use incrementalUrl (not the base URL).
+    jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 4) * 1000);
+    const fetchMock = mockFetchByUrl({
+      [INCREMENTAL_URL]: makePagedFeed([], { incrementalFacetHref: INCREMENTAL_URL })
+    }) as unknown as typeof fetch;
+    global.fetch = fetchMock;
+
+    await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
+    expect((fetchMock as jest.Mock).mock.calls[0][0]).toBe(INCREMENTAL_URL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLibraries — general behaviour (originally from Release 1 tests)
+// ---------------------------------------------------------------------------
+
+describe("getLibraries", () => {
+  beforeEach(() => resetRegistryCaches());
+
+  it("returns static libraries when no registries are configured", async () => {
+    const config = makeConfig({
+      libraries: { "my-lib": { title: "My Lib", authDocUrl: "https://my.lib/auth" } }
+    });
+    const result = await getLibraries(config);
+    expect(result).toEqual(config.libraries);
+  });
+
+  it("fetches from registry and returns merged libraries", async () => {
+    const feed = makePagedFeed([
+      { id: "urn:uuid:reg", title: "Registry Lib", authDocUrl: "https://r.example.com/auth" }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
-    const minInterval = 1;
-    const maxInterval = 2;
+    const result = await getLibraries(makeConfig({ registries: [makeRegistryConfig()] }));
+
+    expect(result["urn:uuid:reg"]).toBeDefined();
+  });
+
+  it("static libraries override registry libraries with the same key", async () => {
+    const feed = makePagedFeed([
+      { id: "urn:uuid:shared", title: "Registry Version", authDocUrl: "https://r.example.com/auth" }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+
     const config = makeConfig({
-      registries: [
-        {
-          url: REGISTRY_URL,
-          refreshMinInterval: minInterval,
-          refreshMaxInterval: maxInterval
-        }
-      ]
+      libraries: { "urn:uuid:shared": { title: "Static Version", authDocUrl: "https://static.example.com/auth" } },
+      registries: [makeRegistryConfig()]
     });
 
-    await getLibraries(config);
+    const result = await getLibraries(config);
+    expect(result["urn:uuid:shared"]?.title).toBe("Static Version");
+  });
 
-    // Advance time past maxInterval so a refresh is triggered.
-    const originalNow = Date.now;
-    Date.now = () => originalNow() + (maxInterval + 1) * 1000;
+  it("gives earlier registries precedence over later ones for the same key", async () => {
+    const feed1 = makePagedFeed([
+      { id: "urn:uuid:shared", title: "First Registry", authDocUrl: "https://r1.example.com/auth" }
+    ]);
+    const feed2 = makePagedFeed([
+      { id: "urn:uuid:shared", title: "Second Registry", authDocUrl: "https://r2.example.com/auth" }
+    ]);
 
-    // Second call fails.
-    global.fetch = mockFetchError() as unknown as typeof fetch;
+    const multiMock = jest.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, statusText: "OK", json: async () => feed1 })
+      .mockResolvedValueOnce({ ok: true, status: 200, statusText: "OK", json: async () => feed2 });
+    global.fetch = multiMock as unknown as typeof fetch;
+
+    const config = makeConfig({
+      registries: [makeRegistryConfig(), makeRegistryConfig({ url: REGISTRY_URL_2 })]
+    });
 
     const result = await getLibraries(config);
-
-    // Should still have cached library, not an empty result.
-    expect(result["urn:uuid:cached"]).toBeDefined();
-
-    Date.now = originalNow;
+    expect(result["urn:uuid:shared"]?.title).toBe("First Registry");
   });
 
   it("does not re-fetch before min interval has elapsed", async () => {
-    const feed = makeRegistryFeed([
+    const feed = makePagedFeed([
       { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth" }
     ]);
     const fetchMock = mockFetchSuccess(feed);
     global.fetch = fetchMock as unknown as typeof fetch;
 
     const config = makeConfig({
-      registries: [
-        { url: REGISTRY_URL, refreshMinInterval: 60, refreshMaxInterval: 1 }
-      ]
+      registries: [makeRegistryConfig({ refreshMinInterval: 60, refreshMaxInterval: 1 })]
     });
 
-    // First call fetches.
     await getLibraries(config);
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    // Second call - data is stale (maxInterval=1s elapsed) but min interval not respected.
-    // The fetch mock last attempt was just now, so min interval blocks it.
     await getLibraries(config);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("gives earlier registries precedence over later ones for the same key", async () => {
-    const REGISTRY_URL_2 = "https://registry2.example.com/libraries";
-
-    const feed1 = makeRegistryFeed([
-      {
-        id: "urn:uuid:shared",
-        title: "First Registry Version",
-        authDocUrl: "https://r1.example.com/auth"
-      }
-    ]);
-    const feed2 = makeRegistryFeed([
-      {
-        id: "urn:uuid:shared",
-        title: "Second Registry Version",
-        authDocUrl: "https://r2.example.com/auth"
-      }
-    ]);
-
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        json: async () => feed1
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        json: async () => feed2
-      }) as unknown as typeof fetch;
-
-    const config = makeConfig({
-      registries: [{ url: REGISTRY_URL }, { url: REGISTRY_URL_2 }]
-    });
-
-    const result = await getLibraries(config);
-
-    expect(result["urn:uuid:shared"]?.title).toBe("First Registry Version");
   });
 });

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -11,7 +11,7 @@ import {
   getLibraries,
   resetRegistryCaches
 } from "../libraryRegistry";
-import type { AppConfig, LibrariesConfig, RegistryConfig } from "interfaces";
+import type { AppConfig, RegistryConfig } from "interfaces";
 import {
   DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL,
   DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL
@@ -21,26 +21,28 @@ import {
 // Test infrastructure
 // ---------------------------------------------------------------------------
 
-const REGISTRY_URL   = "https://registry.example.com/libraries";
+const REGISTRY_URL = "https://registry.example.com/libraries";
 const REGISTRY_URL_2 = "https://registry2.example.com/libraries";
 const INCREMENTAL_URL = `${REGISTRY_URL}?order=modified`;
 
 /** Minimal AppConfig for test use. */
 function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {
-    instanceName:  "Test",
-    gtmId:         null,
+    instanceName: "Test",
+    gtmId: null,
     bugsnagApiKey: null,
-    companionApp:  "simplye",
-    showMedium:    true,
-    openebooks:    null,
-    mediaSupport:  {},
-    libraries:     {},
+    companionApp: "simplye",
+    showMedium: true,
+    openebooks: null,
+    mediaSupport: {},
+    libraries: {},
     ...overrides
   };
 }
 
-function makeRegistryConfig(overrides: Partial<RegistryConfig> = {}): RegistryConfig {
+function makeRegistryConfig(
+  overrides: Partial<RegistryConfig> = {}
+): RegistryConfig {
   return { url: REGISTRY_URL, ...overrides };
 }
 
@@ -59,7 +61,11 @@ function makePagedFeed(
 ) {
   const links: object[] = [];
   if (options.nextHref) {
-    links.push({ rel: "next", href: options.nextHref, type: "application/opds+json" });
+    links.push({
+      rel: "next",
+      href: options.nextHref,
+      type: "application/opds+json"
+    });
   }
 
   const facets: object[] = [];
@@ -81,7 +87,11 @@ function makePagedFeed(
   }
 
   return {
-    metadata: { adobe_vendor_id: "", title: "Registry", numberOfItems: catalogs.length },
+    metadata: {
+      adobe_vendor_id: "", // eslint-disable-line camelcase
+      title: "Registry",
+      numberOfItems: catalogs.length
+    },
     links,
     facets,
     catalogs: catalogs.map(({ id, title, authDocUrl, updated }) => ({
@@ -143,7 +153,10 @@ function mockFetchSuccess(body: unknown): jest.Mock {
   });
 }
 
-function mockFetchError(status = 500, statusText = "Internal Server Error"): jest.Mock {
+function mockFetchError(
+  status = 500,
+  statusText = "Internal Server Error"
+): jest.Mock {
   return jest.fn().mockResolvedValue({
     ok: false,
     status,
@@ -159,10 +172,12 @@ function mockFetchError(status = 500, statusText = "Internal Server Error"): jes
 describe("shouldRefresh", () => {
   const NOW = 1_000_000;
 
-  function makeState(overrides: {
-    lastSuccessfulFetch?: number | null;
-    lastAttemptedFetch?: number | null;
-  } = {}) {
+  function makeState(
+    overrides: {
+      lastSuccessfulFetch?: number | null;
+      lastAttemptedFetch?: number | null;
+    } = {}
+  ) {
     return {
       libraries: {},
       lastSuccessfulFetch: null,
@@ -206,12 +221,21 @@ describe("shouldRefresh", () => {
   });
 
   it("respects custom min and max intervals from config", () => {
-    const config = makeRegistryConfig({ refreshMinInterval: 10, refreshMaxInterval: 30 });
+    const config = makeRegistryConfig({
+      refreshMinInterval: 10,
+      refreshMaxInterval: 30
+    });
 
-    const freshState = makeState({ lastSuccessfulFetch: NOW - 29, lastAttemptedFetch: NOW - 11 });
+    const freshState = makeState({
+      lastSuccessfulFetch: NOW - 29,
+      lastAttemptedFetch: NOW - 11
+    });
     expect(shouldRefresh(freshState, config, NOW)).toBe(false);
 
-    const staleState = makeState({ lastSuccessfulFetch: NOW - 31, lastAttemptedFetch: NOW - 11 });
+    const staleState = makeState({
+      lastSuccessfulFetch: NOW - 31,
+      lastAttemptedFetch: NOW - 11
+    });
     expect(shouldRefresh(staleState, config, NOW)).toBe(true);
   });
 });
@@ -225,16 +249,32 @@ describe("fetchRegistryLibraries", () => {
 
   it("returns a LibrariesConfig from a valid single-page feed", async () => {
     const feed = makePagedFeed([
-      { id: "urn:uuid:abc", title: "Library A", authDocUrl: "https://a.example.com/auth" },
-      { id: "urn:uuid:def", title: "Library B", authDocUrl: "https://b.example.com/auth" }
+      {
+        id: "urn:uuid:abc",
+        title: "Library A",
+        authDocUrl: "https://a.example.com/auth"
+      },
+      {
+        id: "urn:uuid:def",
+        title: "Library B",
+        authDocUrl: "https://b.example.com/auth"
+      }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
     const result = await fetchRegistryLibraries(REGISTRY_URL);
 
     expect(result).toEqual({
-      "urn:uuid:abc": { id: "urn:uuid:abc", title: "Library A", authDocUrl: "https://a.example.com/auth" },
-      "urn:uuid:def": { id: "urn:uuid:def", title: "Library B", authDocUrl: "https://b.example.com/auth" }
+      "urn:uuid:abc": {
+        id: "urn:uuid:abc",
+        title: "Library A",
+        authDocUrl: "https://a.example.com/auth"
+      },
+      "urn:uuid:def": {
+        id: "urn:uuid:def",
+        title: "Library B",
+        authDocUrl: "https://b.example.com/auth"
+      }
     });
   });
 
@@ -242,11 +282,21 @@ describe("fetchRegistryLibraries", () => {
     const PAGE_2_URL = `${REGISTRY_URL}?offset=100`;
     global.fetch = mockFetchByUrl({
       [REGISTRY_URL]: makePagedFeed(
-        [{ id: "urn:uuid:p1", title: "Page 1 Lib", authDocUrl: "https://p1.example.com/auth" }],
+        [
+          {
+            id: "urn:uuid:p1",
+            title: "Page 1 Lib",
+            authDocUrl: "https://p1.example.com/auth"
+          }
+        ],
         { nextHref: PAGE_2_URL }
       ),
       [PAGE_2_URL]: makePagedFeed([
-        { id: "urn:uuid:p2", title: "Page 2 Lib", authDocUrl: "https://p2.example.com/auth" }
+        {
+          id: "urn:uuid:p2",
+          title: "Page 2 Lib",
+          authDocUrl: "https://p2.example.com/auth"
+        }
       ])
     }) as unknown as typeof fetch;
 
@@ -260,7 +310,11 @@ describe("fetchRegistryLibraries", () => {
 
   it("skips catalogs missing an auth document link", async () => {
     const feed = makePagedFeed([
-      { id: "urn:uuid:abc", title: "Library A", authDocUrl: "https://a.example.com/auth" },
+      {
+        id: "urn:uuid:abc",
+        title: "Library A",
+        authDocUrl: "https://a.example.com/auth"
+      },
       { id: "urn:uuid:no-auth", title: "No Auth Library" }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
@@ -280,7 +334,10 @@ describe("fetchRegistryLibraries", () => {
   });
 
   it("throws when the response is not ok", async () => {
-    global.fetch = mockFetchError(503, "Service Unavailable") as unknown as typeof fetch;
+    global.fetch = mockFetchError(
+      503,
+      "Service Unavailable"
+    ) as unknown as typeof fetch;
     await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow("503");
   });
 
@@ -288,7 +345,13 @@ describe("fetchRegistryLibraries", () => {
     const PAGE_2_URL = `${REGISTRY_URL}?offset=100`;
     global.fetch = mockFetchByUrl({
       [REGISTRY_URL]: makePagedFeed(
-        [{ id: "urn:uuid:p1", title: "P1", authDocUrl: "https://p1.example.com/auth" }],
+        [
+          {
+            id: "urn:uuid:p1",
+            title: "P1",
+            authDocUrl: "https://p1.example.com/auth"
+          }
+        ],
         { nextHref: PAGE_2_URL }
       ),
       [PAGE_2_URL]: { status: 503, statusText: "Service Unavailable" }
@@ -299,11 +362,17 @@ describe("fetchRegistryLibraries", () => {
 
   it("skips and warns on entries whose computed slug is not valid", async () => {
     const feed = makePagedFeed([
-      { id: "valid-library",   title: "Valid",   authDocUrl: "https://v.example.com/auth" },
+      {
+        id: "valid-library",
+        title: "Valid",
+        authDocUrl: "https://v.example.com/auth"
+      },
       { id: "", title: "Empty Slug", authDocUrl: "https://b.example.com/auth" }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
 
     const result = await fetchRegistryLibraries(REGISTRY_URL);
 
@@ -330,7 +399,9 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
   afterEach(() => jest.restoreAllMocks());
 
-  function makeIncrementalConfig(overrides: Partial<RegistryConfig> = {}): RegistryConfig {
+  function makeIncrementalConfig(
+    overrides: Partial<RegistryConfig> = {}
+  ): RegistryConfig {
     return makeRegistryConfig({
       refreshMinInterval: 1,
       refreshMaxInterval: 1,
@@ -346,7 +417,14 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
   it("single-page full crawl sets reachedEnd, incrementalUrl from facets", async () => {
     const feed = makePagedFeed(
-      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      [
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
+      ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
@@ -361,8 +439,18 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
   it("incremental crawl stops mid-page when an entry is old", async () => {
     const initialFeed = makePagedFeed(
       [
-        { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP },
-        { id: "urn:uuid:b", title: "B", authDocUrl: "https://b.example.com/auth", updated: NEW_TIMESTAMP }
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth",
+          updated: NEW_TIMESTAMP
+        },
+        {
+          id: "urn:uuid:b",
+          title: "B",
+          authDocUrl: "https://b.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
       ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
@@ -373,10 +461,23 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
     const incrementalFeed = makePagedFeed(
       [
-        { id: "urn:uuid:c", title: "C (new)", authDocUrl: "https://c.example.com/auth", updated: NEW_TIMESTAMP },
-        { id: "urn:uuid:a", title: "A (old)", authDocUrl: "https://a.example.com/auth", updated: OLD_TIMESTAMP }
+        {
+          id: "urn:uuid:c",
+          title: "C (new)",
+          authDocUrl: "https://c.example.com/auth",
+          updated: NEW_TIMESTAMP
+        },
+        {
+          id: "urn:uuid:a",
+          title: "A (old)",
+          authDocUrl: "https://a.example.com/auth",
+          updated: OLD_TIMESTAMP
+        }
       ],
-      { incrementalFacetHref: INCREMENTAL_URL, nextHref: `${INCREMENTAL_URL}&offset=100` }
+      {
+        incrementalFacetHref: INCREMENTAL_URL,
+        nextHref: `${INCREMENTAL_URL}&offset=100`
+      }
     );
     global.fetch = mockFetchByUrl({
       [INCREMENTAL_URL]: incrementalFeed
@@ -395,8 +496,18 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
   it("incremental that reaches end of feed replaces cache (deletions applied)", async () => {
     const initialFeed = makePagedFeed(
       [
-        { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP },
-        { id: "urn:uuid:b", title: "B", authDocUrl: "https://b.example.com/auth", updated: NEW_TIMESTAMP }
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth",
+          updated: NEW_TIMESTAMP
+        },
+        {
+          id: "urn:uuid:b",
+          title: "B",
+          authDocUrl: "https://b.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
       ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
@@ -407,7 +518,12 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
     // Incremental feed: A is old (triggers stop), but no next link → reachedEnd.
     const incrementalFeed = makePagedFeed(
       [
-        { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: OLD_TIMESTAMP }
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth",
+          updated: OLD_TIMESTAMP
+        }
       ],
       { incrementalFacetHref: INCREMENTAL_URL } // no nextHref
     );
@@ -428,8 +544,18 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
   it("full crawl after fullRefreshInterval replaces cache", async () => {
     const initialFeed = makePagedFeed(
       [
-        { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP },
-        { id: "urn:uuid:b", title: "B", authDocUrl: "https://b.example.com/auth", updated: NEW_TIMESTAMP }
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth",
+          updated: NEW_TIMESTAMP
+        },
+        {
+          id: "urn:uuid:b",
+          title: "B",
+          authDocUrl: "https://b.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
       ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
@@ -441,10 +567,19 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
     // Full refresh feed: only A.
     const fullFeed = makePagedFeed(
-      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      [
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
+      ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
-    global.fetch = mockFetchByUrl({ [REGISTRY_URL]: fullFeed }) as unknown as typeof fetch;
+    global.fetch = mockFetchByUrl({
+      [REGISTRY_URL]: fullFeed
+    }) as unknown as typeof fetch;
 
     const result = await getLibraries(makeConfig({ registries: [config] }));
 
@@ -454,7 +589,14 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
   it("second fetch within fullRefreshInterval uses incrementalUrl", async () => {
     const initialFeed = makePagedFeed(
-      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      [
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
+      ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
     await doFirstFetch(initialFeed);
@@ -462,7 +604,9 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
     jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 2) * 1000);
 
     const fetchMock = mockFetchByUrl({
-      [INCREMENTAL_URL]: makePagedFeed([], { incrementalFacetHref: INCREMENTAL_URL })
+      [INCREMENTAL_URL]: makePagedFeed([], {
+        incrementalFacetHref: INCREMENTAL_URL
+      })
     }) as unknown as typeof fetch;
     global.fetch = fetchMock;
 
@@ -473,7 +617,14 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
   it("first fetch always uses registryConfig.url regardless of incrementalUrl", async () => {
     const feed = makePagedFeed(
-      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      [
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
+      ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
     const fetchMock = mockFetchSuccess(feed) as unknown as typeof fetch;
@@ -486,11 +637,19 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
   it("logs warning on first fetch when no order=modified facet found", async () => {
     const feed = makePagedFeed(
-      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth" }]
+      [
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth"
+        }
+      ]
       // no incrementalFacetHref
     );
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
-    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const warnSpy = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
 
     await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
 
@@ -501,7 +660,14 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
   it("entry with empty updated string is not treated as a stop signal", async () => {
     const initialFeed = makePagedFeed(
-      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      [
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
+      ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
     await doFirstFetch(initialFeed);
@@ -510,14 +676,28 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
     const incrementalFeed = makePagedFeed(
       [
-        { id: "urn:uuid:b", title: "B (no date)", authDocUrl: "https://b.example.com/auth", updated: "" },
-        { id: "urn:uuid:c", title: "C (new)", authDocUrl: "https://c.example.com/auth", updated: NEW_TIMESTAMP }
+        {
+          id: "urn:uuid:b",
+          title: "B (no date)",
+          authDocUrl: "https://b.example.com/auth",
+          updated: ""
+        },
+        {
+          id: "urn:uuid:c",
+          title: "C (new)",
+          authDocUrl: "https://c.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
       ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
-    global.fetch = mockFetchByUrl({ [INCREMENTAL_URL]: incrementalFeed }) as unknown as typeof fetch;
+    global.fetch = mockFetchByUrl({
+      [INCREMENTAL_URL]: incrementalFeed
+    }) as unknown as typeof fetch;
 
-    const result = await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
+    const result = await getLibraries(
+      makeConfig({ registries: [makeIncrementalConfig()] })
+    );
 
     // Both B (empty date) and C (new) should be collected.
     expect(result["urn:uuid:b"]).toBeDefined();
@@ -526,7 +706,14 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
   it("retains cached state when registry fetch fails", async () => {
     const initialFeed = makePagedFeed(
-      [{ id: "urn:uuid:cached", title: "Cached", authDocUrl: "https://cached.example.com/auth", updated: NEW_TIMESTAMP }],
+      [
+        {
+          id: "urn:uuid:cached",
+          title: "Cached",
+          authDocUrl: "https://cached.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
+      ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
     await doFirstFetch(initialFeed);
@@ -534,14 +721,23 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
     jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 2) * 1000);
     global.fetch = mockFetchError() as unknown as typeof fetch;
 
-    const result = await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
+    const result = await getLibraries(
+      makeConfig({ registries: [makeIncrementalConfig()] })
+    );
 
     expect(result["urn:uuid:cached"]).toBeDefined();
   });
 
   it("retains incrementalUrl in state after a failed fetch", async () => {
     const initialFeed = makePagedFeed(
-      [{ id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth", updated: NEW_TIMESTAMP }],
+      [
+        {
+          id: "urn:uuid:a",
+          title: "A",
+          authDocUrl: "https://a.example.com/auth",
+          updated: NEW_TIMESTAMP
+        }
+      ],
       { incrementalFacetHref: INCREMENTAL_URL }
     );
     await doFirstFetch(initialFeed);
@@ -553,7 +749,9 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
     // The next successful fetch should still use incrementalUrl (not the base URL).
     jest.spyOn(Date, "now").mockReturnValue((NOW_SECONDS + 4) * 1000);
     const fetchMock = mockFetchByUrl({
-      [INCREMENTAL_URL]: makePagedFeed([], { incrementalFacetHref: INCREMENTAL_URL })
+      [INCREMENTAL_URL]: makePagedFeed([], {
+        incrementalFacetHref: INCREMENTAL_URL
+      })
     }) as unknown as typeof fetch;
     global.fetch = fetchMock;
 
@@ -571,7 +769,9 @@ describe("getLibraries", () => {
 
   it("returns static libraries when no registries are configured", async () => {
     const config = makeConfig({
-      libraries: { "my-lib": { title: "My Lib", authDocUrl: "https://my.lib/auth" } }
+      libraries: {
+        "my-lib": { title: "My Lib", authDocUrl: "https://my.lib/auth" }
+      }
     });
     const result = await getLibraries(config);
     expect(result).toEqual(config.libraries);
@@ -579,23 +779,38 @@ describe("getLibraries", () => {
 
   it("fetches from registry and returns merged libraries", async () => {
     const feed = makePagedFeed([
-      { id: "urn:uuid:reg", title: "Registry Lib", authDocUrl: "https://r.example.com/auth" }
+      {
+        id: "urn:uuid:reg",
+        title: "Registry Lib",
+        authDocUrl: "https://r.example.com/auth"
+      }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
-    const result = await getLibraries(makeConfig({ registries: [makeRegistryConfig()] }));
+    const result = await getLibraries(
+      makeConfig({ registries: [makeRegistryConfig()] })
+    );
 
     expect(result["urn:uuid:reg"]).toBeDefined();
   });
 
   it("static libraries override registry libraries with the same key", async () => {
     const feed = makePagedFeed([
-      { id: "urn:uuid:shared", title: "Registry Version", authDocUrl: "https://r.example.com/auth" }
+      {
+        id: "urn:uuid:shared",
+        title: "Registry Version",
+        authDocUrl: "https://r.example.com/auth"
+      }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
     const config = makeConfig({
-      libraries: { "urn:uuid:shared": { title: "Static Version", authDocUrl: "https://static.example.com/auth" } },
+      libraries: {
+        "urn:uuid:shared": {
+          title: "Static Version",
+          authDocUrl: "https://static.example.com/auth"
+        }
+      },
       registries: [makeRegistryConfig()]
     });
 
@@ -605,19 +820,41 @@ describe("getLibraries", () => {
 
   it("gives earlier registries precedence over later ones for the same key", async () => {
     const feed1 = makePagedFeed([
-      { id: "urn:uuid:shared", title: "First Registry", authDocUrl: "https://r1.example.com/auth" }
+      {
+        id: "urn:uuid:shared",
+        title: "First Registry",
+        authDocUrl: "https://r1.example.com/auth"
+      }
     ]);
     const feed2 = makePagedFeed([
-      { id: "urn:uuid:shared", title: "Second Registry", authDocUrl: "https://r2.example.com/auth" }
+      {
+        id: "urn:uuid:shared",
+        title: "Second Registry",
+        authDocUrl: "https://r2.example.com/auth"
+      }
     ]);
 
-    const multiMock = jest.fn()
-      .mockResolvedValueOnce({ ok: true, status: 200, statusText: "OK", json: async () => feed1 })
-      .mockResolvedValueOnce({ ok: true, status: 200, statusText: "OK", json: async () => feed2 });
+    const multiMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => feed1
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => feed2
+      });
     global.fetch = multiMock as unknown as typeof fetch;
 
     const config = makeConfig({
-      registries: [makeRegistryConfig(), makeRegistryConfig({ url: REGISTRY_URL_2 })]
+      registries: [
+        makeRegistryConfig(),
+        makeRegistryConfig({ url: REGISTRY_URL_2 })
+      ]
     });
 
     const result = await getLibraries(config);
@@ -632,7 +869,9 @@ describe("getLibraries", () => {
     global.fetch = fetchMock as unknown as typeof fetch;
 
     const config = makeConfig({
-      registries: [makeRegistryConfig({ refreshMinInterval: 60, refreshMaxInterval: 1 })]
+      registries: [
+        makeRegistryConfig({ refreshMinInterval: 60, refreshMaxInterval: 1 })
+      ]
     });
 
     await getLibraries(config);
@@ -656,16 +895,21 @@ describe("fetch timeout", () => {
   });
 
   /** Returns a fetch mock whose response promise never resolves but rejects on abort. */
-  function mockHangingFetch(): { mock: jest.Mock; capturedSignal: () => AbortSignal | undefined } {
+  function mockHangingFetch(): {
+    mock: jest.Mock;
+    capturedSignal: () => AbortSignal | undefined;
+  } {
     let signal: AbortSignal | undefined;
-    const mock = jest.fn().mockImplementation((_url: string, init: RequestInit) => {
-      signal = init?.signal as AbortSignal | undefined;
-      return new Promise<Response>((_resolve, reject) => {
-        signal?.addEventListener("abort", () =>
-          reject(new DOMException("The operation was aborted.", "AbortError"))
-        );
+    const mock = jest
+      .fn()
+      .mockImplementation((_url: string, init: RequestInit) => {
+        signal = init?.signal as AbortSignal | undefined;
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener("abort", () =>
+            reject(new DOMException("The operation was aborted.", "AbortError"))
+          );
+        });
       });
-    });
     return { mock, capturedSignal: () => signal };
   }
 
@@ -720,19 +964,36 @@ describe("fetch timeout", () => {
     const PAGE_2_URL = `${REGISTRY_URL}?offset=100`;
     const signals: (AbortSignal | undefined)[] = [];
 
-    global.fetch = jest.fn().mockImplementation((url: string, init: RequestInit) => {
-      signals.push(init?.signal as AbortSignal | undefined);
-      const body =
-        url === REGISTRY_URL
-          ? makePagedFeed(
-              [{ id: "urn:uuid:p1", title: "P1", authDocUrl: "https://p1.example.com/auth" }],
-              { nextHref: PAGE_2_URL }
-            )
-          : makePagedFeed([
-              { id: "urn:uuid:p2", title: "P2", authDocUrl: "https://p2.example.com/auth" }
-            ]);
-      return Promise.resolve({ ok: true, status: 200, statusText: "OK", json: async () => body });
-    }) as unknown as typeof fetch;
+    global.fetch = jest
+      .fn()
+      .mockImplementation((url: string, init: RequestInit) => {
+        signals.push(init?.signal as AbortSignal | undefined);
+        const body =
+          url === REGISTRY_URL
+            ? makePagedFeed(
+                [
+                  {
+                    id: "urn:uuid:p1",
+                    title: "P1",
+                    authDocUrl: "https://p1.example.com/auth"
+                  }
+                ],
+                { nextHref: PAGE_2_URL }
+              )
+            : makePagedFeed([
+                {
+                  id: "urn:uuid:p2",
+                  title: "P2",
+                  authDocUrl: "https://p2.example.com/auth"
+                }
+              ]);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => body
+        });
+      }) as unknown as typeof fetch;
 
     await fetchRegistryLibraries(REGISTRY_URL);
 

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -233,8 +233,8 @@ describe("fetchRegistryLibraries", () => {
     const result = await fetchRegistryLibraries(REGISTRY_URL);
 
     expect(result).toEqual({
-      "urn:uuid:abc": { title: "Library A", authDocUrl: "https://a.example.com/auth" },
-      "urn:uuid:def": { title: "Library B", authDocUrl: "https://b.example.com/auth" }
+      "uuid-abc": { title: "Library A", authDocUrl: "https://a.example.com/auth" },
+      "uuid-def": { title: "Library B", authDocUrl: "https://b.example.com/auth" }
     });
   });
 
@@ -253,8 +253,8 @@ describe("fetchRegistryLibraries", () => {
     const result = await fetchRegistryLibraries(REGISTRY_URL);
 
     expect(Object.keys(result)).toHaveLength(2);
-    expect(result["urn:uuid:p1"]).toBeDefined();
-    expect(result["urn:uuid:p2"]).toBeDefined();
+    expect(result["uuid-p1"]).toBeDefined();
+    expect(result["uuid-p2"]).toBeDefined();
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
@@ -267,7 +267,7 @@ describe("fetchRegistryLibraries", () => {
 
     const result = await fetchRegistryLibraries(REGISTRY_URL);
 
-    expect(Object.keys(result)).toEqual(["urn:uuid:abc"]);
+    expect(Object.keys(result)).toEqual(["uuid-abc"]);
   });
 
   it("returns empty result for a feed with no catalogs", async () => {
@@ -282,6 +282,22 @@ describe("fetchRegistryLibraries", () => {
   it("throws when the response is not ok", async () => {
     global.fetch = mockFetchError(503, "Service Unavailable") as unknown as typeof fetch;
     await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow("503");
+  });
+
+  it("skips and warns on entries whose computed slug is not URL-safe", async () => {
+    const feed = makePagedFeed([
+      { id: "valid-library",   title: "Valid",   authDocUrl: "https://v.example.com/auth" },
+      { id: "bad/slug/here",   title: "Bad Slug", authDocUrl: "https://b.example.com/auth" }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = await fetchRegistryLibraries(REGISTRY_URL);
+
+    expect(Object.keys(result)).toEqual(["valid-library"]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("invalid slug")
+    );
   });
 });
 
@@ -326,7 +342,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
       makeConfig({ registries: [makeIncrementalConfig()] })
     );
 
-    expect(result["urn:uuid:a"]).toBeDefined();
+    expect(result["uuid-a"]).toBeDefined();
   });
 
   it("incremental crawl stops mid-page when an entry is old", async () => {
@@ -358,9 +374,9 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
     );
 
     // C is new and should be present; A (old) stops the crawl on the page.
-    expect(result["urn:uuid:c"]).toBeDefined();
+    expect(result["uuid-c"]).toBeDefined();
     // B was cached from the first fetch and not seen in incremental (not replaced).
-    expect(result["urn:uuid:b"]).toBeDefined();
+    expect(result["uuid-b"]).toBeDefined();
   });
 
   it("incremental that reaches end of feed replaces cache (deletions applied)", async () => {
@@ -392,8 +408,8 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
     // reachedEnd = true (no next link), so cache is replaced.
     // A triggered the stop (not accumulated), so both A and B are gone.
-    expect(result["urn:uuid:a"]).toBeUndefined();
-    expect(result["urn:uuid:b"]).toBeUndefined();
+    expect(result["uuid-a"]).toBeUndefined();
+    expect(result["uuid-b"]).toBeUndefined();
   });
 
   it("full crawl after fullRefreshInterval replaces cache", async () => {
@@ -419,8 +435,8 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
     const result = await getLibraries(makeConfig({ registries: [config] }));
 
-    expect(result["urn:uuid:a"]).toBeDefined();
-    expect(result["urn:uuid:b"]).toBeUndefined();
+    expect(result["uuid-a"]).toBeDefined();
+    expect(result["uuid-b"]).toBeUndefined();
   });
 
   it("second fetch within fullRefreshInterval uses incrementalUrl", async () => {
@@ -491,8 +507,8 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
     const result = await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
 
     // Both B (empty date) and C (new) should be collected.
-    expect(result["urn:uuid:b"]).toBeDefined();
-    expect(result["urn:uuid:c"]).toBeDefined();
+    expect(result["uuid-b"]).toBeDefined();
+    expect(result["uuid-c"]).toBeDefined();
   });
 
   it("retains cached state when registry fetch fails", async () => {
@@ -507,7 +523,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
     const result = await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
 
-    expect(result["urn:uuid:cached"]).toBeDefined();
+    expect(result["uuid-cached"]).toBeDefined();
   });
 
   it("retains incrementalUrl in state after a failed fetch", async () => {
@@ -556,7 +572,7 @@ describe("getLibraries", () => {
 
     const result = await getLibraries(makeConfig({ registries: [makeRegistryConfig()] }));
 
-    expect(result["urn:uuid:reg"]).toBeDefined();
+    expect(result["uuid-reg"]).toBeDefined();
   });
 
   it("static libraries override registry libraries with the same key", async () => {
@@ -566,12 +582,12 @@ describe("getLibraries", () => {
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
     const config = makeConfig({
-      libraries: { "urn:uuid:shared": { title: "Static Version", authDocUrl: "https://static.example.com/auth" } },
+      libraries: { "uuid-shared": { title: "Static Version", authDocUrl: "https://static.example.com/auth" } },
       registries: [makeRegistryConfig()]
     });
 
     const result = await getLibraries(config);
-    expect(result["urn:uuid:shared"]?.title).toBe("Static Version");
+    expect(result["uuid-shared"]?.title).toBe("Static Version");
   });
 
   it("gives earlier registries precedence over later ones for the same key", async () => {
@@ -592,7 +608,7 @@ describe("getLibraries", () => {
     });
 
     const result = await getLibraries(config);
-    expect(result["urn:uuid:shared"]?.title).toBe("First Registry");
+    expect(result["uuid-shared"]?.title).toBe("First Registry");
   });
 
   it("does not re-fetch before min interval has elapsed", async () => {

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -1,0 +1,402 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for the server-side library registry manager.
+ * Run under jest.config.node.js.
+ */
+
+import {
+  shouldRefresh,
+  fetchRegistryLibraries,
+  getLibraries,
+  resetRegistryCaches
+} from "../libraryRegistry";
+import type { AppConfig, RegistryConfig } from "interfaces";
+import {
+  DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL,
+  DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL
+} from "constants/registry";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const REGISTRY_URL = "https://registry.example.com/libraries";
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    instanceName: "Test",
+    gtmId: null,
+    bugsnagApiKey: null,
+    companionApp: "simplye",
+    showMedium: true,
+    openebooks: null,
+    mediaSupport: {},
+    libraries: {},
+    ...overrides
+  };
+}
+
+function makeRegistryConfig(
+  overrides: Partial<RegistryConfig> = {}
+): RegistryConfig {
+  return { url: REGISTRY_URL, ...overrides };
+}
+
+/** Builds a minimal valid OPDS2 LibraryRegistryFeed JSON. */
+function makeRegistryFeed(
+  catalogs: Array<{ id: string; title: string; authDocUrl?: string }>
+) {
+  return {
+    catalogs: catalogs.map(({ id, title, authDocUrl }) => ({
+      metadata: { id, title, updated: "", description: "" },
+      links: authDocUrl
+        ? [
+            {
+              rel: "http://opds-spec.org/auth/document",
+              type: "application/vnd.opds.authentication.v1.0+json",
+              href: authDocUrl
+            }
+          ]
+        : []
+    }))
+  };
+}
+
+/** Returns a jest mock that resolves with a successful JSON response. */
+function mockFetchSuccess(body: unknown) {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => body
+  });
+}
+
+/** Returns a jest mock that resolves with an HTTP error response. */
+function mockFetchError(status = 500, statusText = "Internal Server Error") {
+  return jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    statusText,
+    json: async () => ({})
+  });
+}
+
+// ---------------------------------------------------------------------------
+// shouldRefresh
+// ---------------------------------------------------------------------------
+
+describe("shouldRefresh", () => {
+  const NOW = 1_000_000;
+
+  it("returns true when state is undefined (never fetched)", () => {
+    expect(shouldRefresh(undefined, makeRegistryConfig(), NOW)).toBe(true);
+  });
+
+  it("returns true when no successful fetch has occurred", () => {
+    const state = {
+      libraries: {},
+      lastSuccessfulFetch: null,
+      lastAttemptedFetch: null
+    };
+    expect(shouldRefresh(state, makeRegistryConfig(), NOW)).toBe(true);
+  });
+
+  it("returns false when last attempt was within min interval", () => {
+    const state = {
+      libraries: {},
+      lastSuccessfulFetch: NOW - DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL - 1,
+      lastAttemptedFetch: NOW - (DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL - 1)
+    };
+    expect(shouldRefresh(state, makeRegistryConfig(), NOW)).toBe(false);
+  });
+
+  it("returns false when data is fresh (within max interval)", () => {
+    const state = {
+      libraries: {},
+      lastSuccessfulFetch: NOW - (DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL - 1),
+      lastAttemptedFetch: NOW - DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL
+    };
+    expect(shouldRefresh(state, makeRegistryConfig(), NOW)).toBe(false);
+  });
+
+  it("returns true when data is stale (beyond max interval) and min interval respected", () => {
+    const state = {
+      libraries: {},
+      lastSuccessfulFetch: NOW - DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL - 1,
+      lastAttemptedFetch: NOW - DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL - 1
+    };
+    expect(shouldRefresh(state, makeRegistryConfig(), NOW)).toBe(true);
+  });
+
+  it("respects custom min and max intervals from config", () => {
+    const config = makeRegistryConfig({
+      refreshMinInterval: 10,
+      refreshMaxInterval: 30
+    });
+    const freshState = {
+      libraries: {},
+      lastSuccessfulFetch: NOW - 29,
+      lastAttemptedFetch: NOW - 11
+    };
+    expect(shouldRefresh(freshState, config, NOW)).toBe(false);
+
+    const staleState = {
+      libraries: {},
+      lastSuccessfulFetch: NOW - 31,
+      lastAttemptedFetch: NOW - 11
+    };
+    expect(shouldRefresh(staleState, config, NOW)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchRegistryLibraries
+// ---------------------------------------------------------------------------
+
+describe("fetchRegistryLibraries", () => {
+  beforeEach(() => {
+    resetRegistryCaches();
+  });
+
+  it("returns a LibrariesConfig from a valid feed", async () => {
+    const feed = makeRegistryFeed([
+      {
+        id: "urn:uuid:abc",
+        title: "Library A",
+        authDocUrl: "https://a.example.com/auth"
+      },
+      {
+        id: "urn:uuid:def",
+        title: "Library B",
+        authDocUrl: "https://b.example.com/auth"
+      }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+
+    const result = await fetchRegistryLibraries(REGISTRY_URL);
+
+    expect(result).toEqual({
+      "urn:uuid:abc": {
+        title: "Library A",
+        authDocUrl: "https://a.example.com/auth"
+      },
+      "urn:uuid:def": {
+        title: "Library B",
+        authDocUrl: "https://b.example.com/auth"
+      }
+    });
+  });
+
+  it("skips catalogs missing an auth document link", async () => {
+    const feed = makeRegistryFeed([
+      {
+        id: "urn:uuid:abc",
+        title: "Library A",
+        authDocUrl: "https://a.example.com/auth"
+      },
+      { id: "urn:uuid:no-auth", title: "No Auth Library" }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+
+    const result = await fetchRegistryLibraries(REGISTRY_URL);
+
+    expect(Object.keys(result)).toEqual(["urn:uuid:abc"]);
+  });
+
+  it("throws when the response is not ok", async () => {
+    global.fetch = mockFetchError(
+      503,
+      "Service Unavailable"
+    ) as unknown as typeof fetch;
+
+    await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow("503");
+  });
+
+  it("throws when the feed has no catalogs field", async () => {
+    global.fetch = mockFetchSuccess({
+      metadata: { title: "Registry" }
+    }) as unknown as typeof fetch;
+
+    await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow(
+      "catalogs"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLibraries
+// ---------------------------------------------------------------------------
+
+describe("getLibraries", () => {
+  beforeEach(() => {
+    resetRegistryCaches();
+  });
+
+  it("returns static libraries when no registries are configured", async () => {
+    const config = makeConfig({
+      libraries: {
+        "my-lib": { title: "My Lib", authDocUrl: "https://my.lib/auth" }
+      }
+    });
+
+    const result = await getLibraries(config);
+
+    expect(result).toEqual(config.libraries);
+    // fetch should never be called.
+    expect(global.fetch).not.toHaveBeenCalled?.();
+  });
+
+  it("fetches from registry and returns merged libraries", async () => {
+    const feed = makeRegistryFeed([
+      {
+        id: "urn:uuid:reg",
+        title: "Registry Lib",
+        authDocUrl: "https://r.example.com/auth"
+      }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+
+    const config = makeConfig({
+      registries: [{ url: REGISTRY_URL }]
+    });
+
+    const result = await getLibraries(config);
+
+    expect(result["urn:uuid:reg"]).toEqual({
+      title: "Registry Lib",
+      authDocUrl: "https://r.example.com/auth"
+    });
+  });
+
+  it("static libraries override registry libraries with the same key", async () => {
+    const feed = makeRegistryFeed([
+      {
+        id: "urn:uuid:shared",
+        title: "Registry Version",
+        authDocUrl: "https://r.example.com/auth"
+      }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+
+    const config = makeConfig({
+      libraries: {
+        "urn:uuid:shared": {
+          title: "Static Version",
+          authDocUrl: "https://static.example.com/auth"
+        }
+      },
+      registries: [{ url: REGISTRY_URL }]
+    });
+
+    const result = await getLibraries(config);
+
+    expect(result["urn:uuid:shared"]?.title).toBe("Static Version");
+  });
+
+  it("retains cached state when registry fetch fails", async () => {
+    // First call succeeds and populates the cache.
+    const feed = makeRegistryFeed([
+      {
+        id: "urn:uuid:cached",
+        title: "Cached Lib",
+        authDocUrl: "https://cached.example.com/auth"
+      }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+
+    const minInterval = 1;
+    const maxInterval = 2;
+    const config = makeConfig({
+      registries: [
+        {
+          url: REGISTRY_URL,
+          refreshMinInterval: minInterval,
+          refreshMaxInterval: maxInterval
+        }
+      ]
+    });
+
+    await getLibraries(config);
+
+    // Advance time past maxInterval so a refresh is triggered.
+    const originalNow = Date.now;
+    Date.now = () => originalNow() + (maxInterval + 1) * 1000;
+
+    // Second call fails.
+    global.fetch = mockFetchError() as unknown as typeof fetch;
+
+    const result = await getLibraries(config);
+
+    // Should still have cached library, not an empty result.
+    expect(result["urn:uuid:cached"]).toBeDefined();
+
+    Date.now = originalNow;
+  });
+
+  it("does not re-fetch before min interval has elapsed", async () => {
+    const feed = makeRegistryFeed([
+      { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth" }
+    ]);
+    const fetchMock = mockFetchSuccess(feed);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const config = makeConfig({
+      registries: [
+        { url: REGISTRY_URL, refreshMinInterval: 60, refreshMaxInterval: 1 }
+      ]
+    });
+
+    // First call fetches.
+    await getLibraries(config);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second call - data is stale (maxInterval=1s elapsed) but min interval not respected.
+    // The fetch mock last attempt was just now, so min interval blocks it.
+    await getLibraries(config);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives earlier registries precedence over later ones for the same key", async () => {
+    const REGISTRY_URL_2 = "https://registry2.example.com/libraries";
+
+    const feed1 = makeRegistryFeed([
+      {
+        id: "urn:uuid:shared",
+        title: "First Registry Version",
+        authDocUrl: "https://r1.example.com/auth"
+      }
+    ]);
+    const feed2 = makeRegistryFeed([
+      {
+        id: "urn:uuid:shared",
+        title: "Second Registry Version",
+        authDocUrl: "https://r2.example.com/auth"
+      }
+    ]);
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => feed1
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => feed2
+      }) as unknown as typeof fetch;
+
+    const config = makeConfig({
+      registries: [{ url: REGISTRY_URL }, { url: REGISTRY_URL_2 }]
+    });
+
+    const result = await getLibraries(config);
+
+    expect(result["urn:uuid:shared"]?.title).toBe("First Registry Version");
+  });
+});

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -284,6 +284,19 @@ describe("fetchRegistryLibraries", () => {
     await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow("503");
   });
 
+  it("throws when a subsequent page fetch fails", async () => {
+    const PAGE_2_URL = `${REGISTRY_URL}?offset=100`;
+    global.fetch = mockFetchByUrl({
+      [REGISTRY_URL]: makePagedFeed(
+        [{ id: "urn:uuid:p1", title: "P1", authDocUrl: "https://p1.example.com/auth" }],
+        { nextHref: PAGE_2_URL }
+      ),
+      [PAGE_2_URL]: { status: 503, statusText: "Service Unavailable" }
+    }) as unknown as typeof fetch;
+
+    await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow("503");
+  });
+
   it("skips and warns on entries whose computed slug is not URL-safe", async () => {
     const feed = makePagedFeed([
       { id: "valid-library",   title: "Valid",   authDocUrl: "https://v.example.com/auth" },

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -613,3 +613,102 @@ describe("getLibraries", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// fetch timeout
+// ---------------------------------------------------------------------------
+
+describe("fetch timeout", () => {
+  beforeEach(() => resetRegistryCaches());
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  /** Returns a fetch mock whose response promise never resolves but rejects on abort. */
+  function mockHangingFetch(): { mock: jest.Mock; capturedSignal: () => AbortSignal | undefined } {
+    let signal: AbortSignal | undefined;
+    const mock = jest.fn().mockImplementation((_url: string, init: RequestInit) => {
+      signal = init?.signal as AbortSignal | undefined;
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener("abort", () =>
+          reject(new DOMException("The operation was aborted.", "AbortError"))
+        );
+      });
+    });
+    return { mock, capturedSignal: () => signal };
+  }
+
+  it("aborts a hung page fetch after the configured timeout", async () => {
+    jest.useFakeTimers();
+    const { mock, capturedSignal } = mockHangingFetch();
+    global.fetch = mock as unknown as typeof fetch;
+
+    const crawlPromise = fetchRegistryLibraries(REGISTRY_URL, 10);
+    // Attach the rejection handler before advancing timers so the rejection
+    // is not unhandled at the point the abort fires.
+    const assertion = expect(crawlPromise).rejects.toThrow();
+
+    await jest.advanceTimersByTimeAsync(10_001);
+    await assertion;
+
+    expect(capturedSignal()?.aborted).toBe(true);
+  });
+
+  it("clears the timeout after a successful fetch (no timer leak)", async () => {
+    jest.useFakeTimers();
+    const feed = makePagedFeed([
+      { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth" }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+
+    await fetchRegistryLibraries(REGISTRY_URL, 10);
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("uses the timeout field from RegistryConfig", async () => {
+    jest.useFakeTimers();
+    jest.spyOn(Date, "now").mockReturnValue(1_000_000 * 1000);
+
+    const { mock, capturedSignal } = mockHangingFetch();
+    global.fetch = mock as unknown as typeof fetch;
+
+    const config = makeConfig({
+      registries: [makeRegistryConfig({ timeout: 5 })]
+    });
+
+    // getLibraries swallows the error and returns empty; we care about the signal.
+    const resultPromise = getLibraries(config);
+    await jest.advanceTimersByTimeAsync(5_001);
+    await resultPromise;
+
+    expect(capturedSignal()?.aborted).toBe(true);
+  });
+
+  it("passes an abort signal to each page fetch in a multi-page crawl", async () => {
+    const PAGE_2_URL = `${REGISTRY_URL}?offset=100`;
+    const signals: (AbortSignal | undefined)[] = [];
+
+    global.fetch = jest.fn().mockImplementation((url: string, init: RequestInit) => {
+      signals.push(init?.signal as AbortSignal | undefined);
+      const body =
+        url === REGISTRY_URL
+          ? makePagedFeed(
+              [{ id: "urn:uuid:p1", title: "P1", authDocUrl: "https://p1.example.com/auth" }],
+              { nextHref: PAGE_2_URL }
+            )
+          : makePagedFeed([
+              { id: "urn:uuid:p2", title: "P2", authDocUrl: "https://p2.example.com/auth" }
+            ]);
+      return Promise.resolve({ ok: true, status: 200, statusText: "OK", json: async () => body });
+    }) as unknown as typeof fetch;
+
+    await fetchRegistryLibraries(REGISTRY_URL);
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).toBeInstanceOf(AbortSignal);
+    expect(signals[1]).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -233,8 +233,8 @@ describe("fetchRegistryLibraries", () => {
     const result = await fetchRegistryLibraries(REGISTRY_URL);
 
     expect(result).toEqual({
-      "uuid-abc": { title: "Library A", authDocUrl: "https://a.example.com/auth" },
-      "uuid-def": { title: "Library B", authDocUrl: "https://b.example.com/auth" }
+      "urn:uuid:abc": { id: "urn:uuid:abc", title: "Library A", authDocUrl: "https://a.example.com/auth" },
+      "urn:uuid:def": { id: "urn:uuid:def", title: "Library B", authDocUrl: "https://b.example.com/auth" }
     });
   });
 
@@ -253,8 +253,8 @@ describe("fetchRegistryLibraries", () => {
     const result = await fetchRegistryLibraries(REGISTRY_URL);
 
     expect(Object.keys(result)).toHaveLength(2);
-    expect(result["uuid-p1"]).toBeDefined();
-    expect(result["uuid-p2"]).toBeDefined();
+    expect(result["urn:uuid:p1"]).toBeDefined();
+    expect(result["urn:uuid:p2"]).toBeDefined();
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
@@ -267,7 +267,7 @@ describe("fetchRegistryLibraries", () => {
 
     const result = await fetchRegistryLibraries(REGISTRY_URL);
 
-    expect(Object.keys(result)).toEqual(["uuid-abc"]);
+    expect(Object.keys(result)).toEqual(["urn:uuid:abc"]);
   });
 
   it("returns empty result for a feed with no catalogs", async () => {
@@ -297,10 +297,10 @@ describe("fetchRegistryLibraries", () => {
     await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow("503");
   });
 
-  it("skips and warns on entries whose computed slug is not URL-safe", async () => {
+  it("skips and warns on entries whose computed slug is not valid", async () => {
     const feed = makePagedFeed([
       { id: "valid-library",   title: "Valid",   authDocUrl: "https://v.example.com/auth" },
-      { id: "bad/slug/here",   title: "Bad Slug", authDocUrl: "https://b.example.com/auth" }
+      { id: "", title: "Empty Slug", authDocUrl: "https://b.example.com/auth" }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
@@ -355,7 +355,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
       makeConfig({ registries: [makeIncrementalConfig()] })
     );
 
-    expect(result["uuid-a"]).toBeDefined();
+    expect(result["urn:uuid:a"]).toBeDefined();
   });
 
   it("incremental crawl stops mid-page when an entry is old", async () => {
@@ -387,9 +387,9 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
     );
 
     // C is new and should be present; A (old) stops the crawl on the page.
-    expect(result["uuid-c"]).toBeDefined();
+    expect(result["urn:uuid:c"]).toBeDefined();
     // B was cached from the first fetch and not seen in incremental (not replaced).
-    expect(result["uuid-b"]).toBeDefined();
+    expect(result["urn:uuid:b"]).toBeDefined();
   });
 
   it("incremental that reaches end of feed replaces cache (deletions applied)", async () => {
@@ -421,8 +421,8 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
     // reachedEnd = true (no next link), so cache is replaced.
     // A triggered the stop (not accumulated), so both A and B are gone.
-    expect(result["uuid-a"]).toBeUndefined();
-    expect(result["uuid-b"]).toBeUndefined();
+    expect(result["urn:uuid:a"]).toBeUndefined();
+    expect(result["urn:uuid:b"]).toBeUndefined();
   });
 
   it("full crawl after fullRefreshInterval replaces cache", async () => {
@@ -448,8 +448,8 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
     const result = await getLibraries(makeConfig({ registries: [config] }));
 
-    expect(result["uuid-a"]).toBeDefined();
-    expect(result["uuid-b"]).toBeUndefined();
+    expect(result["urn:uuid:a"]).toBeDefined();
+    expect(result["urn:uuid:b"]).toBeUndefined();
   });
 
   it("second fetch within fullRefreshInterval uses incrementalUrl", async () => {
@@ -520,8 +520,8 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
     const result = await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
 
     // Both B (empty date) and C (new) should be collected.
-    expect(result["uuid-b"]).toBeDefined();
-    expect(result["uuid-c"]).toBeDefined();
+    expect(result["urn:uuid:b"]).toBeDefined();
+    expect(result["urn:uuid:c"]).toBeDefined();
   });
 
   it("retains cached state when registry fetch fails", async () => {
@@ -536,7 +536,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 
     const result = await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
 
-    expect(result["uuid-cached"]).toBeDefined();
+    expect(result["urn:uuid:cached"]).toBeDefined();
   });
 
   it("retains incrementalUrl in state after a failed fetch", async () => {
@@ -585,7 +585,7 @@ describe("getLibraries", () => {
 
     const result = await getLibraries(makeConfig({ registries: [makeRegistryConfig()] }));
 
-    expect(result["uuid-reg"]).toBeDefined();
+    expect(result["urn:uuid:reg"]).toBeDefined();
   });
 
   it("static libraries override registry libraries with the same key", async () => {
@@ -595,12 +595,12 @@ describe("getLibraries", () => {
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
     const config = makeConfig({
-      libraries: { "uuid-shared": { title: "Static Version", authDocUrl: "https://static.example.com/auth" } },
+      libraries: { "urn:uuid:shared": { title: "Static Version", authDocUrl: "https://static.example.com/auth" } },
       registries: [makeRegistryConfig()]
     });
 
     const result = await getLibraries(config);
-    expect(result["uuid-shared"]?.title).toBe("Static Version");
+    expect(result["urn:uuid:shared"]?.title).toBe("Static Version");
   });
 
   it("gives earlier registries precedence over later ones for the same key", async () => {
@@ -621,7 +621,7 @@ describe("getLibraries", () => {
     });
 
     const result = await getLibraries(config);
-    expect(result["uuid-shared"]?.title).toBe("First Registry");
+    expect(result["urn:uuid:shared"]?.title).toBe("First Registry");
   });
 
   it("does not re-fetch before min interval has elapsed", async () => {
@@ -679,7 +679,7 @@ describe("fetch timeout", () => {
     // is not unhandled at the point the abort fires.
     const assertion = expect(crawlPromise).rejects.toThrow();
 
-    await jest.advanceTimersByTimeAsync(10_001);
+    await (jest as any).advanceTimersByTimeAsync(10_001);
     await assertion;
 
     expect(capturedSignal()?.aborted).toBe(true);
@@ -710,7 +710,7 @@ describe("fetch timeout", () => {
 
     // getLibraries swallows the error and returns empty; we care about the signal.
     const resultPromise = getLibraries(config);
-    await jest.advanceTimersByTimeAsync(5_001);
+    await (jest as any).advanceTimersByTimeAsync(5_001);
     await resultPromise;
 
     expect(capturedSignal()?.aborted).toBe(true);

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -181,6 +181,7 @@ async function crawlRegistryFeed(
       }
 
       accumulated[slug] = {
+        id: catalog.metadata.id,
         title: catalog.metadata.title,
         authDocUrl: authDocLink.href
       };

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -11,18 +11,31 @@ import { computeSlug } from "utils/librarySlug";
 // Internal state types
 // ---------------------------------------------------------------------------
 
+/*
+ * All timestamps are Unix seconds. lastSuccessfulFetch is updated on any successful
+ * crawl; lastFullFetch only when reachedEnd is true (complete feed traversal).
+ * incrementalUrl === null within a cached entry means the registry does not advertise
+ * an order=modified facet (distinct from a registry absent from the map, which has
+ * never been fetched at all).
+ */
 interface RegistryState {
   libraries: LibrariesConfig;
-  lastSuccessfulFetch: number | null; // Unix seconds — updated on every success
-  lastAttemptedFetch:  number | null; // Unix seconds
-  lastFullFetch:       number | null; // Unix seconds — updated when reachedEnd is true
-  incrementalUrl:      string | null; // order=modified URL from facets; null = not supported
+  lastSuccessfulFetch: number | null;
+  lastAttemptedFetch: number | null;
+  lastFullFetch: number | null;
+  incrementalUrl: string | null;
 }
 
+/*
+ * reachedEnd: true when the final page fetched had no rel="next" link, meaning the
+ * complete current feed state was observed.
+ * incrementalUrl: the order=modified facet URL read from the first page, or null if
+ * the feed does not advertise one.
+ */
 interface CrawlResult {
   libraries: LibrariesConfig;
-  reachedEnd: boolean;           // true ↔ no rel="next" on the last page fetched
-  incrementalUrl: string | null; // order=modified URL from first-page facets, or null
+  reachedEnd: boolean;
+  incrementalUrl: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -189,8 +202,8 @@ export function shouldRefresh(
 }
 
 /**
- * Fetches the library list from a registry URL (full crawl, no early stop).
- * Retained for backward compatibility and direct use in tests.
+ * Performs a full crawl of the registry feed at `url` and returns all discovered
+ * libraries. Does not read or write the module-level cache.
  */
 export async function fetchRegistryLibraries(
   url: string

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -3,7 +3,8 @@ import { OPDS2 } from "interfaces";
 import {
   DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL,
   DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL,
-  DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL
+  DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL,
+  DEFAULT_REGISTRY_FETCH_TIMEOUT
 } from "constants/registry";
 import { computeSlug } from "utils/librarySlug";
 
@@ -104,7 +105,8 @@ function findIncrementalUrl(feed: OPDS2.LibraryRegistryFeed): string | null {
  */
 async function crawlRegistryFeed(
   startUrl: string,
-  stopBefore: number | null
+  stopBefore: number | null,
+  timeoutMs: number
 ): Promise<CrawlResult> {
   const accumulated: LibrariesConfig = {};
   let nextUrl: string | null = startUrl;
@@ -114,7 +116,14 @@ async function crawlRegistryFeed(
 
   while (nextUrl) {
     const currentUrl = nextUrl;
-    const response = await fetch(currentUrl);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    let response: Response;
+    try {
+      response = await fetch(currentUrl, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeoutId);
+    }
     if (!response.ok) {
       if (response.status === 404) {
         console.warn(`Registry feed not found at: ${currentUrl}`);
@@ -206,9 +215,10 @@ export function shouldRefresh(
  * libraries. Does not read or write the module-level cache.
  */
 export async function fetchRegistryLibraries(
-  url: string
+  url: string,
+  timeoutSeconds = DEFAULT_REGISTRY_FETCH_TIMEOUT
 ): Promise<LibrariesConfig> {
-  const result = await crawlRegistryFeed(url, null);
+  const result = await crawlRegistryFeed(url, null, timeoutSeconds * 1000);
   return result.libraries;
 }
 
@@ -238,8 +248,9 @@ async function refreshRegistry(
 
   const canIncremental = !needsFullCrawl && existing.incrementalUrl != null;
 
-  const startUrl = canIncremental ? (existing.incrementalUrl ?? registryConfig.url) : registryConfig.url;
+  const startUrl = canIncremental ? (existing.incrementalUrl as string) : registryConfig.url;
   const stopBefore = canIncremental ? existing.lastSuccessfulFetch : null;
+  const timeoutMs = (registryConfig.timeout ?? DEFAULT_REGISTRY_FETCH_TIMEOUT) * 1000;
   const attemptTime = nowSeconds;
 
   registryCaches.set(registryConfig.url, {
@@ -248,7 +259,7 @@ async function refreshRegistry(
   });
 
   try {
-    const result = await crawlRegistryFeed(startUrl, stopBefore);
+    const result = await crawlRegistryFeed(startUrl, stopBefore, timeoutMs);
 
     if (isFirstFetch && result.incrementalUrl == null) {
       console.warn(

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -1,0 +1,162 @@
+import type { AppConfig, LibrariesConfig, RegistryConfig } from "interfaces";
+import { OPDS2 } from "interfaces";
+import {
+  DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL,
+  DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL
+} from "constants/registry";
+import { computeSlug } from "utils/librarySlug";
+
+interface RegistryState {
+  libraries: LibrariesConfig;
+  lastSuccessfulFetch: number | null; // Unix timestamp in seconds
+  lastAttemptedFetch: number | null; // Unix timestamp in seconds
+}
+
+/*
+ * In-memory cache mapping registry URL to its last-known state.
+ * Persists across API requests within a single server instance.
+ */
+const registryCaches = new Map<string, RegistryState>();
+
+/**
+ * Returns true if a refresh attempt should be made for the given registry.
+ *
+ * A refresh is triggered when the data is stale (time since last success
+ * exceeds maxInterval, or no successful fetch has occurred), provided the
+ * minimum interval since the last attempt has elapsed to avoid hammering
+ * failing registries.
+ */
+export function shouldRefresh(
+  state: RegistryState | undefined,
+  config: RegistryConfig,
+  nowSeconds: number
+): boolean {
+  const minInterval =
+    config.refreshMinInterval ?? DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL;
+  const maxInterval =
+    config.refreshMaxInterval ?? DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL;
+
+  // Respect min interval between attempts regardless of staleness.
+  if (state?.lastAttemptedFetch != null) {
+    if (nowSeconds - state.lastAttemptedFetch < minInterval) return false;
+  }
+
+  // Refresh if we've never succeeded or the data has grown stale.
+  if (!state || state.lastSuccessfulFetch == null) return true;
+  return nowSeconds - state.lastSuccessfulFetch >= maxInterval;
+}
+
+/**
+ * Fetches the library list from a registry URL and converts it to
+ * the internal LibrariesConfig format. Throws on network or parse errors.
+ */
+export async function fetchRegistryLibraries(
+  url: string
+): Promise<LibrariesConfig> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Registry fetch failed for ${url}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const feed = (await response.json()) as OPDS2.LibraryRegistryFeed;
+  if (!feed.catalogs) {
+    throw new Error(`Registry feed missing 'catalogs' field at: ${url}`);
+  }
+
+  return feed.catalogs.reduce<LibrariesConfig>((record, catalog) => {
+    const authDocLink = catalog.links.find(
+      link => link.type === OPDS2.AuthDocumentMediaType
+    );
+    if (!authDocLink) {
+      console.warn(
+        `Skipping library missing auth document link: ${catalog.metadata.title}`
+      );
+      return record;
+    }
+    const slug = computeSlug(catalog);
+    return {
+      ...record,
+      [slug]: { title: catalog.metadata.title, authDocUrl: authDocLink.href }
+    };
+  }, {});
+}
+
+/**
+ * Returns the current merged library list, refreshing from each configured
+ * registry if the data is stale. On fetch failure, retains the most recent
+ * successful state rather than falling back to build-time config.
+ *
+ * Merge precedence (highest to lowest):
+ *   1. Static libraries from config (object `libraries`)
+ *   2. First registry in `registries` array
+ *   3. Subsequent registries (each has lower precedence than earlier ones)
+ */
+export async function getLibraries(
+  config: AppConfig
+): Promise<LibrariesConfig> {
+  const { registries = [], libraries: staticLibraries } = config;
+
+  // No runtime registries configured — return the build-time static libraries.
+  if (registries.length === 0) {
+    return staticLibraries;
+  }
+
+  const nowSeconds = Date.now() / 1000;
+
+  for (const registryConfig of registries) {
+    const state = registryCaches.get(registryConfig.url);
+    if (!shouldRefresh(state, registryConfig, nowSeconds)) continue;
+
+    const attemptTime = nowSeconds;
+    const existing: RegistryState = state ?? {
+      libraries: {},
+      lastSuccessfulFetch: null,
+      lastAttemptedFetch: null
+    };
+
+    // Record the attempt before fetching so a slow/failing request still
+    // updates the timestamp and prevents tight retry loops.
+    registryCaches.set(registryConfig.url, {
+      ...existing,
+      lastAttemptedFetch: attemptTime
+    });
+
+    try {
+      const fetched = await fetchRegistryLibraries(registryConfig.url);
+      registryCaches.set(registryConfig.url, {
+        libraries: fetched,
+        lastSuccessfulFetch: attemptTime,
+        lastAttemptedFetch: attemptTime
+      });
+    } catch (err) {
+      console.error(
+        `Failed to refresh registry ${registryConfig.url}:`,
+        err instanceof Error ? err.message : err
+      );
+      // Retain the existing cached state; lastAttemptedFetch was already updated.
+    }
+  }
+
+  // Build merged registry libraries: earlier registries override later ones.
+  // Iterate in reverse so each subsequent spread raises precedence.
+  let mergedRegistryLibraries: LibrariesConfig = {};
+  for (let i = registries.length - 1; i >= 0; i--) {
+    const state = registryCaches.get(registries[i].url);
+    if (state?.libraries) {
+      mergedRegistryLibraries = {
+        ...mergedRegistryLibraries,
+        ...state.libraries
+      };
+    }
+  }
+
+  // Static libraries override all registry libraries.
+  return { ...mergedRegistryLibraries, ...staticLibraries };
+}
+
+/** Clears all in-memory registry caches. Intended for use in tests only. */
+export function resetRegistryCaches(): void {
+  registryCaches.clear();
+}

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -212,9 +212,81 @@ export async function fetchRegistryLibraries(
   return result.libraries;
 }
 
+/*
+ * Refreshes a single registry cache entry if the data is stale. Sets
+ * lastAttemptedFetch synchronously (before any await) so that subsequent
+ * requests arriving during the async crawl see the in-progress attempt and
+ * skip the duplicate. Errors are logged and swallowed; the existing cached
+ * state is retained.
+ */
+async function refreshRegistry(
+  registryConfig: RegistryConfig,
+  nowSeconds: number
+): Promise<void> {
+  const isFirstFetch = !registryCaches.has(registryConfig.url);
+  const existing = registryCaches.get(registryConfig.url) ?? emptyState;
+
+  if (!shouldRefresh(existing, registryConfig, nowSeconds)) return;
+
+  const fullRefreshInterval =
+    registryConfig.fullRefreshInterval ?? DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL;
+
+  const needsFullCrawl =
+    isFirstFetch ||
+    existing.lastFullFetch == null ||
+    nowSeconds - existing.lastFullFetch >= fullRefreshInterval;
+
+  const canIncremental = !needsFullCrawl && existing.incrementalUrl != null;
+
+  const startUrl = canIncremental ? (existing.incrementalUrl ?? registryConfig.url) : registryConfig.url;
+  const stopBefore = canIncremental ? existing.lastSuccessfulFetch : null;
+  const attemptTime = nowSeconds;
+
+  registryCaches.set(registryConfig.url, {
+    ...existing,
+    lastAttemptedFetch: attemptTime
+  });
+
+  try {
+    const result = await crawlRegistryFeed(startUrl, stopBefore);
+
+    if (isFirstFetch && result.incrementalUrl == null) {
+      console.warn(
+        `Registry at ${registryConfig.url} has no order=modified facet; ` +
+          `incremental fetching is not supported. Full crawls will run every refresh.`
+      );
+    }
+
+    /*
+     * reachedEnd = true: complete view observed (full crawl or incremental
+     * that reached the last page). Replace the cache entirely so deleted
+     * libraries are removed.
+     *
+     * reachedEnd = false: partial view. Overlay new/updated entries onto the
+     * existing cache; unvisited entries are preserved.
+     */
+    const mergedLibraries = result.reachedEnd
+      ? result.libraries
+      : { ...existing.libraries, ...result.libraries };
+
+    registryCaches.set(registryConfig.url, {
+      libraries:           mergedLibraries,
+      lastSuccessfulFetch: attemptTime,
+      lastAttemptedFetch:  attemptTime,
+      lastFullFetch:       result.reachedEnd ? attemptTime : existing.lastFullFetch,
+      incrementalUrl:      result.incrementalUrl ?? existing.incrementalUrl
+    });
+  } catch (err) {
+    console.error(
+      `Failed to refresh registry ${registryConfig.url}:`,
+      err instanceof Error ? err.message : err
+    );
+  }
+}
+
 /**
- * Returns the current merged library list, refreshing from each configured
- * registry if the data is stale. Incremental refreshes (stopping at entries
+ * Returns the current merged library list, refreshing all configured registries
+ * in parallel if their data is stale. Incremental refreshes (stopping at entries
  * older than lastSuccessfulFetch) are used when the feed advertises an
  * order=modified facet. Full crawls replace the cache; partial crawls merge
  * new entries into it. On failure, the existing cached state is retained.
@@ -231,67 +303,9 @@ export async function getLibraries(config: AppConfig): Promise<LibrariesConfig> 
 
   const nowSeconds = Date.now() / 1000;
 
-  for (const registryConfig of registries) {
-    const isFirstFetch = !registryCaches.has(registryConfig.url);
-    const existing = registryCaches.get(registryConfig.url) ?? emptyState;
-
-    if (!shouldRefresh(existing, registryConfig, nowSeconds)) continue;
-
-    const fullRefreshInterval =
-      registryConfig.fullRefreshInterval ?? DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL;
-
-    const needsFullCrawl =
-      isFirstFetch ||
-      existing.lastFullFetch == null ||
-      nowSeconds - existing.lastFullFetch >= fullRefreshInterval;
-
-    const canIncremental = !needsFullCrawl && existing.incrementalUrl != null;
-
-    const startUrl = canIncremental ? (existing.incrementalUrl ?? registryConfig.url) : registryConfig.url;
-    const stopBefore = canIncremental ? existing.lastSuccessfulFetch : null;
-    const attemptTime = nowSeconds;
-
-    registryCaches.set(registryConfig.url, {
-      ...existing,
-      lastAttemptedFetch: attemptTime
-    });
-
-    try {
-      const result = await crawlRegistryFeed(startUrl, stopBefore);
-
-      if (isFirstFetch && result.incrementalUrl == null) {
-        console.warn(
-          `Registry at ${registryConfig.url} has no order=modified facet; ` +
-            `incremental fetching is not supported. Full crawls will run every refresh.`
-        );
-      }
-
-      /*
-       * reachedEnd = true: complete view observed (full crawl or incremental
-       * that reached the last page). Replace the cache entirely so deleted
-       * libraries are removed.
-       *
-       * reachedEnd = false: partial view. Overlay new/updated entries onto the
-       * existing cache; unvisited entries are preserved.
-       */
-      const mergedLibraries = result.reachedEnd
-        ? result.libraries
-        : { ...existing.libraries, ...result.libraries };
-
-      registryCaches.set(registryConfig.url, {
-        libraries:           mergedLibraries,
-        lastSuccessfulFetch: attemptTime,
-        lastAttemptedFetch:  attemptTime,
-        lastFullFetch:       result.reachedEnd ? attemptTime : existing.lastFullFetch,
-        incrementalUrl:      result.incrementalUrl ?? existing.incrementalUrl
-      });
-    } catch (err) {
-      console.error(
-        `Failed to refresh registry ${registryConfig.url}:`,
-        err instanceof Error ? err.message : err
-      );
-    }
-  }
+  await Promise.allSettled(
+    registries.map(registryConfig => refreshRegistry(registryConfig, nowSeconds))
+  );
 
   // Merge: earlier registries override later ones; static libraries override all.
   let mergedRegistryLibraries: LibrariesConfig = {};

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -77,12 +77,12 @@ function findIncrementalUrl(feed: OPDS2.LibraryRegistryFeed): string | null {
  * Crawls the paginated OPDS2 feed starting at `startUrl`, collecting library
  * entries.
  *
- * Full crawl (stopBeforeSeconds === null): follows all rel="next" links.
+ * Full crawl (stopBefore === null): follows all rel="next" links.
  *
- * Incremental crawl (stopBeforeSeconds is a Unix timestamp in seconds): stops
- * as soon as an entry's metadata.updated parses to a value at or before that
- * timestamp, because the feed is sorted newest-first. Entries with
- * unparseable updated values are always collected.
+ * Incremental crawl (stopBefore is a Unix timestamp in seconds): stops as soon
+ * as an entry's metadata.updated parses to a value at or before that timestamp,
+ * because the feed is sorted newest-first. Entries with unparseable updated
+ * values are always collected.
  *
  * reachedEnd is true when no rel="next" link was present on the final page
  * fetched, meaning the complete current feed state was observed. This holds
@@ -91,14 +91,16 @@ function findIncrementalUrl(feed: OPDS2.LibraryRegistryFeed): string | null {
  */
 async function crawlRegistryFeed(
   startUrl: string,
-  stopBeforeSeconds: number | null
+  stopBefore: number | null
 ): Promise<CrawlResult> {
   const accumulated: LibrariesConfig = {};
-  let currentUrl = startUrl;
+  let nextUrl: string | null = startUrl;
+  let isFirstPage = true;
   let incrementalUrl: string | null = null;
+  let effectiveStop = stopBefore;
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
+  while (nextUrl) {
+    const currentUrl = nextUrl;
     const response = await fetch(currentUrl);
     if (!response.ok) {
       if (response.status === 404) {
@@ -112,34 +114,27 @@ async function crawlRegistryFeed(
     const feed = (await response.json()) as OPDS2.LibraryRegistryFeed;
 
     // Read facets from the first page only.
-    if (currentUrl === startUrl) {
+    if (isFirstPage) {
+      isFirstPage = false;
       incrementalUrl = findIncrementalUrl(feed);
       // Defensive: if called in incremental mode but the facet is gone, treat as full.
-      if (incrementalUrl == null && stopBeforeSeconds !== null) {
-        stopBeforeSeconds = null;
-      }
+      if (incrementalUrl == null) effectiveStop = null;
     }
 
-    const nextLink = feed.links?.find(l => l.rel === OPDS2.PaginationNextRelation);
+    nextUrl = feed.links?.find(l => l.rel === OPDS2.PaginationNextRelation)?.href ?? null;
 
-    if (!feed.catalogs || feed.catalogs.length === 0) {
-      if (!nextLink) return { libraries: accumulated, reachedEnd: true, incrementalUrl };
-      currentUrl = nextLink.href;
-      continue;
-    }
-
-    for (const catalog of feed.catalogs) {
+    for (const catalog of feed.catalogs ?? []) {
       const updatedSeconds = Date.parse(catalog.metadata.updated) / 1000;
 
       if (
-        stopBeforeSeconds !== null &&
+        effectiveStop !== null &&
         Number.isFinite(updatedSeconds) &&
-        updatedSeconds <= stopBeforeSeconds
+        updatedSeconds <= effectiveStop
       ) {
         // Stop early. If this is already the last page we still have full coverage.
         return {
           libraries: accumulated,
-          reachedEnd: !nextLink,
+          reachedEnd: !nextUrl,
           incrementalUrl
         };
       }
@@ -160,10 +155,9 @@ async function crawlRegistryFeed(
         authDocUrl: authDocLink.href
       };
     }
-
-    if (!nextLink) return { libraries: accumulated, reachedEnd: true, incrementalUrl };
-    currentUrl = nextLink.href;
   }
+
+  return { libraries: accumulated, reachedEnd: true, incrementalUrl };
 }
 
 // ---------------------------------------------------------------------------
@@ -240,7 +234,7 @@ export async function getLibraries(config: AppConfig): Promise<LibrariesConfig> 
 
     const canIncremental = !needsFullCrawl && existing.incrementalUrl != null;
 
-    const startUrl   = canIncremental ? existing.incrementalUrl! : registryConfig.url;
+    const startUrl = canIncremental ? (existing.incrementalUrl ?? registryConfig.url) : registryConfig.url;
     const stopBefore = canIncremental ? existing.lastSuccessfulFetch : null;
     const attemptTime = nowSeconds;
 

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL,
   DEFAULT_REGISTRY_FETCH_TIMEOUT
 } from "constants/registry";
-import { computeSlug } from "utils/librarySlug";
+import { computeSlug, validateSlug } from "utils/librarySlug";
 
 // ---------------------------------------------------------------------------
 // Internal state types
@@ -172,6 +172,14 @@ async function crawlRegistryFeed(
       }
 
       const slug = computeSlug(catalog);
+      if (!validateSlug(slug)) {
+        console.warn(
+          `Skipping library with invalid slug "${slug}" ` +
+            `(id: ${catalog.metadata.id}): ${catalog.metadata.title}`
+        );
+        continue;
+      }
+
       accumulated[slug] = {
         title: catalog.metadata.title,
         authDocUrl: authDocLink.href

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -2,29 +2,179 @@ import type { AppConfig, LibrariesConfig, RegistryConfig } from "interfaces";
 import { OPDS2 } from "interfaces";
 import {
   DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL,
-  DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL
+  DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL,
+  DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL
 } from "constants/registry";
 import { computeSlug } from "utils/librarySlug";
 
+// ---------------------------------------------------------------------------
+// Internal state types
+// ---------------------------------------------------------------------------
+
 interface RegistryState {
   libraries: LibrariesConfig;
-  lastSuccessfulFetch: number | null; // Unix timestamp in seconds
-  lastAttemptedFetch: number | null; // Unix timestamp in seconds
+  lastSuccessfulFetch: number | null; // Unix seconds — updated on every success
+  lastAttemptedFetch:  number | null; // Unix seconds
+  lastFullFetch:       number | null; // Unix seconds — updated when reachedEnd is true
+  incrementalUrl:      string | null; // order=modified URL from facets; null = not supported
 }
 
+interface CrawlResult {
+  libraries: LibrariesConfig;
+  reachedEnd: boolean;           // true ↔ no rel="next" on the last page fetched
+  incrementalUrl: string | null; // order=modified URL from first-page facets, or null
+}
+
+// ---------------------------------------------------------------------------
+// Module-level cache
+// ---------------------------------------------------------------------------
+
 /*
- * In-memory cache mapping registry URL to its last-known state.
- * Persists across API requests within a single server instance.
+ * In-memory cache keyed by registry URL. Persists across API requests within
+ * a single server instance. A registry absent from this map has never been
+ * fetched (distinct from one with incrementalUrl === null, which means it was
+ * fetched but does not advertise an order=modified facet).
  */
 const registryCaches = new Map<string, RegistryState>();
 
+const emptyState: RegistryState = {
+  libraries: {},
+  lastSuccessfulFetch: null,
+  lastAttemptedFetch:  null,
+  lastFullFetch:       null,
+  incrementalUrl:      null
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the href of the `order=modified` sort facet from the first page
+ * of a registry feed. Returns null if the feed does not advertise that facet.
+ */
+function findIncrementalUrl(feed: OPDS2.LibraryRegistryFeed): string | null {
+  const sortGroup = feed.facets?.find(
+    f => f.metadata["@type"] === OPDS2.SortFacetType
+  );
+  if (!sortGroup) return null;
+
+  const link = sortGroup.links.find(l => {
+    try {
+      return new URL(l.href).searchParams.get("order") === "modified";
+    } catch {
+      return false;
+    }
+  });
+  return link?.href ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Core crawl function
+// ---------------------------------------------------------------------------
+
+/**
+ * Crawls the paginated OPDS2 feed starting at `startUrl`, collecting library
+ * entries.
+ *
+ * Full crawl (stopBeforeSeconds === null): follows all rel="next" links.
+ *
+ * Incremental crawl (stopBeforeSeconds is a Unix timestamp in seconds): stops
+ * as soon as an entry's metadata.updated parses to a value at or before that
+ * timestamp, because the feed is sorted newest-first. Entries with
+ * unparseable updated values are always collected.
+ *
+ * reachedEnd is true when no rel="next" link was present on the final page
+ * fetched, meaning the complete current feed state was observed. This holds
+ * even when stopping early in incremental mode if the stop occurred on the
+ * last page.
+ */
+async function crawlRegistryFeed(
+  startUrl: string,
+  stopBeforeSeconds: number | null
+): Promise<CrawlResult> {
+  const accumulated: LibrariesConfig = {};
+  let currentUrl = startUrl;
+  let incrementalUrl: string | null = null;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const response = await fetch(currentUrl);
+    if (!response.ok) {
+      if (response.status === 404) {
+        console.warn(`Registry feed not found at: ${currentUrl}`);
+      }
+      throw new Error(
+        `Registry fetch failed for ${currentUrl}: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const feed = (await response.json()) as OPDS2.LibraryRegistryFeed;
+
+    // Read facets from the first page only.
+    if (currentUrl === startUrl) {
+      incrementalUrl = findIncrementalUrl(feed);
+      // Defensive: if called in incremental mode but the facet is gone, treat as full.
+      if (incrementalUrl == null && stopBeforeSeconds !== null) {
+        stopBeforeSeconds = null;
+      }
+    }
+
+    const nextLink = feed.links?.find(l => l.rel === OPDS2.PaginationNextRelation);
+
+    if (!feed.catalogs || feed.catalogs.length === 0) {
+      if (!nextLink) return { libraries: accumulated, reachedEnd: true, incrementalUrl };
+      currentUrl = nextLink.href;
+      continue;
+    }
+
+    for (const catalog of feed.catalogs) {
+      const updatedSeconds = Date.parse(catalog.metadata.updated) / 1000;
+
+      if (
+        stopBeforeSeconds !== null &&
+        Number.isFinite(updatedSeconds) &&
+        updatedSeconds <= stopBeforeSeconds
+      ) {
+        // Stop early. If this is already the last page we still have full coverage.
+        return {
+          libraries: accumulated,
+          reachedEnd: !nextLink,
+          incrementalUrl
+        };
+      }
+
+      const authDocLink = catalog.links.find(
+        l => l.type === OPDS2.AuthDocumentMediaType
+      );
+      if (!authDocLink) {
+        console.warn(
+          `Skipping library missing auth document link: ${catalog.metadata.title}`
+        );
+        continue;
+      }
+
+      const slug = computeSlug(catalog);
+      accumulated[slug] = {
+        title: catalog.metadata.title,
+        authDocUrl: authDocLink.href
+      };
+    }
+
+    if (!nextLink) return { libraries: accumulated, reachedEnd: true, incrementalUrl };
+    currentUrl = nextLink.href;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 /**
  * Returns true if a refresh attempt should be made for the given registry.
- *
- * A refresh is triggered when the data is stale (time since last success
- * exceeds maxInterval, or no successful fetch has occurred), provided the
- * minimum interval since the last attempt has elapsed to avoid hammering
- * failing registries.
+ * A refresh is needed when the data is stale (beyond maxInterval since last
+ * success, or no prior success), provided the minimum retry interval since the
+ * last attempt has elapsed to avoid hammering failing endpoints.
  */
 export function shouldRefresh(
   state: RegistryState | undefined,
@@ -36,123 +186,115 @@ export function shouldRefresh(
   const maxInterval =
     config.refreshMaxInterval ?? DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL;
 
-  // Respect min interval between attempts regardless of staleness.
   if (state?.lastAttemptedFetch != null) {
     if (nowSeconds - state.lastAttemptedFetch < minInterval) return false;
   }
 
-  // Refresh if we've never succeeded or the data has grown stale.
   if (!state || state.lastSuccessfulFetch == null) return true;
   return nowSeconds - state.lastSuccessfulFetch >= maxInterval;
 }
 
 /**
- * Fetches the library list from a registry URL and converts it to
- * the internal LibrariesConfig format. Throws on network or parse errors.
+ * Fetches the library list from a registry URL (full crawl, no early stop).
+ * Retained for backward compatibility and direct use in tests.
  */
 export async function fetchRegistryLibraries(
   url: string
 ): Promise<LibrariesConfig> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(
-      `Registry fetch failed for ${url}: ${response.status} ${response.statusText}`
-    );
-  }
-
-  const feed = (await response.json()) as OPDS2.LibraryRegistryFeed;
-  if (!feed.catalogs) {
-    throw new Error(`Registry feed missing 'catalogs' field at: ${url}`);
-  }
-
-  return feed.catalogs.reduce<LibrariesConfig>((record, catalog) => {
-    const authDocLink = catalog.links.find(
-      link => link.type === OPDS2.AuthDocumentMediaType
-    );
-    if (!authDocLink) {
-      console.warn(
-        `Skipping library missing auth document link: ${catalog.metadata.title}`
-      );
-      return record;
-    }
-    const slug = computeSlug(catalog);
-    return {
-      ...record,
-      [slug]: { title: catalog.metadata.title, authDocUrl: authDocLink.href }
-    };
-  }, {});
+  const result = await crawlRegistryFeed(url, null);
+  return result.libraries;
 }
 
 /**
  * Returns the current merged library list, refreshing from each configured
- * registry if the data is stale. On fetch failure, retains the most recent
- * successful state rather than falling back to build-time config.
+ * registry if the data is stale. Incremental refreshes (stopping at entries
+ * older than lastSuccessfulFetch) are used when the feed advertises an
+ * order=modified facet. Full crawls replace the cache; partial crawls merge
+ * new entries into it. On failure, the existing cached state is retained.
  *
  * Merge precedence (highest to lowest):
- *   1. Static libraries from config (object `libraries`)
- *   2. First registry in `registries` array
- *   3. Subsequent registries (each has lower precedence than earlier ones)
+ *   1. Static libraries from config
+ *   2. First registry in registries array
+ *   3. Subsequent registries
  */
-export async function getLibraries(
-  config: AppConfig
-): Promise<LibrariesConfig> {
+export async function getLibraries(config: AppConfig): Promise<LibrariesConfig> {
   const { registries = [], libraries: staticLibraries } = config;
 
-  // No runtime registries configured — return the build-time static libraries.
-  if (registries.length === 0) {
-    return staticLibraries;
-  }
+  if (registries.length === 0) return staticLibraries;
 
   const nowSeconds = Date.now() / 1000;
 
   for (const registryConfig of registries) {
-    const state = registryCaches.get(registryConfig.url);
-    if (!shouldRefresh(state, registryConfig, nowSeconds)) continue;
+    const isFirstFetch = !registryCaches.has(registryConfig.url);
+    const existing = registryCaches.get(registryConfig.url) ?? emptyState;
 
+    if (!shouldRefresh(existing, registryConfig, nowSeconds)) continue;
+
+    const fullRefreshInterval =
+      registryConfig.fullRefreshInterval ?? DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL;
+
+    const needsFullCrawl =
+      isFirstFetch ||
+      existing.lastFullFetch == null ||
+      nowSeconds - existing.lastFullFetch >= fullRefreshInterval;
+
+    const canIncremental = !needsFullCrawl && existing.incrementalUrl != null;
+
+    const startUrl   = canIncremental ? existing.incrementalUrl! : registryConfig.url;
+    const stopBefore = canIncremental ? existing.lastSuccessfulFetch : null;
     const attemptTime = nowSeconds;
-    const existing: RegistryState = state ?? {
-      libraries: {},
-      lastSuccessfulFetch: null,
-      lastAttemptedFetch: null
-    };
 
-    // Record the attempt before fetching so a slow/failing request still
-    // updates the timestamp and prevents tight retry loops.
     registryCaches.set(registryConfig.url, {
       ...existing,
       lastAttemptedFetch: attemptTime
     });
 
     try {
-      const fetched = await fetchRegistryLibraries(registryConfig.url);
+      const result = await crawlRegistryFeed(startUrl, stopBefore);
+
+      if (isFirstFetch && result.incrementalUrl == null) {
+        console.warn(
+          `Registry at ${registryConfig.url} has no order=modified facet; ` +
+            `incremental fetching is not supported. Full crawls will run every refresh.`
+        );
+      }
+
+      /*
+       * reachedEnd = true: complete view observed (full crawl or incremental
+       * that reached the last page). Replace the cache entirely so deleted
+       * libraries are removed.
+       *
+       * reachedEnd = false: partial view. Overlay new/updated entries onto the
+       * existing cache; unvisited entries are preserved.
+       */
+      const mergedLibraries = result.reachedEnd
+        ? result.libraries
+        : { ...existing.libraries, ...result.libraries };
+
       registryCaches.set(registryConfig.url, {
-        libraries: fetched,
+        libraries:           mergedLibraries,
         lastSuccessfulFetch: attemptTime,
-        lastAttemptedFetch: attemptTime
+        lastAttemptedFetch:  attemptTime,
+        lastFullFetch:       result.reachedEnd ? attemptTime : existing.lastFullFetch,
+        incrementalUrl:      result.incrementalUrl ?? existing.incrementalUrl
       });
     } catch (err) {
       console.error(
         `Failed to refresh registry ${registryConfig.url}:`,
         err instanceof Error ? err.message : err
       );
-      // Retain the existing cached state; lastAttemptedFetch was already updated.
     }
   }
 
-  // Build merged registry libraries: earlier registries override later ones.
-  // Iterate in reverse so each subsequent spread raises precedence.
+  // Merge: earlier registries override later ones; static libraries override all.
   let mergedRegistryLibraries: LibrariesConfig = {};
   for (let i = registries.length - 1; i >= 0; i--) {
     const state = registryCaches.get(registries[i].url);
     if (state?.libraries) {
-      mergedRegistryLibraries = {
-        ...mergedRegistryLibraries,
-        ...state.libraries
-      };
+      mergedRegistryLibraries = { ...mergedRegistryLibraries, ...state.libraries };
     }
   }
 
-  // Static libraries override all registry libraries.
   return { ...mergedRegistryLibraries, ...staticLibraries };
 }
 

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -54,9 +54,9 @@ const registryCaches = new Map<string, RegistryState>();
 const emptyState: RegistryState = {
   libraries: {},
   lastSuccessfulFetch: null,
-  lastAttemptedFetch:  null,
-  lastFullFetch:       null,
-  incrementalUrl:      null
+  lastAttemptedFetch: null,
+  lastFullFetch: null,
+  incrementalUrl: null
 };
 
 // ---------------------------------------------------------------------------
@@ -143,7 +143,9 @@ async function crawlRegistryFeed(
       if (incrementalUrl == null) effectiveStop = null;
     }
 
-    nextUrl = feed.links?.find(l => l.rel === OPDS2.PaginationNextRelation)?.href ?? null;
+    nextUrl =
+      feed.links?.find(l => l.rel === OPDS2.PaginationNextRelation)?.href ??
+      null;
 
     for (const catalog of feed.catalogs ?? []) {
       const updatedSeconds = Date.parse(catalog.metadata.updated) / 1000;
@@ -248,7 +250,8 @@ async function refreshRegistry(
   if (!shouldRefresh(existing, registryConfig, nowSeconds)) return;
 
   const fullRefreshInterval =
-    registryConfig.fullRefreshInterval ?? DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL;
+    registryConfig.fullRefreshInterval ??
+    DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL;
 
   const needsFullCrawl =
     isFirstFetch ||
@@ -257,9 +260,12 @@ async function refreshRegistry(
 
   const canIncremental = !needsFullCrawl && existing.incrementalUrl != null;
 
-  const startUrl = canIncremental ? (existing.incrementalUrl as string) : registryConfig.url;
+  const startUrl = canIncremental
+    ? (existing.incrementalUrl as string)
+    : registryConfig.url;
   const stopBefore = canIncremental ? existing.lastSuccessfulFetch : null;
-  const timeoutMs = (registryConfig.timeout ?? DEFAULT_REGISTRY_FETCH_TIMEOUT) * 1000;
+  const timeoutMs =
+    (registryConfig.timeout ?? DEFAULT_REGISTRY_FETCH_TIMEOUT) * 1000;
   const attemptTime = nowSeconds;
 
   registryCaches.set(registryConfig.url, {
@@ -290,11 +296,11 @@ async function refreshRegistry(
       : { ...existing.libraries, ...result.libraries };
 
     registryCaches.set(registryConfig.url, {
-      libraries:           mergedLibraries,
+      libraries: mergedLibraries,
       lastSuccessfulFetch: attemptTime,
-      lastAttemptedFetch:  attemptTime,
-      lastFullFetch:       result.reachedEnd ? attemptTime : existing.lastFullFetch,
-      incrementalUrl:      result.incrementalUrl ?? existing.incrementalUrl
+      lastAttemptedFetch: attemptTime,
+      lastFullFetch: result.reachedEnd ? attemptTime : existing.lastFullFetch,
+      incrementalUrl: result.incrementalUrl ?? existing.incrementalUrl
     });
   } catch (err) {
     console.error(
@@ -316,7 +322,9 @@ async function refreshRegistry(
  *   2. First registry in registries array
  *   3. Subsequent registries
  */
-export async function getLibraries(config: AppConfig): Promise<LibrariesConfig> {
+export async function getLibraries(
+  config: AppConfig
+): Promise<LibrariesConfig> {
   const { registries = [], libraries: staticLibraries } = config;
 
   if (registries.length === 0) return staticLibraries;
@@ -324,7 +332,9 @@ export async function getLibraries(config: AppConfig): Promise<LibrariesConfig> 
   const nowSeconds = Date.now() / 1000;
 
   await Promise.allSettled(
-    registries.map(registryConfig => refreshRegistry(registryConfig, nowSeconds))
+    registries.map(registryConfig =>
+      refreshRegistry(registryConfig, nowSeconds)
+    )
   );
 
   // Merge: earlier registries override later ones; static libraries override all.
@@ -332,7 +342,10 @@ export async function getLibraries(config: AppConfig): Promise<LibrariesConfig> 
   for (let i = registries.length - 1; i >= 0; i--) {
     const state = registryCaches.get(registries[i].url);
     if (state?.libraries) {
-      mergedRegistryLibraries = { ...mergedRegistryLibraries, ...state.libraries };
+      mergedRegistryLibraries = {
+        ...mergedRegistryLibraries,
+        ...state.libraries
+      };
     }
   }
 

--- a/src/types/opds2.ts
+++ b/src/types/opds2.ts
@@ -42,7 +42,8 @@ export interface Group extends Collection<GroupMetadata> {
 export const SortFacetType = "http://palaceproject.io/terms/rel/sort";
 
 /** Property key marking a facet link as the default option for its group. */
-export const FacetDefaultProperty = "http://palaceproject.io/terms/facet/default";
+export const FacetDefaultProperty =
+  "http://palaceproject.io/terms/facet/default";
 
 export interface FacetGroupMetadata {
   title: string;
@@ -115,10 +116,10 @@ export const CatalogLinkTemplateRelation =
   "http://librarysimplified.org/rel/registry/library";
 export const CatalogRootRelation = "http://opds-spec.org/catalog";
 
-export const PaginationNextRelation  = "next";
+export const PaginationNextRelation = "next";
 export const PaginationFirstRelation = "first";
-export const PaginationPrevRelation  = "previous";
-export const PaginationLastRelation  = "last";
+export const PaginationPrevRelation = "previous";
+export const PaginationLastRelation = "last";
 
 export type PaginationLinkRelation =
   | typeof PaginationNextRelation

--- a/src/types/opds2.ts
+++ b/src/types/opds2.ts
@@ -38,7 +38,28 @@ export interface Group extends Collection<GroupMetadata> {
   groups: Feed<GroupMetadata>[];
 }
 
-type LibraryRegistryFeedMetadata = { adobe_vendor_id: string; title: string };
+/** URI identifying the sort facet group in a Library Registry feed. */
+export const SortFacetType = "http://palaceproject.io/terms/rel/sort";
+
+/** Property key marking a facet link as the default option for its group. */
+export const FacetDefaultProperty = "http://palaceproject.io/terms/facet/default";
+
+export interface FacetGroupMetadata {
+  title: string;
+  "@type"?: string; // e.g. SortFacetType
+}
+
+export interface FacetGroup {
+  metadata: FacetGroupMetadata;
+  links: Link[]; // the active facet link has rel === "self"
+}
+
+type LibraryRegistryFeedMetadata = {
+  adobe_vendor_id: string;
+  title: string;
+  numberOfItems?: number;
+};
+
 export interface LibraryRegistryFeed extends Feed<LibraryRegistryFeedMetadata> {
   links: Link[];
   /**
@@ -47,6 +68,7 @@ export interface LibraryRegistryFeed extends Feed<LibraryRegistryFeedMetadata> {
    * in an array. A generic LibraryRegistryFeed has a list of all catalogs
    */
   catalogs?: CatalogEntry[];
+  facets?: FacetGroup[];
 }
 
 type CatalogEntryMetadata = {
@@ -93,10 +115,22 @@ export const CatalogLinkTemplateRelation =
   "http://librarysimplified.org/rel/registry/library";
 export const CatalogRootRelation = "http://opds-spec.org/catalog";
 
+export const PaginationNextRelation  = "next";
+export const PaginationFirstRelation = "first";
+export const PaginationPrevRelation  = "previous";
+export const PaginationLastRelation  = "last";
+
+export type PaginationLinkRelation =
+  | typeof PaginationNextRelation
+  | typeof PaginationFirstRelation
+  | typeof PaginationPrevRelation
+  | typeof PaginationLastRelation;
+
 export type AnyLinkRelation =
   | typeof CatalogLinkTemplateRelation
   | typeof CatalogRootRelation
   | typeof AuthDocumentRelation
+  | PaginationLinkRelation
   | "self"
   | "search"
   | "registry";

--- a/src/utils/__tests__/librarySlug.test.ts
+++ b/src/utils/__tests__/librarySlug.test.ts
@@ -23,16 +23,16 @@ describe("validateSlug", () => {
     expect(validateSlug("my_lib")).toBe(true);
   });
 
-  it("rejects slugs containing colons", () => {
-    expect(validateSlug("urn:uuid:abc")).toBe(false);
+  it("accepts slugs containing colons", () => {
+    expect(validateSlug("urn:uuid:abc")).toBe(true);
   });
 
-  it("rejects slugs containing slashes", () => {
-    expect(validateSlug("a/b")).toBe(false);
+  it("accepts slugs containing slashes", () => {
+    expect(validateSlug("a/b")).toBe(true);
   });
 
-  it("rejects slugs containing spaces", () => {
-    expect(validateSlug("my lib")).toBe(false);
+  it("accepts slugs containing spaces", () => {
+    expect(validateSlug("my lib")).toBe(true);
   });
 
   it("rejects empty strings", () => {
@@ -45,21 +45,14 @@ describe("validateSlug", () => {
 // ---------------------------------------------------------------------------
 
 describe("computeSlug", () => {
-  it("strips 'urn:' prefix and replaces remaining colons with dashes", () => {
-    expect(computeSlug(makeCatalog("urn:uuid:abc123"))).toBe("uuid-abc123");
-  });
-
-  it("handles a realistic UUID URN", () => {
-    const id = "urn:uuid:3f0b05a0-4b6f-11ee-be56-0242ac120002";
-    expect(computeSlug(makeCatalog(id))).toBe(
-      "uuid-3f0b05a0-4b6f-11ee-be56-0242ac120002"
-    );
-  });
-
-  it("handles URNs with multiple colon-separated segments", () => {
+  it("returns URN ids unchanged", () => {
+    expect(computeSlug(makeCatalog("urn:uuid:abc123"))).toBe("urn:uuid:abc123");
     expect(computeSlug(makeCatalog("urn:isbn:0451450523"))).toBe(
-      "isbn-0451450523"
+      "urn:isbn:0451450523"
     );
+    expect(
+      computeSlug(makeCatalog("urn:uuid:3f0b05a0-4b6f-11ee-be56-0242ac120002"))
+    ).toBe("urn:uuid:3f0b05a0-4b6f-11ee-be56-0242ac120002");
   });
 
   it("returns non-URN ids unchanged", () => {
@@ -67,7 +60,7 @@ describe("computeSlug", () => {
     expect(computeSlug(makeCatalog("library123"))).toBe("library123");
   });
 
-  it("produces a slug that passes validateSlug for standard UUID URNs", () => {
+  it("produces a slug that passes validateSlug", () => {
     const slug = computeSlug(
       makeCatalog("urn:uuid:3f0b05a0-4b6f-11ee-be56-0242ac120002")
     );

--- a/src/utils/__tests__/librarySlug.test.ts
+++ b/src/utils/__tests__/librarySlug.test.ts
@@ -1,0 +1,76 @@
+import { computeSlug, validateSlug } from "../librarySlug";
+import type { OPDS2 } from "interfaces";
+
+function makeCatalog(id: string): OPDS2.CatalogEntry {
+  return {
+    metadata: { id, title: "Test Library", updated: "", description: "" },
+    links: []
+  };
+}
+
+// ---------------------------------------------------------------------------
+// validateSlug
+// ---------------------------------------------------------------------------
+
+describe("validateSlug", () => {
+  it("accepts alphanumeric slugs", () => {
+    expect(validateSlug("mylib")).toBe(true);
+    expect(validateSlug("MyLib123")).toBe(true);
+  });
+
+  it("accepts slugs with hyphens and underscores", () => {
+    expect(validateSlug("my-lib")).toBe(true);
+    expect(validateSlug("my_lib")).toBe(true);
+  });
+
+  it("rejects slugs containing colons", () => {
+    expect(validateSlug("urn:uuid:abc")).toBe(false);
+  });
+
+  it("rejects slugs containing slashes", () => {
+    expect(validateSlug("a/b")).toBe(false);
+  });
+
+  it("rejects slugs containing spaces", () => {
+    expect(validateSlug("my lib")).toBe(false);
+  });
+
+  it("rejects empty strings", () => {
+    expect(validateSlug("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeSlug
+// ---------------------------------------------------------------------------
+
+describe("computeSlug", () => {
+  it("strips 'urn:' prefix and replaces remaining colons with dashes", () => {
+    expect(computeSlug(makeCatalog("urn:uuid:abc123"))).toBe("uuid-abc123");
+  });
+
+  it("handles a realistic UUID URN", () => {
+    const id = "urn:uuid:3f0b05a0-4b6f-11ee-be56-0242ac120002";
+    expect(computeSlug(makeCatalog(id))).toBe(
+      "uuid-3f0b05a0-4b6f-11ee-be56-0242ac120002"
+    );
+  });
+
+  it("handles URNs with multiple colon-separated segments", () => {
+    expect(computeSlug(makeCatalog("urn:isbn:0451450523"))).toBe(
+      "isbn-0451450523"
+    );
+  });
+
+  it("returns non-URN ids unchanged", () => {
+    expect(computeSlug(makeCatalog("my-library"))).toBe("my-library");
+    expect(computeSlug(makeCatalog("library123"))).toBe("library123");
+  });
+
+  it("produces a slug that passes validateSlug for standard UUID URNs", () => {
+    const slug = computeSlug(
+      makeCatalog("urn:uuid:3f0b05a0-4b6f-11ee-be56-0242ac120002")
+    );
+    expect(validateSlug(slug)).toBe(true);
+  });
+});

--- a/src/utils/librarySlug.ts
+++ b/src/utils/librarySlug.ts
@@ -1,0 +1,12 @@
+import type { OPDS2 } from "interfaces";
+
+/**
+ * Computes the URL slug for a library from its registry catalog entry.
+ * The slug is used in URL paths (`/[slug]/`).
+ *
+ * Initial implementation uses the catalog metadata ID directly for backward
+ * compatibility. Future releases may slugify titles or combine fields.
+ */
+export function computeSlug(catalogEntry: OPDS2.CatalogEntry): string {
+  return catalogEntry.metadata.id;
+}

--- a/src/utils/librarySlug.ts
+++ b/src/utils/librarySlug.ts
@@ -1,23 +1,21 @@
 import type { OPDS2 } from "interfaces";
 
 /**
- * Returns true if slug can appear as a URL path segment without percent-encoding.
+ * Returns `true` if slug is considered valid.
+ *
+ * TODO: Consider adding more stringent validation rules. For example:
+ *  - RFC 3986 unreserved characters
  */
 export function validateSlug(slug: string): boolean {
-  return slug.length > 0 && encodeURIComponent(slug) === slug;
+  return slug.length > 0;
 }
 
 /**
  * Computes the URL slug for a library from its registry catalog entry.
  * The slug is used in URL paths (`/[slug]/`).
  *
- * URN identifiers (e.g. "urn:uuid:3f0b05a0-...") are normalized by stripping
- * the "urn:" prefix and replacing any remaining colons with dashes.
+ * Currently, the slug is simply the library's registry ID.'
  */
 export function computeSlug(catalogEntry: OPDS2.CatalogEntry): string {
-  let slug = catalogEntry.metadata.id;
-  if (slug.startsWith("urn:")) {
-    slug = slug.slice(4).replace(/:/g, "-");
-  }
-  return slug;
+  return catalogEntry.metadata.id;
 }

--- a/src/utils/librarySlug.ts
+++ b/src/utils/librarySlug.ts
@@ -1,9 +1,23 @@
 import type { OPDS2 } from "interfaces";
 
 /**
+ * Returns true if slug can appear as a URL path segment without percent-encoding.
+ */
+export function validateSlug(slug: string): boolean {
+  return slug.length > 0 && encodeURIComponent(slug) === slug;
+}
+
+/**
  * Computes the URL slug for a library from its registry catalog entry.
  * The slug is used in URL paths (`/[slug]/`).
+ *
+ * URN identifiers (e.g. "urn:uuid:3f0b05a0-...") are normalized by stripping
+ * the "urn:" prefix and replacing any remaining colons with dashes.
  */
 export function computeSlug(catalogEntry: OPDS2.CatalogEntry): string {
-  return catalogEntry.metadata.id;
+  let slug = catalogEntry.metadata.id;
+  if (slug.startsWith("urn:")) {
+    slug = slug.slice(4).replace(/:/g, "-");
+  }
+  return slug;
 }

--- a/src/utils/librarySlug.ts
+++ b/src/utils/librarySlug.ts
@@ -3,9 +3,6 @@ import type { OPDS2 } from "interfaces";
 /**
  * Computes the URL slug for a library from its registry catalog entry.
  * The slug is used in URL paths (`/[slug]/`).
- *
- * Initial implementation uses the catalog metadata ID directly for backward
- * compatibility. Future releases may slugify titles or combine fields.
  */
 export function computeSlug(catalogEntry: OPDS2.CatalogEntry): string {
   return catalogEntry.metadata.id;

--- a/tests/pages/api/libraries.test.ts
+++ b/tests/pages/api/libraries.test.ts
@@ -6,7 +6,10 @@
  */
 
 import type { NextApiRequest, NextApiResponse } from "next";
-import type { LibrariesResponse, LibrariesErrorResponse } from "../libraries";
+import type {
+  LibrariesResponse,
+  LibrariesErrorResponse
+} from "pages/api/libraries";
 
 // Mock the registry module so we can control what getLibraries returns.
 jest.mock("server/libraryRegistry", () => ({
@@ -14,7 +17,7 @@ jest.mock("server/libraryRegistry", () => ({
 }));
 
 import { getLibraries } from "server/libraryRegistry";
-import handler from "../libraries";
+import handler from "pages/api/libraries";
 
 const mockGetLibraries = getLibraries as jest.MockedFunction<
   typeof getLibraries

--- a/tests/pages/api/version.json.test.ts
+++ b/tests/pages/api/version.json.test.ts
@@ -5,8 +5,8 @@
  * (jest.config.node.js) because this is a server-side handler.
  */
 
-import type { VersionInfo } from "../version.json";
-import handler from "../version.json";
+import type { VersionInfo } from "pages/api/version.json";
+import handler from "pages/api/version.json";
 
 describe("GET /api/version.json", () => {
   const originalEnv = process.env;


### PR DESCRIPTION
## Description

- Changes library setup for libraries configured via `libraries: <url-string>` (deprecated) and `registries[].url` to occur at runtime (e.g., `npm run start`), rather than at build time.
- Adds support and optimizations for crawlable paginated library registry feeds, when configured and when required `order=modified` sort facet is advertised.
- Creates hooks for computing and validating slugs.

## Motivation and Context

Improves service start up performance by instantiating library pages during runtime, rather than build time. Our deployment currently builds the app in a docker container, which could not complete startup until the build was finished.

Improves runtime performance by incrementally loading updated registry libraries during refresh, reducing the load on each instance and on the configured registries.

Lays groundwork for future registry improvements.

[Jira PP-3114]

## How Has This Been Tested?

- Manual testing in local dev environment.
- Checks (tests, type checking, linter) pass locally.
- CI tests pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.