### PR TITLE
Trigger configuration load on startup (PP-4124)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,12 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { getAppConfig } = await import("server/appConfig");
+    try {
+      await getAppConfig();
+    } catch (e) {
+      // Next.js does not exit on register() errors, so we must do it ourselves.
+      console.error(e instanceof Error ? e.message : String(e));
+      process.exit(1);
+    }
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,9 +4,7 @@ import OpenEbooksLandingPage from "components/OpenEbooksLanding";
 import MultiLibraryHome from "components/MultiLibraryHome";
 import withAppProps, { AppProps } from "dataflow/withAppProps";
 import { getAppConfig } from "server/appConfig";
-import { AppSetupError } from "errors";
 import type { AppConfig } from "interfaces";
-import FALLBACK_APP_CONFIG from "config/fallbackAppConfig";
 
 type HomeProps = AppProps & { appConfig: AppConfig };
 
@@ -18,15 +16,7 @@ const HomePage: NextPage<HomeProps> = ({ appConfig, ...rest }) => {
 };
 
 export const getServerSideProps: GetServerSideProps<HomeProps> = async ctx => {
-  let appConfig: AppConfig;
-  try {
-    appConfig = await getAppConfig();
-  } catch (e) {
-    if (e instanceof AppSetupError) {
-      return { props: { appConfig: FALLBACK_APP_CONFIG } };
-    }
-    throw e;
-  }
+  const appConfig = await getAppConfig();
   if (appConfig.openebooks) {
     const fetchProps = withAppProps(
       undefined,

--- a/src/server/__tests__/instrumentation.test.ts
+++ b/src/server/__tests__/instrumentation.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("server/appConfig", () => ({
+  getAppConfig: jest.fn()
+}));
+
+import { register } from "../../instrumentation";
+import { getAppConfig } from "server/appConfig";
+
+const mockGetAppConfig = getAppConfig as jest.Mock;
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+describe("register", () => {
+  it("does not call getAppConfig when NEXT_RUNTIME is 'edge'", async () => {
+    process.env.NEXT_RUNTIME = "edge";
+    await register();
+    expect(mockGetAppConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not call getAppConfig when NEXT_RUNTIME is unset", async () => {
+    delete process.env.NEXT_RUNTIME;
+    await register();
+    expect(mockGetAppConfig).not.toHaveBeenCalled();
+  });
+
+  it("calls getAppConfig when NEXT_RUNTIME is 'nodejs'", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    mockGetAppConfig.mockResolvedValue({});
+    await register();
+    expect(mockGetAppConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves without error when getAppConfig succeeds", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    mockGetAppConfig.mockResolvedValue({});
+    await expect(register()).resolves.toBeUndefined();
+  });
+
+  describe("when getAppConfig throws", () => {
+    let exitSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      process.env.NEXT_RUNTIME = "nodejs";
+      exitSpy = jest
+        .spyOn(process, "exit")
+        .mockImplementation(() => undefined as never);
+      errorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      exitSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it("calls process.exit(1)", async () => {
+      mockGetAppConfig.mockRejectedValue(new Error("bad config"));
+      await register();
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("logs the error message when the thrown value is an Error", async () => {
+      mockGetAppConfig.mockRejectedValue(new Error("config not found"));
+      await register();
+      expect(errorSpy).toHaveBeenCalledWith("config not found");
+    });
+
+    it("logs String(e) when the thrown value is not an Error", async () => {
+      mockGetAppConfig.mockRejectedValue("plain string error");
+      await register();
+      expect(errorSpy).toHaveBeenCalledWith("plain string error");
+    });
+  });
+});


### PR DESCRIPTION
**Note:** This PR is stacked on #125, which is, in turn, stacked on #124, and should not be merged until those have landed.

## Description

Trigger configuration load success or failure immediately upon startup:
- Uses the Instrumentation API to load and validate the app configuration at server startup, rather than on the first request.
- If config loading fails — missing `CONFIG_FILE`, unreachable URL, invalid YAML — the error message is printed to stderr and the process fails fast, exiting with an error before serving any requests.

## Motivation and Context

This change makes misconfiguration immediately visible when deploying or starting the server locally. Previously, missing or invalid configuration would not be detected until the first request hit a handler that called `getAppConfig()`, resulting in a silent failure or a confusing runtime error rather than a clear startup message.

[Jira PP-4124]

## How Has This Been Tested?

- Manual testing in local dev environment, starting the server in the following configurations with valid, invalid, and missing file/unreachable URL:
  - without config (`CONFIG_FILE= npm run start`)
  - with local config file (`CONFIG_FILE=<filename> ...`)
  - with remote config file (`CONFIG_FILE=<url> ...`)
- All checks pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/24896724703) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.