### PR TITLE
Run tests and other checks during Docker image build (PP-3955)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ RUN apk add --no-cache git
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-ENV NODE_ENV=production
 # Ensure CI checks pass before build.
-RUN npm run test:ci && npm run type-check && npm run lint && npm run build
+RUN npm run test:ci && npm run type-check && npm run lint
+# Note: We must set `NODE_ENV` after the CI checks, but before the build.
+ENV NODE_ENV=production
+RUN npm run build
 
 FROM node:20.18.1-alpine AS runner
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NODE_ENV=production
-RUN npm run build
+# Ensure CI checks pass before build.
+RUN npm run test:ci && npm run type-check && npm run lint && npm run build
 
 FROM node:20.18.1-alpine AS runner
 WORKDIR /app


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #125, which is, in turn, stacked on #124, and should not be merged until both of those have landed. 

## Description

Runs tests, type checker, and linter before building the Next.js app during the "builder" stage of the Docker image build.

**Important Note:** that the tests will not run successfully if the `NODE_ENV` environment variable is set to "production" and that value **must** be set for the build, so it needs to be set between the checks and the build.

## Motivation and Context

Guarantees that the code that makes it into the Docker image passes those checks in the Docker container environment.

[Jira PP-3955]

## How Has This Been Tested?

The [Publish image to Docker registry](https://github.com/ThePalaceProject/web-patron/actions/runs/24913944073/job/72961985775#logs) CI step passed.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.