### PR TITLE
Add runtime config module with ArkType validation (PP-4124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ __To have your library added to the demo, register it with NYPL's Library Regist
   <!-- * [Demo](#community-demo) -->
 - [Configuring the App](#configuring-the-app)
   - [Configuration File](#configuration-file)
+    - [Configuration Options](#configuration-options)
+    - [Media Support](#media-support)
   - [Environment Variables](#environment-variables)
   - [Manager, Registry, and Application Configurations](#manager--registry--and-application-configurations)
   - [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings)
@@ -65,9 +67,30 @@ __To have your library added to the demo, register it with NYPL's Library Regist
 
 ## Configuration File
 
-To deploy the application, there are a few configuration variables that need to be set up. Most notably, the app needs to know what libraries to support and the url for each library's Circulation Manager backend. This is called the authentication document url, and each library the app runs has a unique authentication document url. Additionally, the app needs to know which media formats to support, and how. Finally, there are a few other variables that can be configured.
+The app is configured with a YAML file. Point the app at it by setting the `CONFIG_FILE` environment variable to a local path or HTTP(S) URL. `./community-config.yml` is a fully-annotated example covering all options.
 
-The production configuration is defined in a YAML config file. You can find more details on the options in the `./community-config.yml` file. To run the app, you must tell it where to find the config file. This is done via the `CONFIG_FILE` environment variable. If you don't set anything, the sample config is used. See [environment variables](#environment-variables) below for more information.
+### Configuration Options
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `instance_name` | string | `"Patron Web Catalog"` | Name used in error tracking and debug output. Not patron-facing. |
+| `companion_app` | `"simplye"` \| `"openebooks"` | `"simplye"` | Selects which companion mobile app to reference in redirect prompts. |
+| `show_medium` | boolean | `true` | Whether to display the medium (e-book, audiobook, etc.) label on book cards. |
+| `bugsnag_api_key` | string | — | Bugsnag project API key. Omit to disable error tracking. |
+| `gtmId` | string | — | Google Tag Manager container ID (e.g. `GTM-XXXX`). Omit to disable analytics. |
+| `media_support` | mapping | `{}` | Per-MIME-type rendering mode. See [Media Support](#media-support) below. |
+| `libraries` | mapping or string | — | Static library definitions, or a deprecated registry URL string. See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
+| `registries` | list | `[]` | One or more library registry URLs fetched at runtime. See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
+
+### Media Support
+
+Each entry in `media_support` maps a MIME type to one of three rendering modes:
+
+- **`show`** — Read the book in the web app.
+- **`redirect`** — Display a prompt directing the patron to the companion mobile app.
+- **`redirect-and-show`** — Offer both options.
+
+Any MIME type not listed is treated as unsupported and hidden from patrons. See `community-config.yml` for a full list of common types and their recommended settings.
 
 ## Environment Variables
 

--- a/jest.config.node.js
+++ b/jest.config.node.js
@@ -19,6 +19,8 @@ module.exports = {
     "**/server/**/?(*.)+(spec|test).[tj]s?(x)"
   ],
   testPathIgnorePatterns: ["/node_modules/", "/.next/"],
+  // arktype and its ark*/@ark/* dependencies ship as ESM and must be transformed.
+  transformIgnorePatterns: ["/node_modules/(?!(arktype|arkregex|@ark)/)"],
   // No setup files for Node.js tests - these are browser-specific
   setupFiles: [],
   setupFilesAfterEnv: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@theme-ui/match-media": "^0.17.2",
         "@theme-ui/mdx": "^0.17.2",
         "@thepalaceproject/webpub-viewer": "^0.1.0",
+        "arktype": "^2.2.0",
         "chalk": "^4.1.0",
         "date-fns": "^4.1.0",
         "deepmerge": "^4.2.2",
@@ -146,6 +147,21 @@
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@ark/schema": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@ark/schema/-/schema-0.56.0.tgz",
+      "integrity": "sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ark/util": "0.56.0"
+      }
+    },
+    "node_modules/@ark/util": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@ark/util/-/util-0.56.0.tgz",
+      "integrity": "sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==",
+      "license": "MIT"
+    },
     "node_modules/@axe-core/react": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.11.1.tgz",
@@ -187,6 +203,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -981,6 +998,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1059,7 +1077,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1077,7 +1094,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1095,7 +1111,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1113,7 +1128,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1131,7 +1145,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1149,7 +1162,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1167,7 +1179,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1185,7 +1196,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1203,7 +1213,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1221,7 +1230,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1239,7 +1247,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1257,7 +1264,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1275,7 +1281,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1293,7 +1298,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1311,7 +1315,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1329,7 +1332,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1347,7 +1349,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1365,7 +1366,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1383,7 +1383,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1401,7 +1400,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1419,7 +1417,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1437,7 +1434,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1455,7 +1451,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1473,7 +1468,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1491,7 +1485,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1509,7 +1502,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1710,6 +1702,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -2951,7 +2944,6 @@
       "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -2962,7 +2954,6 @@
       "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/fake-timers": "30.3.0",
         "@jest/types": "30.3.0",
@@ -2979,7 +2970,6 @@
       "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expect": "30.3.0",
         "jest-snapshot": "30.3.0"
@@ -2994,7 +2984,6 @@
       "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0"
       },
@@ -3008,7 +2997,6 @@
       "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "@sinonjs/fake-timers": "^15.0.0",
@@ -3027,7 +3015,6 @@
       "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -3055,7 +3042,6 @@
       "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "jest-regex-util": "30.0.1"
@@ -3318,7 +3304,6 @@
       "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -3332,7 +3317,6 @@
       "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "chalk": "^4.1.2",
@@ -3543,7 +3527,6 @@
       "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -3593,7 +3576,6 @@
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -3951,8 +3933,7 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
       "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -3970,7 +3951,6 @@
       "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
@@ -4266,7 +4246,6 @@
       "integrity": "sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/theming": "8.6.18",
         "better-opn": "^3.0.2",
@@ -4299,7 +4278,6 @@
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4313,7 +4291,6 @@
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4644,6 +4621,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4776,6 +4754,7 @@
       "resolved": "https://registry.npmjs.org/@theme-ui/core/-/core-0.17.4.tgz",
       "integrity": "sha512-Thi46ulVpTbsU+DafydCrt6AftWvG+NicsA62MasObd0sbrfPPZVjuZdEt6yNDwzWXaI2UjNmJa8G4Uty+ALrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@theme-ui/css": "^0.17.4",
         "deepmerge": "^4.2.2"
@@ -4790,6 +4769,7 @@
       "resolved": "https://registry.npmjs.org/@theme-ui/css/-/css-0.17.4.tgz",
       "integrity": "sha512-lyitzWdqszEK+T76ad4XUYQM+UCUadeFqMsjjKB8E461oQHxCKuV7fY/SRJr6hP/Zxk/mAEQnwNp2wjc0z8OIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.10"
       },
@@ -4842,6 +4822,7 @@
       "resolved": "https://registry.npmjs.org/@theme-ui/theme-provider/-/theme-provider-0.17.4.tgz",
       "integrity": "sha512-A79XVNdkyLydTZFFsheWDsjOW16dSOAFhbByrJfM/9Y+4iJoaoQfFJ3IoCUvS7dBYgwTiPOBiEyeBgpDDTyclw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@theme-ui/color-modes": "^0.17.4",
         "@theme-ui/core": "^0.17.4",
@@ -4959,7 +4940,6 @@
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -4970,8 +4950,7 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/glob-to-regexp": {
       "version": "0.4.4",
@@ -5127,7 +5106,8 @@
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -5177,6 +5157,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5188,6 +5169,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5335,6 +5317,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -5559,7 +5542,6 @@
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -5570,24 +5552,21 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
@@ -5595,7 +5574,6 @@
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -5607,8 +5585,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
@@ -5616,7 +5593,6 @@
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5630,7 +5606,6 @@
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -5641,7 +5616,6 @@
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -5651,8 +5625,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
@@ -5660,7 +5633,6 @@
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5678,7 +5650,6 @@
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -5693,7 +5664,6 @@
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5707,7 +5677,6 @@
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -5723,7 +5692,6 @@
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -5734,16 +5702,14 @@
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -5757,6 +5723,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5792,7 +5759,6 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -5851,6 +5817,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5868,7 +5835,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -5887,7 +5853,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5904,8 +5869,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -6034,6 +5998,26 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/arkregex": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/arkregex/-/arkregex-0.0.5.tgz",
+      "integrity": "sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ark/util": "0.56.0"
+      }
+    },
+    "node_modules/arktype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arktype/-/arktype-2.2.0.tgz",
+      "integrity": "sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ark/schema": "0.56.0",
+        "@ark/util": "0.56.0",
+        "arkregex": "0.0.5"
       }
     },
     "node_modules/array-back": {
@@ -6220,7 +6204,6 @@
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -6538,7 +6521,6 @@
       "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "open": "^8.0.4"
       },
