### PR TITLE
Statically configured libraries load at runtime, not build time (PP-4083)

### DIFF
--- a/msw/handlers/index.ts
+++ b/msw/handlers/index.ts
@@ -1,11 +1,5 @@
 import { http, HttpResponse } from "msw";
-import { APP_CONFIG } from "utils/env";
 import { PATRON_PROFILE_FIELDS } from "types/patronProfile";
-
-export const openEBackendUrl = APP_CONFIG.libraries["app"]?.authDocUrl.replace(
-  "/groups",
-  ""
-);
 
 export const handlers = [
   http.get("*/patrons/me/", ({ request }) => {

--- a/next.config.js
+++ b/next.config.js
@@ -63,7 +63,7 @@ log(
 );
 log(`Open eBooks Config: `, APP_CONFIG.openebooks);
 log(`Media Support: `, APP_CONFIG.mediaSupport);
-log(`Libraries: `, APP_CONFIG.libraries);
+log(`Libraries: (resolved at runtime from ${CONFIG_FILE})`);
 
 const config = {
   env: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
         "styled-system": "^5.1.2",
         "swr": "^1.3.0",
         "theme-ui": "^0.17.2",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.0",
+        "yaml": "^1.10.3"
       },
       "devDependencies": {
         "@axe-core/react": "^4.1.0",
@@ -187,6 +188,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -981,6 +983,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1059,7 +1062,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1077,7 +1079,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1095,7 +1096,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1113,7 +1113,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1131,7 +1130,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1149,7 +1147,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1167,7 +1164,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1185,7 +1181,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1203,7 +1198,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1221,7 +1215,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1239,7 +1232,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1257,7 +1249,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1275,7 +1266,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1293,7 +1283,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1311,7 +1300,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1329,7 +1317,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1347,7 +1334,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1365,7 +1351,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1383,7 +1368,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1401,7 +1385,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1419,7 +1402,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1437,7 +1419,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1455,7 +1436,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1473,7 +1453,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1491,7 +1470,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1509,7 +1487,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1710,6 +1687,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -2951,7 +2929,6 @@
       "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -2962,7 +2939,6 @@
       "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/fake-timers": "30.3.0",
         "@jest/types": "30.3.0",
@@ -2979,7 +2955,6 @@
       "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expect": "30.3.0",
         "jest-snapshot": "30.3.0"
@@ -2994,7 +2969,6 @@
       "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0"
       },
@@ -3008,7 +2982,6 @@
       "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "@sinonjs/fake-timers": "^15.0.0",
@@ -3027,7 +3000,6 @@
       "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -3055,7 +3027,6 @@
       "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-regex-util": "30.0.1"
@@ -3318,7 +3289,6 @@
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -3332,7 +3302,6 @@
       "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "chalk": "^4.1.2",
@@ -3543,7 +3512,6 @@
       "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -3593,7 +3561,6 @@
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -3951,8 +3918,7 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
       "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -3970,7 +3936,6 @@
       "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
@@ -4266,7 +4231,6 @@
       "integrity": "sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/theming": "8.6.18",
         "better-opn": "^3.0.2",
@@ -4299,7 +4263,6 @@
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4313,7 +4276,6 @@
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4644,6 +4606,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4776,6 +4739,7 @@
       "resolved": "https://registry.npmjs.org/@theme-ui/core/-/core-0.17.4.tgz",
       "integrity": "sha512-Thi46ulVpTbsU+DafydCrt6AftWvG+NicsA62MasObd0sbrfPPZVjuZdEt6yNDwzWXaI2UjNmJa8G4Uty+ALrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@theme-ui/css": "^0.17.4",
         "deepmerge": "^4.2.2"
@@ -4790,6 +4754,7 @@
       "resolved": "https://registry.npmjs.org/@theme-ui/css/-/css-0.17.4.tgz",
       "integrity": "sha512-lyitzWdqszEK+T76ad4XUYQM+UCUadeFqMsjjKB8E461oQHxCKuV7fY/SRJr6hP/Zxk/mAEQnwNp2wjc0z8OIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.10"
       },
@@ -4842,6 +4807,7 @@
       "resolved": "https://registry.npmjs.org/@theme-ui/theme-provider/-/theme-provider-0.17.4.tgz",
       "integrity": "sha512-A79XVNdkyLydTZFFsheWDsjOW16dSOAFhbByrJfM/9Y+4iJoaoQfFJ3IoCUvS7dBYgwTiPOBiEyeBgpDDTyclw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@theme-ui/color-modes": "^0.17.4",
         "@theme-ui/core": "^0.17.4",
@@ -4959,7 +4925,6 @@
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -4970,8 +4935,7 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/glob-to-regexp": {
       "version": "0.4.4",
@@ -5127,7 +5091,8 @@
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -5177,6 +5142,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5188,6 +5154,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5335,6 +5302,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -5559,7 +5527,6 @@
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -5570,24 +5537,21 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
@@ -5595,7 +5559,6 @@
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -5607,8 +5570,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
@@ -5616,7 +5578,6 @@
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5630,7 +5591,6 @@
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -5641,7 +5601,6 @@
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -5651,8 +5610,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
@@ -5660,7 +5618,6 @@
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5678,7 +5635,6 @@
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -5693,7 +5649,6 @@
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5707,7 +5662,6 @@
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -5723,7 +5677,6 @@
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -5734,16 +5687,14 @@
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -5757,6 +5708,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5792,7 +5744,6 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -5851,6 +5802,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5868,7 +5820,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -5887,7 +5838,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5904,8 +5854,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -6220,7 +6169,6 @@
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -6538,7 +6486,6 @@
       "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "open": "^8.0.4"
       },
@@ -6600,8 +6547,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -6629,6 +6575,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7022,7 +6969,6 @@
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -7703,6 +7649,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.6",
         "@cypress/xvfb": "^1.2.4",
@@ -8031,7 +7978,6 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8264,6 +8210,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -8424,8 +8371,7 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -8534,7 +8480,6 @@
       "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -8602,6 +8547,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8658,6 +8604,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9119,7 +9066,6 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -9176,7 +9122,6 @@
       "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/expect-utils": "30.3.0",
         "@jest/get-type": "30.1.0",
@@ -9284,8 +9229,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -10339,7 +10283,6 @@
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -10497,7 +10440,6 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -10891,7 +10833,6 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -11079,6 +11020,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -13448,7 +13390,6 @@
       "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
@@ -13465,7 +13406,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13479,7 +13419,6 @@
       "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.3.0",
         "@jest/get-type": "30.1.0",
@@ -13496,7 +13435,6 @@
       "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -13512,7 +13450,6 @@
       "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@jest/types": "30.3.0",
@@ -13534,7 +13471,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13548,7 +13484,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13562,7 +13497,6 @@
       "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -13578,7 +13512,6 @@
       "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "@types/node": "*",
@@ -13612,7 +13545,6 @@
       "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -14615,7 +14547,6 @@
       "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
@@ -14649,7 +14580,6 @@
       "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.3.0",
@@ -14676,7 +14606,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14690,7 +14619,6 @@
       "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "workspaces": [
         "test/babel-8"
       ],
