### PR TITLE
[PP-4097] Add JIRA release sync workflow to CI.

### DIFF
--- a/.github/workflows/jira-release-sync.yml
+++ b/.github/workflows/jira-release-sync.yml
@@ -1,0 +1,21 @@
+name: Jira Release Sync
+on:
+  release:
+    types: [published]
+jobs:
+  sync-to-jira:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync release to Jira
+        uses: ThePalaceProject/circulation/.github/actions/jira-release-sync@main
+        with:
+          jira-base-url: ${{ secrets.JIRA_BASE_URL }}
+          jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}
+          jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
+
+          release-name: "Admin UI ${{ github.event.release.tag_name }}"
+          release-url: ${{ github.event.release.html_url }}
+          release-body: ${{ github.event.release.body }}

--- a/.github/workflows/jira-release-sync.yml
+++ b/.github/workflows/jira-release-sync.yml
@@ -16,6 +16,6 @@ jobs:
           jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}
           jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
 
-          release-name: "Admin UI ${{ github.event.release.tag_name }}"
+          release-name: "CPW ${{ github.event.release.tag_name }}"
           release-url: ${{ github.event.release.html_url }}
           release-body: ${{ github.event.release.body }}


### PR DESCRIPTION
## Description

Adds the JIRA Sync release plugin to ci workflows.   The workflow is triggered by a github release "published" event. 

## Motivation and Context
David has requested that we automate the creation of a JIRA release and tagging of associated tickets with the github release tag when we publish new web-patron releases.

[[Jira PP-4097]](https://ebce-lyrasis.atlassian.net/browse/PP-4097)

## How Has This Been Tested?
I created a tag and published associated release (on the last commit in this PR). You can see it created the release as expected in JIRA here: https://ebce-lyrasis.atlassian.net/projects/PP/versions/13189/tab/release-report-all-issues
Here's the published github release here: https://github.com/ThePalaceProject/web-patron/releases/tag/test-release-2
## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