@@ -6600,8 +6582,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -6629,6 +6610,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7022,7 +7004,6 @@
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -7703,6 +7684,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.6",
         "@cypress/xvfb": "^1.2.4",
@@ -8031,7 +8013,6 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8251,7 +8232,6 @@
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.0"
@@ -8266,6 +8246,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -8426,8 +8407,7 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -8536,7 +8516,6 @@
       "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -8604,6 +8583,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8660,6 +8640,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9121,7 +9102,6 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -9178,7 +9158,6 @@
       "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/expect-utils": "30.3.0",
         "@jest/get-type": "30.1.0",
@@ -9286,8 +9265,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -10341,7 +10319,6 @@
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -10499,7 +10476,6 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -10893,7 +10869,6 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -11081,6 +11056,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -13450,7 +13426,6 @@
       "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
@@ -13467,7 +13442,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13481,7 +13455,6 @@
       "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.3.0",
         "@jest/get-type": "30.1.0",
@@ -13498,7 +13471,6 @@
       "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -13514,7 +13486,6 @@
       "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@jest/types": "30.3.0",
@@ -13536,7 +13507,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13550,7 +13520,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13564,7 +13533,6 @@
       "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -13580,7 +13548,6 @@
       "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "@types/node": "*",
@@ -13614,7 +13581,6 @@
       "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -14617,7 +14583,6 @@
       "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
@@ -14651,7 +14616,6 @@
       "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.3.0",
@@ -14678,7 +14642,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -14692,7 +14655,6 @@
       "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "workspaces": [
         "test/babel-8"
       ],
@@ -14713,7 +14675,6 @@
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.23.9",
         "@babel/parser": "^7.23.9",
@@ -14731,7 +14692,6 @@
       "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/diff-sequences": "30.3.0",
         "@jest/get-type": "30.1.0",
@@ -14748,7 +14708,6 @@
       "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "@types/node": "*",
@@ -14774,7 +14733,6 @@
       "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
@@ -14792,7 +14750,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14806,7 +14763,6 @@
       "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
@@ -14822,7 +14778,6 @@
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -14836,7 +14791,6 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -14850,7 +14804,6 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -14867,7 +14820,6 @@
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -14882,7 +14834,6 @@
       "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.3.0",
         "@types/node": "*",
@@ -14901,7 +14852,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15279,7 +15229,6 @@
       "integrity": "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -15629,7 +15578,6 @@
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -16181,8 +16129,7 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/next": {
       "version": "15.5.15",
@@ -16510,7 +16457,6 @@
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -17009,6 +16955,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -17257,6 +17204,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -17269,6 +17217,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17501,7 +17450,6 @@
       "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
@@ -17519,7 +17467,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17644,7 +17591,6 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18956,7 +18902,6 @@
       "integrity": "sha512-b+u3CEM6FjDHru+nhUSjDofpWSBp2rINziJWgApm72wwGasQ/wKXftZe4tI2Y5HPv6OpzXSZHOFq87H4vfsgsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -18971,7 +18916,6 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -18991,7 +18935,6 @@
       "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -19044,7 +18987,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -19058,7 +19000,6 @@
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -19073,8 +19014,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
       "version": "4.3.3",
@@ -19082,7 +19022,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -19103,7 +19042,6 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -19119,8 +19057,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/terser/node_modules/source-map": {
       "version": "0.6.1",
@@ -19128,7 +19065,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19139,7 +19075,6 @@
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -19359,6 +19294,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19647,6 +19583,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19815,7 +19752,6 @@
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -19930,7 +19866,6 @@
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -20070,7 +20005,6 @@
       "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -20106,7 +20040,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -20120,7 +20053,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -20135,7 +20067,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -20145,8 +20076,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
@@ -20154,7 +20084,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -20638,6 +20567,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@theme-ui/match-media": "^0.17.2",
     "@theme-ui/mdx": "^0.17.2",
     "@thepalaceproject/webpub-viewer": "^0.1.0",