@@ -14711,7 +14639,6 @@
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -14729,7 +14656,6 @@
       "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.3.0",
         "@jest/get-type": "30.1.0",
@@ -14746,7 +14672,6 @@
       "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "@types/node": "*",
@@ -14772,7 +14697,6 @@
       "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
@@ -14790,7 +14714,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14804,7 +14727,6 @@
       "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -14820,7 +14742,6 @@
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -14834,7 +14755,6 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -14848,7 +14768,6 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -14865,7 +14784,6 @@
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -14880,7 +14798,6 @@
       "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "@types/node": "*",
@@ -14899,7 +14816,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15277,7 +15193,6 @@
       "integrity": "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -15627,7 +15542,6 @@
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -16179,8 +16093,7 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/next": {
       "version": "15.5.14",
@@ -16517,7 +16430,6 @@
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -17016,6 +16928,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17264,6 +17177,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17276,6 +17190,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17508,7 +17423,6 @@
       "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
@@ -17526,7 +17440,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17651,7 +17564,6 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18976,7 +18888,6 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -18996,7 +18907,6 @@
       "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -19049,7 +18959,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -19063,7 +18972,6 @@
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -19078,8 +18986,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
       "version": "4.3.3",
@@ -19087,7 +18994,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -19108,7 +19014,6 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -19124,8 +19029,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map": {
       "version": "0.6.1",
@@ -19133,7 +19037,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19144,7 +19047,6 @@
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -19364,6 +19266,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19652,6 +19555,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19820,7 +19724,6 @@
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -19935,7 +19838,6 @@
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -20075,7 +19977,6 @@
       "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -20111,7 +20012,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -20125,7 +20025,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -20140,7 +20039,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -20150,8 +20048,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
