### PR TITLE
Fix registry cache race condition (PP-4102)

### DIFF
--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -949,6 +949,35 @@ describe("concurrent first-fetch coalescing", () => {
     // Only one network request despite two concurrent callers.
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("concurrent callers both get an empty result when the in-progress crawl fails", async () => {
+    let resolveFetch!: () => void;
+    const fetchGate = new Promise<void>(resolve => {
+      resolveFetch = resolve;
+    });
+
+    const fetchMock = jest.fn().mockReturnValue(
+      fetchGate.then(() => ({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+        json: async () => ({})
+      }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const config = makeConfig({ registries: [makeRegistryConfig()] });
+
+    const p1 = getLibraries(config);
+    const p2 = getLibraries(config);
+    resolveFetch();
+
+    const [result1, result2] = await Promise.all([p1, p2]);
+
+    expect(result1).toEqual({});
+    expect(result2).toEqual({});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -893,6 +893,65 @@ describe("getLibraries", () => {
 });
 
 // ---------------------------------------------------------------------------
+// concurrent first-fetch coalescing
+// ---------------------------------------------------------------------------
+
+describe("concurrent first-fetch coalescing", () => {
+  beforeEach(() => {
+    resetRegistryCaches();
+    (getStaticLibraries as jest.Mock).mockResolvedValue({});
+  });
+
+  it("concurrent getLibraries calls both receive the fetched libraries, not an empty list", async () => {
+    /*
+     * Simulate the Next.js ISR race: two getStaticProps calls arrive before
+     * the registry has been fetched. The first call starts the crawl and sets
+     * lastAttemptedFetch; without pendingRefreshes the second call would see
+     * lastAttemptedFetch within minInterval, skip the refresh, and return an
+     * empty library list.
+     *
+     * Gate the fetch behind a promise so both calls are in-flight when the
+     * network response arrives.
+     */
+    let resolveFetch!: () => void;
+    const fetchGate = new Promise<void>(resolve => {
+      resolveFetch = resolve;
+    });
+
+    const feed = makePagedFeed([
+      {
+        id: "urn:uuid:abc",
+        title: "Library A",
+        authDocUrl: "https://a.example.com/auth"
+      }
+    ]);
+
+    const fetchMock = jest.fn().mockReturnValue(
+      fetchGate.then(() => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => feed
+      }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const config = makeConfig({ registries: [makeRegistryConfig()] });
+
+    const p1 = getLibraries(config);
+    const p2 = getLibraries(config);
+    resolveFetch();
+
+    const [result1, result2] = await Promise.all([p1, p2]);
+
+    expect(result1["urn:uuid:abc"]).toBeDefined();
+    expect(result2["urn:uuid:abc"]).toBeDefined();
+    // Only one network request despite two concurrent callers.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // fetch timeout
 // ---------------------------------------------------------------------------
 

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -252,11 +252,10 @@ export async function fetchRegistryLibraries(
  * skip the duplicate. Errors are logged and swallowed; the existing cached
  * state is retained.
  *
- * If a crawl for this URL is already in-progress (tracked in pendingRefreshes),
- * this function awaits that crawl instead of starting a new one. This prevents
- * the race where a concurrent request skips the refresh (because
- * lastAttemptedFetch is set) and reads an empty cache before the first crawl
- * has completed.
+ * If a crawl for this URL is already in progress, await it, rather than
+ * returning stale data or starting a new one. This prevents the race where
+ * a concurrent request skips the refresh and reads an empty cache before
+ * the first crawl has completed.
  */
 async function refreshRegistry(
   registryConfig: RegistryConfig,
@@ -297,11 +296,12 @@ async function refreshRegistry(
     lastAttemptedFetch: attemptTime
   });
 
-  // Wrap the crawl in a named promise so concurrent callers can await it.
-  // All synchronous setup above runs before the first await, so
-  // pendingRefreshes is populated before the event loop can schedule another
-  // call to this function.
-  const crawlPromise = (async () => {
+  // Register the crawl promise before starting the crawl so that any
+  // concurrent caller arriving after this point is guaranteed to find it.
+  let startCrawl!: () => void;
+  const crawlPromise = new Promise<void>(resolve => {
+    startCrawl = resolve;
+  }).then(async () => {
     try {
       const result = await crawlRegistryFeed(startUrl, stopBefore, timeoutMs);
 
@@ -337,10 +337,11 @@ async function refreshRegistry(
         err instanceof Error ? err.message : err
       );
     }
-  })();
+  });
 
-  pendingRefreshes.set(registryConfig.url, crawlPromise);
   try {
+    pendingRefreshes.set(registryConfig.url, crawlPromise);
+    startCrawl();
     await crawlPromise;
   } finally {
     pendingRefreshes.delete(registryConfig.url);
@@ -390,7 +391,13 @@ export async function getLibraries(
   return { ...mergedRegistryLibraries, ...staticLibraries };
 }
 
-/** Clears all in-memory registry caches. Intended for use in tests only. */
+/**
+ * Clears all in-memory registry caches. Intended for use in tests only.
+ *
+ * Note: clearing pendingRefreshes while a crawl is still in-progress will
+ * cause the next caller to start a new crawl rather than await the original.
+ * Avoid calling this mid-flight in tests that have already kicked off a crawl.
+ */
 export function resetRegistryCaches(): void {
   registryCaches.clear();
   pendingRefreshes.clear();

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -52,6 +52,17 @@ interface CrawlResult {
  */
 const registryCaches = new Map<string, RegistryState>();
 
+/*
+ * Tracks crawls that are currently in-progress. Used to coalesce concurrent
+ * requests: if a crawl for a URL is already running, latecomers await the
+ * same promise rather than returning an empty cache immediately. Without this,
+ * the Next.js ISR fallback can fire two simultaneous getStaticProps calls —
+ * the first starts the crawl (setting lastAttemptedFetch), and the second
+ * sees lastAttemptedFetch within minInterval, skips the refresh, and returns
+ * an empty library list, causing a spurious 404 on the very first page load.
+ */
+const pendingRefreshes = new Map<string, Promise<void>>();
+
 const emptyState: RegistryState = {
   libraries: {},
   lastSuccessfulFetch: null,
@@ -240,11 +251,23 @@ export async function fetchRegistryLibraries(
  * requests arriving during the async crawl see the in-progress attempt and
  * skip the duplicate. Errors are logged and swallowed; the existing cached
  * state is retained.
+ *
+ * If a crawl for this URL is already in-progress (tracked in pendingRefreshes),
+ * this function awaits that crawl instead of starting a new one. This prevents
+ * the race where a concurrent request skips the refresh (because
+ * lastAttemptedFetch is set) and reads an empty cache before the first crawl
+ * has completed.
  */
 async function refreshRegistry(
   registryConfig: RegistryConfig,
   nowSeconds: number
 ): Promise<void> {
+  const pending = pendingRefreshes.get(registryConfig.url);
+  if (pending) {
+    await pending;
+    return;
+  }
+
   const isFirstFetch = !registryCaches.has(registryConfig.url);
   const existing = registryCaches.get(registryConfig.url) ?? emptyState;
 
@@ -274,40 +297,53 @@ async function refreshRegistry(
     lastAttemptedFetch: attemptTime
   });
 
-  try {
-    const result = await crawlRegistryFeed(startUrl, stopBefore, timeoutMs);
+  // Wrap the crawl in a named promise so concurrent callers can await it.
+  // All synchronous setup above runs before the first await, so
+  // pendingRefreshes is populated before the event loop can schedule another
+  // call to this function.
+  const crawlPromise = (async () => {
+    try {
+      const result = await crawlRegistryFeed(startUrl, stopBefore, timeoutMs);
 
-    if (isFirstFetch && result.incrementalUrl == null) {
-      console.warn(
-        `Registry at ${registryConfig.url} has no order=modified facet; ` +
-          `incremental fetching is not supported. Full crawls will run every refresh.`
+      if (isFirstFetch && result.incrementalUrl == null) {
+        console.warn(
+          `Registry at ${registryConfig.url} has no order=modified facet; ` +
+            `incremental fetching is not supported. Full crawls will run every refresh.`
+        );
+      }
+
+      /*
+       * reachedEnd = true: complete view observed (full crawl or incremental
+       * that reached the last page). Replace the cache entirely so deleted
+       * libraries are removed.
+       *
+       * reachedEnd = false: partial view. Overlay new/updated entries onto the
+       * existing cache; unvisited entries are preserved.
+       */
+      const mergedLibraries = result.reachedEnd
+        ? result.libraries
+        : { ...existing.libraries, ...result.libraries };
+
+      registryCaches.set(registryConfig.url, {
+        libraries: mergedLibraries,
+        lastSuccessfulFetch: attemptTime,
+        lastAttemptedFetch: attemptTime,
+        lastFullFetch: result.reachedEnd ? attemptTime : existing.lastFullFetch,
+        incrementalUrl: result.incrementalUrl ?? existing.incrementalUrl
+      });
+    } catch (err) {
+      console.error(
+        `Failed to refresh registry ${registryConfig.url}:`,
+        err instanceof Error ? err.message : err
       );
     }
+  })();
 
-    /*
-     * reachedEnd = true: complete view observed (full crawl or incremental
-     * that reached the last page). Replace the cache entirely so deleted
-     * libraries are removed.
-     *
-     * reachedEnd = false: partial view. Overlay new/updated entries onto the
-     * existing cache; unvisited entries are preserved.
-     */
-    const mergedLibraries = result.reachedEnd
-      ? result.libraries
-      : { ...existing.libraries, ...result.libraries };
-
-    registryCaches.set(registryConfig.url, {
-      libraries: mergedLibraries,
-      lastSuccessfulFetch: attemptTime,
-      lastAttemptedFetch: attemptTime,
-      lastFullFetch: result.reachedEnd ? attemptTime : existing.lastFullFetch,
-      incrementalUrl: result.incrementalUrl ?? existing.incrementalUrl
-    });
-  } catch (err) {
-    console.error(
-      `Failed to refresh registry ${registryConfig.url}:`,
-      err instanceof Error ? err.message : err
-    );
+  pendingRefreshes.set(registryConfig.url, crawlPromise);
+  try {
+    await crawlPromise;
+  } finally {
+    pendingRefreshes.delete(registryConfig.url);
   }
 }
 
@@ -357,4 +393,5 @@ export async function getLibraries(
 /** Clears all in-memory registry caches. Intended for use in tests only. */
 export function resetRegistryCaches(): void {
   registryCaches.clear();
+  pendingRefreshes.clear();
 }


### PR DESCRIPTION
## Description

Fixes a registry cache race condition by tracking the in-progress crawl instead of returning an empty cache immediately. Duplicate overlapping calls now await the in-progress call.

## Motivation and Context

After `npm run build && npm run start` (I did not see this bug with `npm run dev`), the first navigation to a registry-sourced library page intermittently returned a 404 ("No authentication document url is configured"). A subsequent visit would succeed.

ISR was firing two near-simultaneous `getStaticProps` calls on a cold page load. The first call set `lastAttemptedFetch` synchronously before its async crawl completed. The second call hit the `shouldRefresh` min-interval guard, returned immediately with an empty cache, and caused the 404. The error page would set revalidation, so subsequent visits worked once the first crawl had finished.

The fix tracks in-progress crawl promises, so subsequent requests await the active crawl rather than bailing early.

[Jira PP-4102]

## How Has This Been Tested?

- Manual local testing with both `npm run build-and-start` and `npm run dev`.
- New tests (happy path, failure path) specifically for that condition. Happy path test failed against the pre-fix code.
- All checks pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/24567733387) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.