+    "arktype": "^2.2.0",
     "chalk": "^4.1.0",
     "date-fns": "^4.1.0",
     "deepmerge": "^4.2.2",

--- a/src/components/context/AppConfigContext.tsx
+++ b/src/components/context/AppConfigContext.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import type { AppConfig } from "interfaces";
+
+const AppConfigContext = React.createContext<AppConfig | undefined>(undefined);
+
+export function useAppConfig(): AppConfig {
+  const context = React.useContext(AppConfigContext);
+  if (context === undefined) {
+    throw new Error(
+      "useAppConfig must be used within an AppConfigContext.Provider"
+    );
+  }
+  return context;
+}
+
+export default AppConfigContext;

--- a/src/components/context/__tests__/AppConfigContext.test.tsx
+++ b/src/components/context/__tests__/AppConfigContext.test.tsx
@@ -1,0 +1,59 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test
+} from "@jest/globals";
+import * as React from "react";
+import { renderHook } from "@testing-library/react";
+import AppConfigContext, { useAppConfig } from "../AppConfigContext";
+import { fixtures } from "test-utils";
+import type { AppConfig } from "interfaces";
+
+const withProvider =
+  (config: AppConfig) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <AppConfigContext.Provider value={config}>
+      {children}
+    </AppConfigContext.Provider>
+  );
+
+describe("useAppConfig", () => {
+  test("returns the config supplied by the nearest Provider", () => {
+    const { result } = renderHook(() => useAppConfig(), {
+      wrapper: withProvider(fixtures.config)
+    });
+    expect(result.current).toBe(fixtures.config);
+  });
+
+  describe("when used outside a Provider", () => {
+    beforeEach(() => {
+      jest.spyOn(console, "error").mockImplementation(() => undefined);
+    });
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    test("throws with an explanatory message", () => {
+      expect(() => renderHook(() => useAppConfig())).toThrow(
+        "useAppConfig must be used within an AppConfigContext.Provider"
+      );
+    });
+  });
+
+  test.each<[string, Partial<AppConfig>]>([
+    ["instanceName", { instanceName: "Custom Library" }],
+    ["gtmId", { gtmId: "GTM-XXXX" }],
+    ["bugsnagApiKey", { bugsnagApiKey: "abc123" }],
+    ["companionApp", { companionApp: "openebooks" }],
+    ["showMedium", { showMedium: false }]
+  ])("passes the %s field through unchanged", (_field, override) => {
+    const config = { ...fixtures.config, ...override };
+    const { result } = renderHook(() => useAppConfig(), {
+      wrapper: withProvider(config)
+    });
+    expect(result.current).toMatchObject(override);
+  });
+});

--- a/src/config/__tests__/fallbackAppConfig.test.ts
+++ b/src/config/__tests__/fallbackAppConfig.test.ts
@@ -1,0 +1,20 @@
+import FALLBACK_APP_CONFIG from "config/fallbackAppConfig";
+
+describe("FALLBACK_APP_CONFIG", () => {
+  test.each([
+    ["instanceName", ""],
+    ["companionApp", "simplye"],
+    ["showMedium", true],
+    ["gtmId", null],
+    ["bugsnagApiKey", null],
+    ["openebooks", null]
+  ])("%s defaults to %p", (field, expected) => {
+    expect(FALLBACK_APP_CONFIG[field as keyof typeof FALLBACK_APP_CONFIG]).toBe(
+      expected
+    );
+  });
+
+  test("mediaSupport defaults to empty object", () => {
+    expect(FALLBACK_APP_CONFIG.mediaSupport).toEqual({});
+  });
+});