@@ -20159,7 +20056,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -20643,6 +20539,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "styled-system": "^5.1.2",
     "swr": "^1.3.0",
     "theme-ui": "^0.17.2",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "yaml": "^1.10.3"
   },
   "devDependencies": {
     "@axe-core/react": "^4.1.0",

--- a/src/components/MultiLibraryHome.tsx
+++ b/src/components/MultiLibraryHome.tsx
@@ -21,7 +21,9 @@ const MultiLibraryHome: React.FC = () => {
     fetchLibraries
   );
 
-  if (!data || error) return null;
+  if (error)
+    return <p>Unable to load static libraries from configuration file.</p>;
+  if (!data?.libraries) return null;
 
   const sorted = [...data.libraries].sort(
     (a: ClientLibrary, b: ClientLibrary) => {

--- a/src/components/__tests__/MultiLibraryHome.test.tsx
+++ b/src/components/__tests__/MultiLibraryHome.test.tsx
@@ -102,7 +102,7 @@ describe("MultiLibraryHome", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("returns null on fetch error", () => {
+  it("displays an error message on fetch error", () => {
     mockedSWR.mockReturnValue(
       makeSwrResponse<any>({
         data: undefined,
@@ -110,8 +110,12 @@ describe("MultiLibraryHome", () => {
       })
     );
 
-    const { container } = render(<MultiLibraryHome />);
-    expect(container.firstChild).toBeNull();
+    render(<MultiLibraryHome />);
+    expect(
+      screen.getByText(
+        "Unable to load static libraries from configuration file."
+      )
+    ).toBeInTheDocument();
   });
 
   it("displays instance name in heading", () => {

--- a/src/config/__tests__/fetch-config.test.js
+++ b/src/config/__tests__/fetch-config.test.js
@@ -26,7 +26,10 @@ describe("fetch-config", () => {
   });
 
   describe("static libraries config (object format)", () => {
-    test("parses static libraries from object", async () => {
+    // Static library entries are validated and resolved at runtime by
+    // src/server/staticLibraries.ts. fetch-config always outputs libraries: {}.
+
+    test("outputs empty libraries regardless of object-format libraries in config", async () => {
       const yamlConfig = `
 instance_name: Test Instance
 libraries:
@@ -37,16 +40,6 @@ media_support: {}
 
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toEqual({
-        "main-street": {
-          title: "main-street",
-          authDocUrl: "https://example.com/main-street/auth"
-        },
-        "lyr-reads": {
-          title: "lyr-reads",
-          authDocUrl: "https://example.com/lyr-reads/auth"
-        }
-      });
       expect(config.registries).toEqual([]);
     });
 
@@ -59,282 +52,7 @@ media_support: {}
 
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toEqual({});
       expect(config.registries).toEqual([]);
-    });
-  });
-
-  describe("enhanced library config format (object with authDocUrl/title)", () => {
-    test("parses library with object format and custom title", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  main-lib:
-    authDocUrl: https://example.com/main/auth
-    title: "Main Library"
-media_support: {}
-      `;
-
-      const config = await parseConfig(yamlConfig);
-
-      expect(config.libraries).toEqual({
-        "main-lib": {
-          title: "Main Library",
-          authDocUrl: "https://example.com/main/auth"
-        }
-      });
-    });
-
-    test("parses library with object format without title (uses slug)", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  my-library:
-    authDocUrl: https://example.com/my-library/auth
-media_support: {}
-      `;
-
-      const config = await parseConfig(yamlConfig);
-
-      expect(config.libraries).toEqual({
-        "my-library": {
-          title: "my-library",
-          authDocUrl: "https://example.com/my-library/auth"
-        }
-      });
-    });
-
-    test("mixes string and object formats in same config", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  simple-lib: https://example.com/simple/auth
-  custom-lib:
-    authDocUrl: https://example.com/custom/auth
-    title: "Custom Library"
-  another-lib:
-    authDocUrl: https://example.com/another/auth
-media_support: {}
-      `;
-
-      const config = await parseConfig(yamlConfig);
-
-      expect(config.libraries).toEqual({
-        "simple-lib": {
-          title: "simple-lib",
-          authDocUrl: "https://example.com/simple/auth"
-        },
-        "custom-lib": {
-          title: "Custom Library",
-          authDocUrl: "https://example.com/custom/auth"
-        },
-        "another-lib": {
-          title: "another-lib",
-          authDocUrl: "https://example.com/another/auth"
-        }
-      });
-    });
-
-    test("throws error for null value", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib: null
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'] cannot be null or undefined"
-      );
-    });
-
-    test("throws error for empty string value", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib: ""
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'] cannot be an empty string"
-      );
-    });
-
-    test("throws error for whitespace-only string value", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib: "   "
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'] cannot be an empty string"
-      );
-    });
-
-    test("throws error for object missing authDocUrl", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib:
-    title: "My Library"
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
-      );
-    });
-
-    test("throws error for object with non-string authDocUrl", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib:
-    authDocUrl: 12345
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
-      );
-    });
-
-    test("throws error for object with empty string authDocUrl", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib:
-    authDocUrl: ""
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'].authDocUrl cannot be an empty string"
-      );
-    });
-
-    test("throws error for object with whitespace-only authDocUrl", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib:
-    authDocUrl: "  "
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'].authDocUrl cannot be an empty string"
-      );
-    });
-
-    test("throws error for object with non-string title", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib:
-    authDocUrl: https://example.com/auth
-    title: 123
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'].title must be a string"
-      );
-    });
-
-    test("throws error for object with empty string title", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib:
-    authDocUrl: https://example.com/auth
-    title: ""
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'].title cannot be an empty string"
-      );
-    });
-
-    test("throws error for object with whitespace-only title", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib:
-    authDocUrl: https://example.com/auth
-    title: "   "
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'].title cannot be an empty string"
-      );
-    });
-
-    test("throws error for number value", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib: 12345
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'] must be either a string (auth doc URL) or an object with 'authDocUrl' property"
-      );
-    });
-
-    test("throws error for boolean value", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib: true
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'] must be either a string (auth doc URL) or an object with 'authDocUrl' property"
-      );
-    });
-
-    test("throws error for array value", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  bad-lib:
-    - https://example.com/auth
-media_support: {}
-      `;
-
-      await expect(parseConfig(yamlConfig)).rejects.toThrow(
-        "CONFIG_FILE.libraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
-      );
-    });
-
-    test("ignores extra keys in object format", async () => {
-      const yamlConfig = `
-instance_name: Test Instance
-libraries:
-  my-lib:
-    authDocUrl: https://example.com/auth
-    title: "My Library"
-    extra_field: "ignored"
-    another_field: 123
-media_support: {}
-      `;
-
-      const config = await parseConfig(yamlConfig);
-
-      expect(config.libraries).toEqual({
-        "my-lib": {
-          title: "My Library",
-          authDocUrl: "https://example.com/auth"
-        }
-      });
     });
   });
 
@@ -477,7 +195,6 @@ media_support: {}
 
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toEqual({});
       expect(config.registries).toEqual([
         {
           url: "https://registry.example.com/libraries",
@@ -488,7 +205,7 @@ media_support: {}
       expect(fetch).not.toHaveBeenCalled();
     });
 
-    test("static libraries are present at build time; registry libraries are runtime-only", async () => {
+    test("static library entries do not appear in build output; registry config is stored", async () => {
       const yamlConfig = `
 instance_name: Test Instance
 libraries:
@@ -502,12 +219,6 @@ media_support: {}
 
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toEqual({
-        "shared-slug": {
-          title: "Static Override Library",
-          authDocUrl: "https://example.com/static-override/auth"
-        }
-      });
       expect(config.registries).toEqual([
         {
           url: "https://registry.example.com/libraries",
@@ -530,7 +241,6 @@ media_support: {}
 
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toEqual({});
       expect(config.registries).toHaveLength(2);
       expect(config.registries[0].url).toBe(
         "https://registry1.example.com/libraries"
@@ -541,7 +251,7 @@ media_support: {}
       expect(fetch).not.toHaveBeenCalled();
     });
 
-    test("combines static libraries with registries config", async () => {
+    test("static library entries are omitted from build output; registries config is stored", async () => {
       const yamlConfig = `
 instance_name: Test Instance
 libraries:
@@ -553,12 +263,6 @@ media_support: {}
 
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toEqual({
-        "static-lib": {
-          title: "static-lib",
-          authDocUrl: "https://example.com/static/auth"
-        }
-      });
       expect(config.registries).toEqual([
         {
           url: "https://registry.example.com/libraries",
@@ -601,7 +305,6 @@ media_support: {}
 
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toEqual({});
       expect(config.registries).toEqual([
         {
           url: "https://registry.example.com/libraries",
@@ -651,7 +354,6 @@ media_support: {}
 
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toBeDefined();
       expect(config.registries).toEqual([]);
     });
 
@@ -665,7 +367,6 @@ media_support: {}
 
       const config = await parseConfig(yamlConfig);
 
-      expect(config.libraries).toEqual({});
       expect(config.registries).toHaveLength(1);
       expect(fetch).not.toHaveBeenCalled();
     });

--- a/src/config/fetch-config.js
+++ b/src/config/fetch-config.js
@@ -56,77 +56,6 @@ async function fetchConfigFile(configFileUrl) {
 }
 
 /**
- * Creates a LibrariesConfig from the object in the config file.
- * Supports two formats:
- * 1. String format: slug maps to auth doc URL (slug becomes title)
- * 2. Object format: slug maps to { authDocUrl, title? }
- */
-function makeLibrariesConfig(libraries) {
-  return Object.keys(libraries).reduce((record, slug) => {
-    const value = libraries[slug];
-
-    // Validate value is not null/undefined
-    if (value == null) {
-      throw new AppSetupError(
-        `CONFIG_FILE.libraries['${slug}'] cannot be null or undefined`
-      );
-    }
-
-    // Handle string format (backward compatible)
-    if (typeof value === "string") {
-      if (value.trim() === "") {
-        throw new AppSetupError(
-          `CONFIG_FILE.libraries['${slug}'] cannot be an empty string`
-        );
-      }
-      return { ...record, [slug]: { title: slug, authDocUrl: value } };
-    }
-
-    // Handle object format
-    if (typeof value === "object") {
-      // Validate authDocUrl exists and is a string
-      if (!("authDocUrl" in value) || typeof value.authDocUrl !== "string") {
-        throw new AppSetupError(
-          `CONFIG_FILE.libraries['${slug}'] must have an 'authDocUrl' property with a valid URL string`
-        );
-      }
-      // Validate authDocUrl is not empty
-      if (value.authDocUrl.trim() === "") {
-        throw new AppSetupError(
-          `CONFIG_FILE.libraries['${slug}'].authDocUrl cannot be an empty string`
-        );
-      }
-
-      // Validate title if present
-      let title = slug; // default to slug
-      if ("title" in value) {
-        if (typeof value.title !== "string") {
-          throw new AppSetupError(
-            `CONFIG_FILE.libraries['${slug}'].title must be a string`
-          );
-        }
-        if (value.title.trim() === "") {
-          throw new AppSetupError(
-            `CONFIG_FILE.libraries['${slug}'].title cannot be an empty string`
-          );
-        }
-        title = value.title;
-      }
-
-      return {
-        ...record,
-        [slug]: { title, authDocUrl: value.authDocUrl }
-      };
-    }
-
-    // Invalid type
-    throw new AppSetupError(
-      `CONFIG_FILE.libraries['${slug}'] must be either a string (auth doc URL) or an object with 'authDocUrl' property`
-    );
-  }, {});
-}
-
-/**
  * Validates and parses the registries array from the config file
  * Returns an array of registry configurations with defaults applied
  */
@@ -203,16 +132,11 @@ async function parseConfig(raw) {
     ];
   }
 
-  // Apply static libraries (these take precedence over registry libraries at runtime).
-  let libraries = {};
-  if (unparsed.libraries && typeof unparsed.libraries === "object") {
-    libraries = makeLibrariesConfig(unparsed.libraries);
-  }
+  // Static libraries are resolved at runtime by src/server/staticLibraries.ts.
 
   // otherwise assume the file is properly structured.
   return {
     instanceName: unparsed.instance_name || "Patron Web Catalog",
-    libraries,
     registries,
     mediaSupport: unparsed.media_support || {},
     bugsnagApiKey: unparsed.bugsnag_api_key || null,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,7 +19,6 @@ export { OPDS1 };
 export type AppConfig = {
   instanceName: string;
   mediaSupport: MediaSupportConfig;
-  libraries: LibrariesConfig;
   registries?: RegistryConfig[];
   companionApp: "simplye" | "openebooks";
   showMedium: boolean;

--- a/src/pages/api/libraries.ts
+++ b/src/pages/api/libraries.ts
@@ -3,7 +3,7 @@
  *
  * Returns the current list of available libraries. For configs that specify
  * a `registries` array, libraries are fetched at runtime and cached
- * server-side. For configs with only static `libraries`, the build-time
+ * server-side. For configs with only static `libraries`, the runtime-loaded
  * list is returned directly.
  *
  * Only client-safe fields are included in the response; full registry

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -16,6 +16,14 @@ import {
   DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL,
   DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL
 } from "constants/registry";
+import { resetStaticLibrariesCache } from "../staticLibraries";
+
+jest.mock("../staticLibraries", () => ({
+  getStaticLibraries: jest.fn().mockResolvedValue({}),
+  resetStaticLibrariesCache: jest.fn()
+}));
+
+import { getStaticLibraries } from "../staticLibraries";
 
 // ---------------------------------------------------------------------------
 // Test infrastructure
@@ -35,7 +43,6 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     showMedium: true,
     openebooks: null,
     mediaSupport: {},
-    libraries: {},
     ...overrides
   };
 }
@@ -765,16 +772,20 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 // ---------------------------------------------------------------------------
 
 describe("getLibraries", () => {
-  beforeEach(() => resetRegistryCaches());
+  beforeEach(() => {
+    resetRegistryCaches();
+    resetStaticLibrariesCache();
+    (getStaticLibraries as jest.Mock).mockResolvedValue({});
+  });
 
   it("returns static libraries when no registries are configured", async () => {
-    const config = makeConfig({
-      libraries: {
-        "my-lib": { title: "My Lib", authDocUrl: "https://my.lib/auth" }
-      }
-    });
-    const result = await getLibraries(config);
-    expect(result).toEqual(config.libraries);
+    const staticLibs = {
+      "my-lib": { title: "My Lib", authDocUrl: "https://my.lib/auth" }
+    };
+    (getStaticLibraries as jest.Mock).mockResolvedValue(staticLibs);
+
+    const result = await getLibraries(makeConfig());
+    expect(result).toEqual(staticLibs);
   });
 
   it("fetches from registry and returns merged libraries", async () => {
@@ -804,17 +815,16 @@ describe("getLibraries", () => {
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
-    const config = makeConfig({
-      libraries: {
-        "urn:uuid:shared": {
-          title: "Static Version",
-          authDocUrl: "https://static.example.com/auth"
-        }
-      },
-      registries: [makeRegistryConfig()]
+    (getStaticLibraries as jest.Mock).mockResolvedValue({
+      "urn:uuid:shared": {
+        title: "Static Version",
+        authDocUrl: "https://static.example.com/auth"
+      }
     });
 
-    const result = await getLibraries(config);
+    const result = await getLibraries(
+      makeConfig({ registries: [makeRegistryConfig()] })
+    );
     expect(result["urn:uuid:shared"]?.title).toBe("Static Version");
   });
 

--- a/src/server/__tests__/staticLibraries.test.ts
+++ b/src/server/__tests__/staticLibraries.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the runtime static library loader.
+ * Run under jest.config.node.js.
+ */
+
+import {
+  getStaticLibraries,
+  resetStaticLibrariesCache
+} from "../staticLibraries";
+
+jest.mock("fs", () => ({
+  readFileSync: jest.fn()
+}));
+
+import { readFileSync } from "fs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeYaml(libraries: string): string {
+  return `instance_name: Test\n${libraries}\nmedia_support: {}`;
+}
+
+function mockConfigFile(content: string): void {
+  process.env.CONFIG_FILE = "/test/config.yml";
+  (readFileSync as jest.Mock).mockReturnValue(content);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("getStaticLibraries", () => {
+  beforeEach(() => {
+    resetStaticLibrariesCache();
+    delete process.env.CONFIG_FILE;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.CONFIG_FILE;
+  });
+
+  it("returns empty object when CONFIG_FILE is not set", async () => {
+    const result = await getStaticLibraries();
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when config has no libraries section", async () => {
+    mockConfigFile(`instance_name: Test\nmedia_support: {}`);
+    const result = await getStaticLibraries();
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when libraries is a string (deprecated registry URL)", async () => {
+    mockConfigFile(
+      makeYaml("libraries: https://registry.example.com/libraries")
+    );
+    const result = await getStaticLibraries();
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when libraries is empty object", async () => {
+    mockConfigFile(makeYaml("libraries: {}"));
+    const result = await getStaticLibraries();
+    expect(result).toEqual({});
+  });
+
+  it("parses string-format entry (auth doc URL, slug as title)", async () => {
+    mockConfigFile(makeYaml("libraries:\n  my-lib: https://example.com/auth"));
+    const result = await getStaticLibraries();
+    expect(result).toEqual({
+      "my-lib": { title: "my-lib", authDocUrl: "https://example.com/auth" }
+    });
+  });
+
+  it("parses object-format entry with authDocUrl and title", async () => {
+    mockConfigFile(
+      makeYaml(
+        "libraries:\n  my-lib:\n    authDocUrl: https://example.com/auth\n    title: My Library"
+      )
+    );
+    const result = await getStaticLibraries();
+    expect(result).toEqual({
+      "my-lib": { title: "My Library", authDocUrl: "https://example.com/auth" }
+    });
+  });
+
+  it("uses slug as title when title is absent from object-format entry", async () => {
+    mockConfigFile(
+      makeYaml(
+        "libraries:\n  my-lib:\n    authDocUrl: https://example.com/auth"
+      )
+    );
+    const result = await getStaticLibraries();
+    expect(result["my-lib"]?.title).toBe("my-lib");
+  });
+
+  it("parses multiple entries", async () => {
+    mockConfigFile(
+      makeYaml(
+        "libraries:\n  lib-a: https://a.example.com/auth\n  lib-b: https://b.example.com/auth"
+      )
+    );
+    const result = await getStaticLibraries();
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result["lib-a"]?.authDocUrl).toBe("https://a.example.com/auth");
+    expect(result["lib-b"]?.authDocUrl).toBe("https://b.example.com/auth");
+  });
+
+  it("caches the result on subsequent calls", async () => {
+    mockConfigFile(makeYaml("libraries:\n  my-lib: https://example.com/auth"));
+    await getStaticLibraries();
+    await getStaticLibraries();
+    expect(readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-reads after resetStaticLibrariesCache", async () => {
+    mockConfigFile(makeYaml("libraries:\n  my-lib: https://example.com/auth"));
+    await getStaticLibraries();
+    resetStaticLibrariesCache();
+    await getStaticLibraries();
+    expect(readFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  describe("validation errors", () => {
+    it("throws for null value", async () => {
+      mockConfigFile(makeYaml("libraries:\n  bad-lib: null"));
+      await expect(getStaticLibraries()).rejects.toThrow(
+        "CONFIG_FILE.libraries['bad-lib'] cannot be null or undefined"
+      );
+    });
+
+    it("throws for empty string value", async () => {
+      mockConfigFile(makeYaml('libraries:\n  bad-lib: ""'));
+      await expect(getStaticLibraries()).rejects.toThrow(
+        "CONFIG_FILE.libraries['bad-lib'] cannot be an empty string"
+      );
+    });
+
+    it("throws for whitespace-only string value", async () => {
+      mockConfigFile(makeYaml('libraries:\n  bad-lib: "   "'));
+      await expect(getStaticLibraries()).rejects.toThrow(
+        "CONFIG_FILE.libraries['bad-lib'] cannot be an empty string"
+      );
+    });
+
+    it("throws for object missing authDocUrl", async () => {
+      mockConfigFile(makeYaml("libraries:\n  bad-lib:\n    title: My Library"));
+      await expect(getStaticLibraries()).rejects.toThrow(
+        "CONFIG_FILE.libraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
+      );
+    });
+
+    it("throws for object with non-string authDocUrl", async () => {
+      mockConfigFile(makeYaml("libraries:\n  bad-lib:\n    authDocUrl: 12345"));
+      await expect(getStaticLibraries()).rejects.toThrow(
+        "CONFIG_FILE.libraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
+      );
+    });
+
+    it("throws for object with empty authDocUrl", async () => {
+      mockConfigFile(makeYaml('libraries:\n  bad-lib:\n    authDocUrl: ""'));
+      await expect(getStaticLibraries()).rejects.toThrow(
+        "CONFIG_FILE.libraries['bad-lib'].authDocUrl cannot be an empty string"
+      );
+    });
+
+    it("throws for object with non-string title", async () => {
+      mockConfigFile(
+        makeYaml(
+          "libraries:\n  bad-lib:\n    authDocUrl: https://example.com/auth\n    title: 123"
+        )
+      );
+      await expect(getStaticLibraries()).rejects.toThrow(
+        "CONFIG_FILE.libraries['bad-lib'].title must be a string"
+      );
+    });
+
+    it("throws for object with empty title", async () => {
+      mockConfigFile(
+        makeYaml(
+          'libraries:\n  bad-lib:\n    authDocUrl: https://example.com/auth\n    title: ""'
+        )
+      );
+      await expect(getStaticLibraries()).rejects.toThrow(
+        "CONFIG_FILE.libraries['bad-lib'].title cannot be an empty string"
+      );
+    });
+
+    it("throws for number value", async () => {
+      mockConfigFile(makeYaml("libraries:\n  bad-lib: 12345"));
+      await expect(getStaticLibraries()).rejects.toThrow(
+        "CONFIG_FILE.libraries['bad-lib'] must be either a string (auth doc URL) or an object with 'authDocUrl' property"
+      );
+    });
+
+    it("throws for boolean value", async () => {
+      mockConfigFile(makeYaml("libraries:\n  bad-lib: true"));
+      await expect(getStaticLibraries()).rejects.toThrow(
+        "CONFIG_FILE.libraries['bad-lib'] must be either a string (auth doc URL) or an object with 'authDocUrl' property"
+      );
+    });
+  });
+});

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_REGISTRY_FETCH_TIMEOUT
 } from "constants/registry";
 import { computeSlug, validateSlug } from "utils/librarySlug";
+import { getStaticLibraries } from "./staticLibraries";
 
 // ---------------------------------------------------------------------------
 // Internal state types
@@ -325,7 +326,8 @@ async function refreshRegistry(
 export async function getLibraries(
   config: AppConfig
 ): Promise<LibrariesConfig> {
-  const { registries = [], libraries: staticLibraries } = config;
+  const { registries = [] } = config;
+  const staticLibraries = await getStaticLibraries();
 
   if (registries.length === 0) return staticLibraries;
 

--- a/src/server/staticLibraries.ts
+++ b/src/server/staticLibraries.ts
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment node
+ *
+ * Provides the static library list from the app's config file, read once
+ * at runtime on first access. The result is cached for the lifetime of the
+ * server process; the static libraries do not change after startup.
+ *
+ * This module is server-only. It reads CONFIG_FILE directly rather than using
+ * the baked APP_CONFIG so that the library entries (auth doc URLs, titles) are
+ * resolved at runtime, not embedded in the build artifact.
+ */
+
+import { readFileSync } from "fs";
+import YAML from "yaml";
+import type { LibrariesConfig } from "interfaces";
+import { AppSetupError } from "errors";
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalizes and validates a single static library entry.
+ * Accepts either a string (auth doc URL, slug used as title) or an object
+ * with `authDocUrl` and optional `title`.
+ */
+function parseLibraryEntry(
+  slug: string,
+  value: unknown
+): { title: string; authDocUrl: string } {
+  if (value == null) {
+    throw new AppSetupError(
+      `CONFIG_FILE.libraries['${slug}'] cannot be null or undefined`
+    );
+  }
+
+  if (typeof value === "string") {
+    if (value.trim() === "") {
+      throw new AppSetupError(
+        `CONFIG_FILE.libraries['${slug}'] cannot be an empty string`
+      );
+    }
+    return { title: slug, authDocUrl: value };
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    const entry = value as Record<string, unknown>;
+
+    if (!("authDocUrl" in entry) || typeof entry.authDocUrl !== "string") {
+      throw new AppSetupError(
+        `CONFIG_FILE.libraries['${slug}'] must have an 'authDocUrl' property with a valid URL string`
+      );
+    }
+    if (entry.authDocUrl.trim() === "") {
+      throw new AppSetupError(
+        `CONFIG_FILE.libraries['${slug}'].authDocUrl cannot be an empty string`
+      );
+    }
+
+    let title = slug;
+    if ("title" in entry) {
+      if (typeof entry.title !== "string") {
+        throw new AppSetupError(
+          `CONFIG_FILE.libraries['${slug}'].title must be a string`
+        );
+      }
+      if (entry.title.trim() === "") {
+        throw new AppSetupError(
+          `CONFIG_FILE.libraries['${slug}'].title cannot be an empty string`
+        );
+      }
+      title = entry.title;
+    }
+
+    return { title, authDocUrl: entry.authDocUrl };
+  }
+
+  throw new AppSetupError(
+    `CONFIG_FILE.libraries['${slug}'] must be either a string (auth doc URL) or an object with 'authDocUrl' property`
+  );
+}
+
+/**
+ * Validates and normalizes the raw `libraries` object from the config YAML.
+ */
+function parseStaticLibraries(raw: Record<string, unknown>): LibrariesConfig {
+  return Object.keys(raw).reduce<LibrariesConfig>((acc, slug) => {
+    acc[slug] = parseLibraryEntry(slug, raw[slug]);
+    return acc;
+  }, {});
+}
+
+// ---------------------------------------------------------------------------
+// Runtime cache and loader
+// ---------------------------------------------------------------------------
+
+let cached: LibrariesConfig | null = null;
+
+/**
+ * Returns the static libraries defined in the config file. Reads and parses
+ * CONFIG_FILE on the first call, then returns the cached result on subsequent
+ * calls. Returns an empty object when CONFIG_FILE is not set or contains no
+ * static `libraries` section.
+ */
+export async function getStaticLibraries(): Promise<LibrariesConfig> {
+  if (cached !== null) return cached;
+
+  const configFile = process.env.CONFIG_FILE;
+  if (!configFile) {
+    cached = {};
+    return cached;
+  }
+
+  let text: string;
+  if (configFile.startsWith("http")) {
+    const res = await fetch(configFile);
+    if (!res.ok) {
+      throw new Error(`Could not fetch config file at: ${configFile}`);
+    }
+    text = await res.text();
+  } else {
+    text = readFileSync(configFile, "utf8");
+  }
+
+  const raw = YAML.parse(text) as Record<string, unknown>;
+
+  /*
+   * Only the object format defines static libraries. A string value is the
+   * deprecated registry URL format (handled as a runtime registry entry
+   * elsewhere), and a missing or falsy value means no static libraries.
+   */
+  if (
+    !raw?.libraries ||
+    typeof raw.libraries !== "object" ||
+    Array.isArray(raw.libraries)
+  ) {
+    cached = {};
+    return cached;
+  }
+
+  cached = parseStaticLibraries(raw.libraries as Record<string, unknown>);
+  return cached;
+}
+
+/** Clears the in-memory cache. Intended for use in tests only. */
+export function resetStaticLibrariesCache(): void {
+  cached = null;
+}

--- a/src/server/staticLibraries.ts
+++ b/src/server/staticLibraries.ts
@@ -14,6 +14,7 @@ import { readFileSync } from "fs";
 import YAML from "yaml";
 import type { LibrariesConfig } from "interfaces";
 import { AppSetupError } from "errors";
+import { isHttpUrl } from "utils/parse";
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -112,7 +113,7 @@ export async function getStaticLibraries(): Promise<LibrariesConfig> {
   }
 
   let text: string;
-  if (configFile.startsWith("http")) {
+  if (isHttpUrl(configFile)) {
     const res = await fetch(configFile);
     if (!res.ok) {
       throw new Error(`Could not fetch config file at: ${configFile}`);

--- a/src/server/staticLibraries.ts
+++ b/src/server/staticLibraries.ts
@@ -15,6 +15,7 @@ import YAML from "yaml";
 import type { LibrariesConfig } from "interfaces";
 import { AppSetupError } from "errors";
 import { isHttpUrl } from "utils/parse";
+import { DEFAULT_REGISTRY_FETCH_TIMEOUT } from "constants/registry";
 
 // ---------------------------------------------------------------------------
 // Validation helpers
@@ -114,7 +115,17 @@ export async function getStaticLibraries(): Promise<LibrariesConfig> {
 
   let text: string;
   if (isHttpUrl(configFile)) {
-    const res = await fetch(configFile);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      DEFAULT_REGISTRY_FETCH_TIMEOUT * 1000
+    );
+    let res: Response;
+    try {
+      res = await fetch(configFile, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeoutId);
+    }
     if (!res.ok) {
       throw new Error(`Could not fetch config file at: ${configFile}`);
     }

--- a/src/test-utils/fixtures/config.ts
+++ b/src/test-utils/fixtures/config.ts
@@ -7,9 +7,6 @@ export const config: AppConfig = {
   companionApp: "simplye",
   showMedium: true,
   openebooks: null,
-  libraries: {
-    lib1: { title: "lib1", authDocUrl: "http://lib1.com" }
-  },
   mediaSupport: {
     "application/epub+zip": "show",
     "application/kepub+zip": "show",

--- a/src/utils/__tests__/parse.test.ts
+++ b/src/utils/__tests__/parse.test.ts
@@ -1,4 +1,4 @@
-import { parseUrl } from "utils/parse";
+import { parseUrl, isHttpUrl } from "utils/parse";
 
 describe("parseUrl()", () => {
   describe("Invalid URL", () => {
@@ -28,5 +28,19 @@ describe("parseUrl()", () => {
       expect(url).not.toBeNull();
       expect(url!.href).toBe("https://www.secure.com/");
     });
+  });
+});
+
+describe("isHttpUrl()", () => {
+  test.each([
+    ["https://www.example.com", true],
+    ["http://www.example.com", true],
+    ["ftp://www.example.com", false],
+    ["file:///etc/passwd", false],
+    ["no-protocol", false],
+    ["#$%", false],
+    ["", false]
+  ])("%s → %s", (input, expected) => {
+    expect(isHttpUrl(input)).toBe(expected);
   });
 });

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -9,3 +9,18 @@ export const parseUrl = (raw: string | undefined): URL | null => {
     return null;
   }
 };
+
+const _validUrlOrNull = (raw: string | undefined): URL | null => {
+  try {
+    if (!raw) return null;
+    const decoded = decodeURIComponent(raw);
+    return new URL(decoded);
+  } catch {
+    return null;
+  }
+};
+
+export const isHttpUrl = (raw: string): boolean => {
+  const url = _validUrlOrNull(raw);
+  return !!url && ["https:", "http:"].includes(url.protocol);
+};

--- a/tests/pages/api/libraries.test.ts
+++ b/tests/pages/api/libraries.test.ts
@@ -34,8 +34,7 @@ const VALID_APP_CONFIG = JSON.stringify({
   companionApp: "simplye",
   showMedium: true,
   openebooks: null,
-  mediaSupport: {},
-  libraries: {}
+  mediaSupport: {}
 });
 
 function makeRes() {


### PR DESCRIPTION
## Description

- Moves static library loading from build time to runtime. Libraries defined in the `libraries` section of `CONFIG_FILE` are now read and cached on first server request rather than baked into the build artifact.
- Registry-sourced libraries continue to be fetched and cached per the existing registry refresh logic.

## Motivation and Context

- Waiting to generate libraries pages for the statically-specified libraries improves build performance, allowing the container to become ready more quickly.
- Library configuration (auth doc URLs, titles) was previously embedded in the build artifact, requiring a rebuild to reflect config changes. This change allows the server to serve the current library list from `CONFIG_FILE` without a rebuild.

[Jira PP-4083]

## How Has This Been Tested?

- Manual testing in local development environment.
- New and updated tests.
- All checks (tests, type checker, linter) pass locally.
- Build succeeds locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/24487198022) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.