--- a/src/config/fallbackAppConfig.ts
+++ b/src/config/fallbackAppConfig.ts
@@ -1,0 +1,13 @@
+import type { AppConfig } from "interfaces";
+
+const FALLBACK_APP_CONFIG: AppConfig = {
+  instanceName: "",
+  mediaSupport: {},
+  companionApp: "simplye",
+  showMedium: true,
+  gtmId: null,
+  bugsnagApiKey: null,
+  openebooks: null
+};
+
+export default FALLBACK_APP_CONFIG;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,6 +20,7 @@ export type AppConfig = {
   instanceName: string;
   mediaSupport: MediaSupportConfig;
   registries?: RegistryConfig[];
+  staticLibraries?: LibrariesConfig;
   companionApp: "simplye" | "openebooks";
   showMedium: boolean;
   gtmId: string | null;

--- a/src/server/__tests__/appConfig.test.ts
+++ b/src/server/__tests__/appConfig.test.ts
@@ -96,6 +96,21 @@ describe("getAppConfig", () => {
     expect(config.instanceName).toBe("My Catalog");
   });
 
+  // --- YAML structure ---
+
+  it.each([
+    ["null", "~"],
+    ["a bare scalar", "just a string"],
+    ["a sequence", "- item1\n- item2"]
+  ])(
+    "throws AppSetupError when the config file is %s rather than a mapping",
+    async (_label, yaml) => {
+      process.env.CONFIG_FILE = "/etc/app/config.yml";
+      mockFile(yaml);
+      await expect(getAppConfig()).rejects.toThrow(AppSetupError);
+    }
+  );
+
   // --- HTTP URL ---
 
   it("fetches config from an http URL", async () => {
@@ -140,6 +155,15 @@ describe("getAppConfig", () => {
     global.fetch = mockFetchText("", false, 503) as unknown as typeof fetch;
 
     await expect(getAppConfig()).rejects.toThrow(AppSetupError);
+  });
+
+  it("includes a non-Error rejection value in the error message", async () => {
+    process.env.CONFIG_FILE = "https://example.com/config.yml";
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue("network failure") as unknown as typeof fetch;
+
+    await expect(getAppConfig()).rejects.toThrow("network failure");
   });
 
   // --- Fetch timeout ---
@@ -436,6 +460,34 @@ describe("config parsing", () => {
       expect((await load(yaml)).mediaSupport).toEqual({
         "application/epub+zip": "show"
       });
+    });
+
+    it.each(["show", "redirect", "redirect-and-show", "unsupported"])(
+      "accepts the valid value '%s'",
+      async level => {
+        const yaml = `media_support:\n  application/epub+zip: ${level}`;
+        await expect(load(yaml)).resolves.not.toThrow();
+      }
+    );
+
+    it("throws AppSetupError for an unrecognized value", async () => {
+      await expect(
+        load(`media_support:\n  application/epub+zip: invalid-mode`)
+      ).rejects.toThrow(AppSetupError);
+    });
+
+    it("error message names the MIME type and the bad value", async () => {
+      await expect(
+        load(`media_support:\n  application/epub+zip: invalid-mode`)
+      ).rejects.toThrow(
+        `CONFIG_FILE.media_support['application/epub+zip'] has unrecognized value "invalid-mode"`
+      );
+    });
+
+    it("error message lists all valid values", async () => {
+      await expect(
+        load(`media_support:\n  application/epub+zip: invalid-mode`)
+      ).rejects.toThrow("show, redirect, redirect-and-show, unsupported");
     });
   });
 

--- a/src/server/__tests__/appConfig.test.ts
+++ b/src/server/__tests__/appConfig.test.ts
@@ -1,0 +1,555 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for src/server/appConfig.ts.
+ */
+
+import path from "path";
+import type { AppConfig } from "interfaces";
+import { getAppConfig, resetAppConfigCache } from "../appConfig";
+import { AppSetupError } from "errors";
+import { DEFAULT_REGISTRY_FETCH_TIMEOUT } from "constants/registry";
+
+jest.mock("fs", () => ({ readFileSync: jest.fn() }));
+
+import { readFileSync } from "fs";
+
+const mockReadFileSync = readFileSync as jest.Mock;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MINIMAL_YAML = `instance_name: Test Library`;
+
+function mockFile(yaml: string): void {
+  mockReadFileSync.mockReturnValue(yaml);
+}
+
+function mockFetchText(text: string, ok = true, status = 200): jest.Mock {
+  return jest.fn().mockResolvedValue({
+    ok,
+    status,
+    text: async () => text
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Global setup — runs before every test in this file.
+// ---------------------------------------------------------------------------
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  resetAppConfigCache();
+  process.env = { ...originalEnv };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+// ---------------------------------------------------------------------------
+// getAppConfig — environment and I/O behaviour
+// ---------------------------------------------------------------------------
+
+describe("getAppConfig", () => {
+  it("throws AppSetupError when CONFIG_FILE is not set", async () => {
+    delete process.env.CONFIG_FILE;
+    await expect(getAppConfig()).rejects.toThrow(AppSetupError);
+  });
+
+  it("error message mentions CONFIG_FILE when env var is missing", async () => {
+    delete process.env.CONFIG_FILE;
+    await expect(getAppConfig()).rejects.toThrow("CONFIG_FILE");
+  });
+
+  // --- Local file ---
+
+  it("reads an absolute file path directly", async () => {
+    process.env.CONFIG_FILE = "/etc/app/config.yml";
+    mockFile(MINIMAL_YAML);
+
+    await getAppConfig();
+    expect(mockReadFileSync).toHaveBeenCalledWith(
+      "/etc/app/config.yml",
+      "utf8"
+    );
+  });
+
+  it("resolves a relative path against process.cwd()", async () => {
+    process.env.CONFIG_FILE = "config/app.yml";
+    mockFile(MINIMAL_YAML);
+
+    await getAppConfig();
+    expect(mockReadFileSync).toHaveBeenCalledWith(
+      path.join(process.cwd(), "config/app.yml"),
+      "utf8"
+    );
+  });
+
+  it("returns a parsed config from a local file", async () => {
+    process.env.CONFIG_FILE = "/etc/app/config.yml";
+    mockFile(`instance_name: My Catalog`);
+
+    const config = await getAppConfig();
+    expect(config.instanceName).toBe("My Catalog");
+  });
+
+  // --- HTTP URL ---
+
+  it("fetches config from an http URL", async () => {
+    process.env.CONFIG_FILE = "http://example.com/config.yml";
+    global.fetch = mockFetchText(MINIMAL_YAML) as unknown as typeof fetch;
+
+    await getAppConfig();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://example.com/config.yml",
+      expect.any(Object)
+    );
+  });
+
+  it("fetches config from an https URL", async () => {
+    process.env.CONFIG_FILE = "https://example.com/config.yml";
+    global.fetch = mockFetchText(MINIMAL_YAML) as unknown as typeof fetch;
+
+    const config = await getAppConfig();
+    expect(config.instanceName).toBe("Test Library");
+  });
+
+  it("passes an AbortSignal to fetch", async () => {
+    process.env.CONFIG_FILE = "https://example.com/config.yml";
+    let capturedSignal: AbortSignal | undefined;
+    global.fetch = jest
+      .fn()
+      .mockImplementation((_url: string, init: RequestInit) => {
+        capturedSignal = init?.signal as AbortSignal;
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: async () => MINIMAL_YAML
+        });
+      }) as unknown as typeof fetch;
+
+    await getAppConfig();
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("throws AppSetupError when the HTTP response is not ok", async () => {
+    process.env.CONFIG_FILE = "https://example.com/config.yml";
+    global.fetch = mockFetchText("", false, 503) as unknown as typeof fetch;
+
+    await expect(getAppConfig()).rejects.toThrow(AppSetupError);
+  });
+
+  // --- Fetch timeout ---
+
+  describe("fetch timeout", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.restoreAllMocks();
+    });
+
+    it("aborts a hung fetch after DEFAULT_REGISTRY_FETCH_TIMEOUT seconds", async () => {
+      jest.useFakeTimers();
+      process.env.CONFIG_FILE = "https://example.com/config.yml";
+      let capturedSignal: AbortSignal | undefined;
+      global.fetch = jest
+        .fn()
+        .mockImplementation((_url: string, init: RequestInit) => {
+          capturedSignal = init?.signal as AbortSignal;
+          return new Promise<never>((_resolve, reject) => {
+            capturedSignal?.addEventListener("abort", () =>
+              reject(new DOMException("aborted", "AbortError"))
+            );
+          });
+        }) as unknown as typeof fetch;
+
+      const configPromise = getAppConfig();
+      const assertion = expect(configPromise).rejects.toThrow();
+      await (jest as any).advanceTimersByTimeAsync(
+        DEFAULT_REGISTRY_FETCH_TIMEOUT * 1000 + 1
+      );
+      await assertion;
+
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it("clears the fetch timeout after a successful response", async () => {
+      jest.useFakeTimers();
+      process.env.CONFIG_FILE = "https://example.com/config.yml";
+      global.fetch = mockFetchText(MINIMAL_YAML) as unknown as typeof fetch;
+
+      await getAppConfig();
+      expect(jest.getTimerCount()).toBe(0);
+    });
+  });
+
+  // --- Caching ---
+
+  it("returns the same object reference on repeated calls", async () => {
+    process.env.CONFIG_FILE = "/etc/app/config.yml";
+    mockFile(MINIMAL_YAML);
+
+    const first = await getAppConfig();
+    const second = await getAppConfig();
+
+    expect(first).toBe(second);
+    expect(mockReadFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-reads the file after resetAppConfigCache()", async () => {
+    process.env.CONFIG_FILE = "/etc/app/config.yml";
+    mockFile(`instance_name: First`);
+    await getAppConfig();
+
+    resetAppConfigCache();
+    mockFile(`instance_name: Second`);
+
+    const config = await getAppConfig();
+    expect(config.instanceName).toBe("Second");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config parsing — tested via getAppConfig with a local file mock.
+// ---------------------------------------------------------------------------
+
+describe("config parsing", () => {
+  beforeEach(() => {
+    process.env.CONFIG_FILE = "/test/config.yml";
+  });
+
+  async function load(yaml: string): Promise<AppConfig> {
+    mockFile(yaml);
+    return getAppConfig();
+  }
+
+  // --- instanceName ---
+
+  describe("instanceName", () => {
+    it("uses instance_name when it is a string", async () => {
+      expect((await load(`instance_name: My Library`)).instanceName).toBe(
+        "My Library"
+      );
+    });
+
+    it("defaults to 'Patron Web Catalog' when instance_name is absent", async () => {
+      expect((await load(`other: value`)).instanceName).toBe(
+        "Patron Web Catalog"
+      );
+    });
+
+    it("defaults to 'Patron Web Catalog' when instance_name is not a string", async () => {
+      expect((await load(`instance_name: 42`)).instanceName).toBe(
+        "Patron Web Catalog"
+      );
+    });
+  });
+
+  // --- companionApp ---
+
+  describe("companionApp", () => {
+    it("is 'openebooks' when companion_app is 'openebooks'", async () => {
+      expect((await load(`companion_app: openebooks`)).companionApp).toBe(
+        "openebooks"
+      );
+    });
+
+    it("defaults to 'simplye' when companion_app is absent", async () => {
+      expect((await load(MINIMAL_YAML)).companionApp).toBe("simplye");
+    });
+
+    it("is 'simplye' for unrecognized companion_app values", async () => {
+      expect((await load(`companion_app: other`)).companionApp).toBe("simplye");
+    });
+  });
+
+  // --- showMedium ---
+
+  describe("showMedium", () => {
+    it("defaults to true when show_medium is absent", async () => {
+      expect((await load(MINIMAL_YAML)).showMedium).toBe(true);
+    });
+
+    it("is false when show_medium is false", async () => {
+      expect((await load(`show_medium: false`)).showMedium).toBe(false);
+    });
+
+    it("is true when show_medium is true", async () => {
+      expect((await load(`show_medium: true`)).showMedium).toBe(true);
+    });
+  });
+
+  // --- openebooks ---
+
+  describe("openebooks", () => {
+    it("is null when openebooks section is absent", async () => {
+      expect((await load(MINIMAL_YAML)).openebooks).toBeNull();
+    });
+
+    it("parses openebooks.default_library into defaultLibrary", async () => {
+      const yaml = "openebooks:\n  default_library: nyc-lib";
+      expect((await load(yaml)).openebooks).toEqual({
+        defaultLibrary: "nyc-lib"
+      });
+    });
+  });
+
+  // --- bugsnagApiKey ---
+
+  describe("bugsnagApiKey", () => {
+    it("is null when absent", async () => {
+      expect((await load(MINIMAL_YAML)).bugsnagApiKey).toBeNull();
+    });
+
+    it("uses the string value of bugsnag_api_key", async () => {
+      expect((await load(`bugsnag_api_key: abc123`)).bugsnagApiKey).toBe(
+        "abc123"
+      );
+    });
+  });
+
+  // --- gtmId ---
+
+  describe("gtmId", () => {
+    it("is null when absent", async () => {
+      expect((await load(MINIMAL_YAML)).gtmId).toBeNull();
+    });
+
+    it("uses the string value of gtmId", async () => {
+      expect((await load(`gtmId: GTM-XXXX`)).gtmId).toBe("GTM-XXXX");
+    });
+  });
+
+  // --- registries ---
+
+  describe("registries", () => {
+    it("defaults to an empty array when registries is absent", async () => {
+      expect((await load(MINIMAL_YAML)).registries).toEqual([]);
+    });
+
+    it("parses a single registry with default intervals", async () => {
+      const yaml = "registries:\n  - url: https://reg.example.com/";
+      expect((await load(yaml)).registries).toEqual([
+        {
+          url: "https://reg.example.com/",
+          refreshMinInterval: 60,
+          refreshMaxInterval: 300
+        }
+      ]);
+    });
+
+    it("parses multiple registries", async () => {
+      const yaml = [
+        "registries:",
+        "  - url: https://reg1.example.com/",
+        "  - url: https://reg2.example.com/"
+      ].join("\n");
+      expect((await load(yaml)).registries).toHaveLength(2);
+    });
+
+    it("uses custom refreshMinInterval and refreshMaxInterval when provided", async () => {
+      const yaml = [
+        "registries:",
+        "  - url: https://reg.example.com/",
+        "    refreshMinInterval: 30",
+        "    refreshMaxInterval: 600"
+      ].join("\n");
+      expect((await load(yaml)).registries).toMatchObject([
+        { refreshMinInterval: 30, refreshMaxInterval: 600 }
+      ]);
+    });
+
+    it("throws AppSetupError when registries is not an array", async () => {
+      await expect(load(`registries: not-an-array`)).rejects.toThrow(
+        AppSetupError
+      );
+    });
+
+    it("throws AppSetupError when a registry entry is not an object", async () => {
+      await expect(load("registries:\n  - just-a-string")).rejects.toThrow(
+        AppSetupError
+      );
+    });
+
+    it("throws AppSetupError when a registry entry is missing url", async () => {
+      await expect(load("registries:\n  - name: missing-url")).rejects.toThrow(
+        AppSetupError
+      );
+    });
+
+    it("throws AppSetupError when a registry entry url is not a string", async () => {
+      await expect(load("registries:\n  - url: 42")).rejects.toThrow(
+        AppSetupError
+      );
+    });
+  });
+
+  // --- deprecated string libraries field ---
+
+  describe("deprecated libraries field", () => {
+    it("adds a string libraries value as a registry entry", async () => {
+      const config = await load(`libraries: https://old.example.com/libs`);
+      expect(config.registries).toEqual([
+        {
+          url: "https://old.example.com/libs",
+          refreshMinInterval: 60,
+          refreshMaxInterval: 300
+        }
+      ]);
+    });
+
+    it("emits a deprecation warning when string libraries is used", async () => {
+      const warnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+      await load(`libraries: https://old.example.com/libs`);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("deprecated")
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("appends the string libraries entry after explicit registries", async () => {
+      const yaml = [
+        "registries:",
+        "  - url: https://reg.example.com/",
+        "libraries: https://old.example.com/libs"
+      ].join("\n");
+      const config = await load(yaml);
+      expect(config.registries).toHaveLength(2);
+      expect(config.registries?.[0]?.url).toBe("https://reg.example.com/");
+      expect(config.registries?.[1]?.url).toBe("https://old.example.com/libs");
+    });
+  });
+
+  // --- mediaSupport ---
+
+  describe("mediaSupport", () => {
+    it("defaults to an empty object when media_support is absent", async () => {
+      expect((await load(MINIMAL_YAML)).mediaSupport).toEqual({});
+    });
+
+    it("passes through media_support values", async () => {
+      const yaml = "media_support:\n  application/epub+zip: show";
+      expect((await load(yaml)).mediaSupport).toEqual({
+        "application/epub+zip": "show"
+      });
+    });
+  });
+
+  // --- libraries ---
+
+  describe("libraries", () => {
+    it.each([
+      ["absent", MINIMAL_YAML],
+      [
+        "a string (deprecated registry URL)",
+        "libraries: https://registry.example.com/libraries"
+      ]
+    ])("is undefined when libraries is %s", async (_label, yaml) => {
+      expect((await load(yaml)).staticLibraries).toBeUndefined();
+    });
+
+    it("is an empty object when libraries is an empty object", async () => {
+      expect((await load("libraries: {}")).staticLibraries).toEqual({});
+    });
+
+    it("parses a string-format entry (auth doc URL, slug as title)", async () => {
+      expect(
+        (await load(`libraries:\n  my-lib: https://example.com/auth`))
+          .staticLibraries
+      ).toEqual({
+        "my-lib": { title: "my-lib", authDocUrl: "https://example.com/auth" }
+      });
+    });
+
+    it("parses an object-format entry with authDocUrl and title", async () => {
+      const yaml =
+        "libraries:\n  my-lib:\n    authDocUrl: https://example.com/auth\n    title: My Library";
+      expect((await load(yaml)).staticLibraries).toEqual({
+        "my-lib": {
+          title: "My Library",
+          authDocUrl: "https://example.com/auth"
+        }
+      });
+    });
+
+    it("uses slug as title when title is absent from object-format entry", async () => {
+      const yaml =
+        "libraries:\n  my-lib:\n    authDocUrl: https://example.com/auth";
+      expect((await load(yaml)).staticLibraries?.["my-lib"]?.title).toBe(
+        "my-lib"
+      );
+    });
+
+    it("parses multiple entries", async () => {
+      const yaml =
+        "libraries:\n  lib-a: https://a.example.com/auth\n  lib-b: https://b.example.com/auth";
+      const { staticLibraries } = await load(yaml);
+      expect(Object.keys(staticLibraries!)).toHaveLength(2);
+      expect(staticLibraries?.["lib-a"]?.authDocUrl).toBe(
+        "https://a.example.com/auth"
+      );
+      expect(staticLibraries?.["lib-b"]?.authDocUrl).toBe(
+        "https://b.example.com/auth"
+      );
+    });
+
+    it.each([
+      [
+        "null entry",
+        "libraries:\n  bad-lib: null",
+        "CONFIG_FILE.libraries['bad-lib'] cannot be null or undefined"
+      ],
+      [
+        "empty string entry",
+        `libraries:\n  bad-lib: ""`,
+        "CONFIG_FILE.libraries['bad-lib'] cannot be an empty string"
+      ],
+      [
+        "whitespace-only string entry",
+        `libraries:\n  bad-lib: "   "`,
+        "CONFIG_FILE.libraries['bad-lib'] cannot be an empty string"
+      ],
+      [
+        "object missing authDocUrl",
+        "libraries:\n  bad-lib:\n    title: My Library",
+        "CONFIG_FILE.libraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
+      ],
+      [
+        "object with non-string authDocUrl",
+        "libraries:\n  bad-lib:\n    authDocUrl: 12345",
+        "CONFIG_FILE.libraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
+      ],
+      [
+        "object with empty authDocUrl",
+        `libraries:\n  bad-lib:\n    authDocUrl: ""`,
+        "CONFIG_FILE.libraries['bad-lib'].authDocUrl cannot be an empty string"
+      ],
+      [
+        "object with non-string title",
+        "libraries:\n  bad-lib:\n    authDocUrl: https://example.com/auth\n    title: 123",
+        "CONFIG_FILE.libraries['bad-lib'].title must be a string"
+      ],
+      [
+        "object with empty title",
+        `libraries:\n  bad-lib:\n    authDocUrl: https://example.com/auth\n    title: ""`,
+        "CONFIG_FILE.libraries['bad-lib'].title cannot be an empty string"
+      ],
+      [
+        "numeric entry",
+        "libraries:\n  bad-lib: 12345",
+        "CONFIG_FILE.libraries['bad-lib'] must be either a string (auth doc URL) or an object with 'authDocUrl' property"
+      ],
+      [
+        "boolean entry",
+        "libraries:\n  bad-lib: true",
+        "CONFIG_FILE.libraries['bad-lib'] must be either a string (auth doc URL) or an object with 'authDocUrl' property"
+      ]
+    ])("throws AppSetupError for %s", async (_label, yaml, expectedMessage) => {
+      await expect(load(yaml)).rejects.toThrow(expectedMessage);
+    });
+  });
+});

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -1,6 +1,4 @@
 /**
- * @jest-environment node
- *
  * Provides the parsed app configuration from the config file, read once
  * at runtime on first access. The result is cached for the lifetime of the
  * server process.

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -47,6 +47,16 @@ const RawConfigSchema = type({
   "openebooks?": { default_library: "string" }
 });
 
+const DEFAULT_MIN_INTERVAL = 60;
+const DEFAULT_MAX_INTERVAL = 300;
+
+const VALID_MEDIA_SUPPORT_VALUES = new Set<string>([
+  "show",
+  "redirect",
+  "redirect-and-show",
+  "unsupported"
+]);
+
 // ---------------------------------------------------------------------------
 // Parsing helpers
 // ---------------------------------------------------------------------------
@@ -102,10 +112,9 @@ function parseLibraryEntry(
 }
 
 function parseLibrariesConfig(raw: Record<string, unknown>): LibrariesConfig {
-  return Object.keys(raw).reduce<LibrariesConfig>((acc, slug) => {
-    acc[slug] = parseLibraryEntry(slug, raw[slug]);
-    return acc;
-  }, {});
+  return Object.fromEntries(
+    Object.keys(raw).map(slug => [slug, parseLibraryEntry(slug, raw[slug])])
+  );
 }
 
 function parseYaml(input: Record<string, unknown>): AppConfig {
@@ -123,10 +132,7 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     ? { defaultLibrary: result.openebooks.default_library }
     : null;
 
-  const DEFAULT_MIN_INTERVAL = 60;
-  const DEFAULT_MAX_INTERVAL = 300;
-
-  let registries: RegistryConfig[] = (result.registries ?? []).map(r => ({
+  const baseRegistries: RegistryConfig[] = (result.registries ?? []).map(r => ({
     url: r.url,
     refreshMinInterval: r.refreshMinInterval ?? DEFAULT_MIN_INTERVAL,
     refreshMaxInterval: r.refreshMaxInterval ?? DEFAULT_MAX_INTERVAL
@@ -139,15 +145,19 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
         "Please migrate to the 'registries' array format. " +
         "See the 'Libraries and Registries Configuration Settings' section in README.md."
     );
-    registries = [
-      ...registries,
-      {
-        url: result.libraries,
-        refreshMinInterval: DEFAULT_MIN_INTERVAL,
-        refreshMaxInterval: DEFAULT_MAX_INTERVAL
-      }
-    ];
   }
+
+  const registries: RegistryConfig[] =
+    typeof result.libraries === "string"
+      ? [
+          ...baseRegistries,
+          {
+            url: result.libraries,
+            refreshMinInterval: DEFAULT_MIN_INTERVAL,
+            refreshMaxInterval: DEFAULT_MAX_INTERVAL
+          }
+        ]
+      : baseRegistries;
 
   // Object-format libraries: static slug → authDocUrl entries baked into the config.
   const staticLibraries =
@@ -156,6 +166,15 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     !Array.isArray(result.libraries)
       ? parseLibrariesConfig(result.libraries as Record<string, unknown>)
       : undefined;
+
+  for (const [mime, level] of Object.entries(result.media_support ?? {})) {
+    if (!VALID_MEDIA_SUPPORT_VALUES.has(level)) {
+      throw new AppSetupError(
+        `CONFIG_FILE.media_support['${mime}'] has unrecognized value "${level}". ` +
+          `Valid values: ${[...VALID_MEDIA_SUPPORT_VALUES].join(", ")}.`
+      );
+    }
+  }
 
   return {
     instanceName:
@@ -206,7 +225,7 @@ export async function getAppConfig(): Promise<AppConfig> {
       res = await fetch(configFile, { signal: controller.signal });
     } catch (e) {
       throw new AppSetupError(
-        `Could not reach config file at: ${configFile}: ${(e as Error).message}`
+        `Could not reach config file at: ${configFile}: ${e instanceof Error ? e.message : String(e)}`
       );
     } finally {
       clearTimeout(timeoutId);
@@ -224,8 +243,13 @@ export async function getAppConfig(): Promise<AppConfig> {
     text = readFileSync(resolved, "utf8");
   }
 
-  const raw = YAML.parse(text) as Record<string, unknown>;
-  cached = parseYaml(raw);
+  const raw: unknown = YAML.parse(text);
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new AppSetupError(
+      "Config file must be a YAML mapping (key: value pairs), not a null value, scalar, or sequence."
+    );
+  }
+  cached = parseYaml(raw as Record<string, unknown>);
   return cached;
 }
 

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -1,0 +1,235 @@
+/**
+ * @jest-environment node
+ *
+ * Provides the parsed app configuration from the config file, read once
+ * at runtime on first access. The result is cached for the lifetime of the
+ * server process.
+ *
+ * This module is server-only. It reads CONFIG_FILE directly so that
+ * configuration is resolved at runtime, not embedded in the build artifact.
+ */
+
+import { readFileSync } from "fs";
+import path from "path";
+import YAML from "yaml";
+import { type } from "arktype";
+import type {
+  AppConfig,
+  LibrariesConfig,
+  MediaSupportConfig,
+  RegistryConfig
+} from "interfaces";
+import { AppSetupError } from "errors";
+import { isHttpUrl } from "utils/parse";
+import { DEFAULT_REGISTRY_FETCH_TIMEOUT } from "constants/registry";
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const RegistryEntrySchema = type({
+  url: "string",
+  "refreshMinInterval?": "number",
+  "refreshMaxInterval?": "number"
+});
+
+const RawConfigSchema = type({
+  // Intentionally permissive: any non-string value silently defaults.
+  "instance_name?": "unknown",
+  "companion_app?": "string",
+  "show_medium?": "boolean",
+  "bugsnag_api_key?": "string",
+  "gtmId?": "string",
+  "registries?": RegistryEntrySchema.array(),
+  "libraries?": "string | Record<string, unknown>",
+  "media_support?": "Record<string, string>",
+  // eslint-disable-next-line camelcase
+  "openebooks?": { default_library: "string" }
+});
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+
+function parseLibraryEntry(
+  slug: string,
+  value: unknown
+): { title: string; authDocUrl: string } {
+  if (value == null) {
+    throw new AppSetupError(
+      `CONFIG_FILE.libraries['${slug}'] cannot be null or undefined`
+    );
+  }
+  if (typeof value === "string") {
+    if (value.trim() === "") {
+      throw new AppSetupError(
+        `CONFIG_FILE.libraries['${slug}'] cannot be an empty string`
+      );
+    }
+    return { title: slug, authDocUrl: value };
+  }
+  if (typeof value === "object" && !Array.isArray(value)) {
+    const entry = value as Record<string, unknown>;
+    if (!("authDocUrl" in entry) || typeof entry.authDocUrl !== "string") {
+      throw new AppSetupError(
+        `CONFIG_FILE.libraries['${slug}'] must have an 'authDocUrl' property with a valid URL string`
+      );
+    }
+    if (entry.authDocUrl.trim() === "") {
+      throw new AppSetupError(
+        `CONFIG_FILE.libraries['${slug}'].authDocUrl cannot be an empty string`
+      );
+    }
+    let title = slug;
+    if ("title" in entry) {
+      if (typeof entry.title !== "string") {
+        throw new AppSetupError(
+          `CONFIG_FILE.libraries['${slug}'].title must be a string`
+        );
+      }
+      if (entry.title.trim() === "") {
+        throw new AppSetupError(
+          `CONFIG_FILE.libraries['${slug}'].title cannot be an empty string`
+        );
+      }
+      title = entry.title;
+    }
+    return { title, authDocUrl: entry.authDocUrl };
+  }
+  throw new AppSetupError(
+    `CONFIG_FILE.libraries['${slug}'] must be either a string (auth doc URL) or an object with 'authDocUrl' property`
+  );
+}
+
+function parseLibrariesConfig(raw: Record<string, unknown>): LibrariesConfig {
+  return Object.keys(raw).reduce<LibrariesConfig>((acc, slug) => {
+    acc[slug] = parseLibraryEntry(slug, raw[slug]);
+    return acc;
+  }, {});
+}
+
+function parseYaml(input: Record<string, unknown>): AppConfig {
+  const result = RawConfigSchema(input);
+  if (result instanceof type.errors) {
+    throw new AppSetupError(`Invalid config file:\n${result.summary}`);
+  }
+
+  const companionApp =
+    result.companion_app === "openebooks" ? "openebooks" : "simplye";
+
+  const showMedium = result.show_medium !== false;
+
+  const openebooks = result.openebooks
+    ? { defaultLibrary: result.openebooks.default_library }
+    : null;
+
+  const DEFAULT_MIN_INTERVAL = 60;
+  const DEFAULT_MAX_INTERVAL = 300;
+
+  let registries: RegistryConfig[] = (result.registries ?? []).map(r => ({
+    url: r.url,
+    refreshMinInterval: r.refreshMinInterval ?? DEFAULT_MIN_INTERVAL,
+    refreshMaxInterval: r.refreshMaxInterval ?? DEFAULT_MAX_INTERVAL
+  }));
+
+  // Deprecated: string `libraries` treated as a registry URL.
+  if (typeof result.libraries === "string") {
+    console.warn(
+      "WARNING: Using a string for 'libraries' in config is deprecated. " +
+        "Please migrate to the 'registries' array format. " +
+        "See the 'Libraries and Registries Configuration Settings' section in README.md."
+    );
+    registries = [
+      ...registries,
+      {
+        url: result.libraries,
+        refreshMinInterval: DEFAULT_MIN_INTERVAL,
+        refreshMaxInterval: DEFAULT_MAX_INTERVAL
+      }
+    ];
+  }
+
+  // Object-format libraries: static slug → authDocUrl entries baked into the config.
+  const staticLibraries =
+    result.libraries &&
+    typeof result.libraries === "object" &&
+    !Array.isArray(result.libraries)
+      ? parseLibrariesConfig(result.libraries as Record<string, unknown>)
+      : undefined;
+
+  return {
+    instanceName:
+      typeof result.instance_name === "string"
+        ? result.instance_name
+        : "Patron Web Catalog",
+    registries,
+    staticLibraries,
+    mediaSupport: (result.media_support as MediaSupportConfig) ?? {},
+    bugsnagApiKey: result.bugsnag_api_key ?? null,
+    gtmId: result.gtmId ?? null,
+    companionApp,
+    showMedium,
+    openebooks
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Runtime cache and loader
+// ---------------------------------------------------------------------------
+
+let cached: AppConfig | null = null;
+
+/**
+ * Returns the parsed app configuration. Reads and parses CONFIG_FILE on the
+ * first call, then returns the cached result on subsequent calls.
+ */
+export async function getAppConfig(): Promise<AppConfig> {
+  if (cached !== null) return cached;
+
+  const configFile = process.env.CONFIG_FILE;
+  if (!configFile) {
+    throw new AppSetupError(
+      "CONFIG_FILE environment variable is not set. " +
+        "Set it to the path or URL of your config YAML file."
+    );
+  }
+
+  let text: string;
+  if (isHttpUrl(configFile)) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      DEFAULT_REGISTRY_FETCH_TIMEOUT * 1000
+    );
+    let res: Response;
+    try {
+      res = await fetch(configFile, { signal: controller.signal });
+    } catch (e) {
+      throw new AppSetupError(
+        `Could not reach config file at: ${configFile}: ${(e as Error).message}`
+      );
+    } finally {
+      clearTimeout(timeoutId);
+    }
+    if (!res.ok) {
+      throw new AppSetupError(
+        `Could not fetch config file at: ${configFile} (HTTP ${res.status})`
+      );
+    }
+    text = await res.text();
+  } else {
+    const resolved = path.isAbsolute(configFile)
+      ? configFile
+      : path.join(process.cwd(), configFile);
+    text = readFileSync(resolved, "utf8");
+  }
+
+  const raw = YAML.parse(text) as Record<string, unknown>;
+  cached = parseYaml(raw);
+  return cached;
+}
+
+/** Clears the in-memory cache. Intended for use in tests only. */
+export function resetAppConfigCache(): void {
+  cached = null;
+}


### PR DESCRIPTION
## Description

**Note:** This is the first in a series of PRs to move fully to runtime configuration. Other associated PRs will stack on this one.

Adds the server-side runtime config module and supporting pieces that subsequent PRs will wire into the app. No existing code is changed; nothing imports these new files yet.

Specifically, this PR adds:
- A server-side config loader that reads and parses `CONFIG_FILE` at runtime on first request and caches the result for the process lifetime. `ArkType` validates the raw YAML structure upfront so malformed configs produce a clear error rather than a confusing downstream failure. Per-slug library-entry errors are handled separately so their messages can include the offending slug in the path.
- A React context and `useAppConfig()` hook for components to consume config values, and a safe fallback config for use before `pageProps` is available (e.g. during SSR).
- Support for the `staticLibraries` "shape" in `AppConfig` — object-format `libraries` entries mapping slugs directly to auth document URLs.
- A config file reference in the README (options table and media support explanation), so the deprecation warning for the legacy string `libraries` format has somewhere concrete to point.

## Motivation and Context

The long-term goal is to read configuration at server startup rather than baking its contents into the build artifact, so that config changes don't require a full rebuild and redeploy.

This PR adds the new module without activating it; a follow-on PR will switch consumers over.

[JIRA PP-4124]

## How Has This Been Tested?

- Includes unit tests for the new functionality.
- All check pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/24856257601) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.