### PR TITLE
Snake_case in config docs, but also accept camelCase (PP-4124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ The app is configured with a YAML file. Point the app at it by setting the `CONF
 | `companion_app` | `"simplye"` \| `"openebooks"` | `"simplye"` | Selects which companion mobile app to reference in redirect prompts. |
 | `show_medium` | boolean | `true` | Whether to display the medium (e-book, audiobook, etc.) label on book cards. |
 | `bugsnag_api_key` | string | — | Bugsnag project API key. Omit to disable error tracking. |
-| `gtmId` | string | — | Google Tag Manager container ID (e.g. `GTM-XXXX`). Omit to disable analytics. |
+| `gtm_id` | string | — | Google Tag Manager container ID (e.g. `GTM-XXXX`). Omit to disable analytics. |
 | `media_support` | mapping | `{}` | Per-MIME-type rendering mode. See [Media Support](#media-support) below. |
-| `staticLibraries` | mapping | — | Static library definitions. See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
+| `static_libraries` | mapping | — | Static library definitions. See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
 | `registries` | list | `[]` | One or more library registry URLs fetched at runtime. See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
-| `libraries` | mapping or string | — | **Deprecated.** Use `staticLibraries` (mapping) or `registries` (string). See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
+| `libraries` | mapping or string | — | **Deprecated.** Use `static_libraries` (mapping) or `registries` (string). See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
 
 ### Media Support
 
@@ -133,7 +133,7 @@ Define libraries directly in your configuration file as a dictionary mapping lib
 
 **Simple Format:**
 ```yaml
-staticLibraries:
+static_libraries:
   my-library: https://circulation.example.com/my-library/authentication_document
   another-lib: https://circulation.example.com/another-lib/authentication_document
 ```
@@ -143,7 +143,7 @@ staticLibraries:
 You can also specify a custom display title for each library that will appear on the multi-library selection page:
 
 ```yaml
-staticLibraries:
+static_libraries:
   my-library:
     authDocUrl: https://circulation.example.com/my-library/authentication_document
     title: "My Public Library"
@@ -185,7 +185,7 @@ registries:
 Combine static libraries with registry-based libraries. Static library definitions always take precedence over registry entries when slugs conflict:
 
 ```yaml
-staticLibraries:
+static_libraries:
   featured-library:
     authDocUrl: https://circulation.example.com/featured/authentication_document
     title: "Featured Library"
@@ -201,7 +201,7 @@ In this example, if the registry also contains a library with slug `featured-lib
 
 Using an object for `libraries` to define static libraries:
 ```yaml
-# DEPRECATED — rename to staticLibraries
+# DEPRECATED — rename to static_libraries
 libraries:
   my-library: https://circulation.example.com/my-library/authentication_document
 ```
@@ -219,7 +219,7 @@ libraries:
   my-library: https://circulation.example.com/my-library/authentication_document
 
 # NEW (recommended):
-staticLibraries:
+static_libraries:
   my-library: https://circulation.example.com/my-library/authentication_document
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ You can also specify a custom display title for each library that will appear on
 ```yaml
 static_libraries:
   my-library:
-    authDocUrl: https://circulation.example.com/my-library/authentication_document
+    auth_doc_url: https://circulation.example.com/my-library/authentication_document
     title: "My Public Library"
   another-lib:
-    authDocUrl: https://circulation.example.com/another-lib/authentication_document
+    auth_doc_url: https://circulation.example.com/another-lib/authentication_document
     title: "Community Reading Center"
 ```
 
@@ -166,8 +166,8 @@ Instead of hardcoding libraries, you can configure the app to fetch library info
 ```yaml
 registries:
   - url: https://registry.thepalaceproject.org/libraries/qa
-    refreshMinInterval: 60      # Seconds between fetch attempts (default: 60)
-    refreshMaxInterval: 300     # Seconds before forcing refresh (default: 300)
+    refresh_min_interval: 60    # Seconds between fetch attempts (default: 60)
+    refresh_max_interval: 300   # Seconds before forcing refresh (default: 300)
 ```
 
 **Multiple Registries:**
@@ -187,7 +187,7 @@ Combine static libraries with registry-based libraries. Static library definitio
 ```yaml
 static_libraries:
   featured-library:
-    authDocUrl: https://circulation.example.com/featured/authentication_document
+    auth_doc_url: https://circulation.example.com/featured/authentication_document
     title: "Featured Library"
 registries:
   - url: https://registry.thepalaceproject.org/libraries/qa

--- a/community-config.yml
+++ b/community-config.yml
@@ -67,7 +67,7 @@ companion_app: simplye
 #    Define libraries as a mapping from slug to authentication document URL.
 #    These libraries are served directly from the running application.
 #
-staticLibraries:
+static_libraries:
   main-street-city: https://demo.thepalaceproject.org/GA0000/authentication_document
 #
 # 2. RUNTIME LIBRARY REGISTRIES (recommended for dynamic library lists):
@@ -76,23 +76,23 @@ staticLibraries:
 #
 # registries:
 #   - url: https://registry.thepalaceproject.org/libraries
-#     refreshMinInterval: 60   # Minimum seconds between fetch attempts (default: 60)
-#     refreshMaxInterval: 300  # Maximum seconds after last successful fetch before auto-refresh (default: 300)
+#     refresh_min_interval: 60  # Minimum seconds between fetch attempts (default: 60)
+#     refresh_max_interval: 300 # Maximum seconds after last successful fetch before auto-refresh (default: 300)
 #
 # You can also define multiple registries (earlier registries take precedence for slug conflicts):
 # registries:
 #   - url: https://registry.thepalaceproject.org/libraries
-#     refreshMinInterval: 60
-#     refreshMaxInterval: 300
+#     refresh_min_interval: 60
+#     refresh_max_interval: 300
 #   - url: https://regional-registry.example.com/libraries
-#     refreshMinInterval: 120
-#     refreshMaxInterval: 600
+#     refresh_min_interval: 120
+#     refresh_max_interval: 600
 #
 # 3. HYBRID (static + registries):
 #    Combine static libraries with runtime registries. Static libraries always
 #    take precedence over registry libraries if there are slug conflicts.
 #
-# staticLibraries:
+# static_libraries:
 #   featured-lib: https://example.com/featured/auth
 # registries:
 #   - url: https://registry.thepalaceproject.org/libraries
@@ -100,7 +100,7 @@ staticLibraries:
 # DEPRECATED FORMATS (temporarily supported for backward compatibility):
 #
 # Using an object for 'libraries' to define static libraries is deprecated.
-# Rename it to 'staticLibraries':
+# Rename it to 'static_libraries':
 #
 #   libraries:                                         # DEPRECATED
 #     my-library: https://example.com/auth_document   # DEPRECATED

--- a/src/server/__tests__/appConfig.test.ts
+++ b/src/server/__tests__/appConfig.test.ts
@@ -813,4 +813,79 @@ describe("config parsing", () => {
       await expect(load(yaml)).rejects.toThrow(expectedMessage);
     });
   });
+
+  // --- key form tolerance ---
+
+  describe("key form tolerance", () => {
+    const SNAKE_YAML = [
+      "instance_name: Test Instance",
+      "companion_app: openebooks",
+      "show_medium: false",
+      "bugsnag_api_key: key-abc",
+      "gtm_id: GTM-TEST",
+      "static_libraries:",
+      "  my-lib:",
+      "    auth_doc_url: https://example.com/auth",
+      "    title: My Library",
+      "media_support:",
+      "  application/epub+zip: show",
+      "registries:",
+      "  - url: https://registry.example.com",
+      "    refresh_min_interval: 30",
+      "    refresh_max_interval: 120",
+      "openebooks:",
+      "  default_library: my-lib"
+    ].join("\n");
+
+    const CAMEL_YAML = [
+      "instanceName: Test Instance",
+      "companionApp: openebooks",
+      "showMedium: false",
+      "bugsnagApiKey: key-abc",
+      "gtmId: GTM-TEST",
+      "staticLibraries:",
+      "  my-lib:",
+      "    authDocUrl: https://example.com/auth",
+      "    title: My Library",
+      "mediaSupport:",
+      "  application/epub+zip: show",
+      "registries:",
+      "  - url: https://registry.example.com",
+      "    refreshMinInterval: 30",
+      "    refreshMaxInterval: 120",
+      "openebooks:",
+      "  defaultLibrary: my-lib"
+    ].join("\n");
+
+    it.each([
+      ["snake_case", SNAKE_YAML],
+      ["camelCase", CAMEL_YAML]
+    ])(
+      "parses all top-level keys from %s YAML into identical config",
+      async (_form, yaml) => {
+        expect(await load(yaml)).toEqual({
+          instanceName: "Test Instance",
+          companionApp: "openebooks",
+          showMedium: false,
+          bugsnagApiKey: "key-abc",
+          gtmId: "GTM-TEST",
+          staticLibraries: {
+            "my-lib": {
+              title: "My Library",
+              authDocUrl: "https://example.com/auth"
+            }
+          },
+          mediaSupport: { "application/epub+zip": "show" },
+          registries: [
+            {
+              url: "https://registry.example.com",
+              refreshMinInterval: 30,
+              refreshMaxInterval: 120
+            }
+          ],
+          openebooks: { defaultLibrary: "my-lib" }
+        });
+      }
+    );
+  });
 });

--- a/src/server/__tests__/appConfig.test.ts
+++ b/src/server/__tests__/appConfig.test.ts
@@ -6,7 +6,11 @@
 
 import path from "path";
 import type { AppConfig } from "interfaces";
-import { getAppConfig, resetAppConfigCache } from "../appConfig";
+import {
+  getAppConfig,
+  normalizeConfigKeys,
+  resetAppConfigCache
+} from "../appConfig";
 import { AppSetupError } from "errors";
 import { DEFAULT_REGISTRY_FETCH_TIMEOUT } from "constants/registry";
 
@@ -48,6 +52,71 @@ beforeEach(() => {
 afterEach(() => {
   process.env = originalEnv;
 });
+
+// ---------------------------------------------------------------------------
+// normalizeConfigKeys
+// ---------------------------------------------------------------------------
+
+/* eslint-disable camelcase */
+describe("normalizeConfigKeys", () => {
+  it.each([
+    ["returns object unchanged when key is absent", {}, ["fooBar"], {}],
+    [
+      "returns object unchanged when camelCase key is already present",
+      { fooBar: 42 },
+      ["fooBar"],
+      { fooBar: 42 }
+    ],
+    [
+      "renames snake_case key to camelCase",
+      { foo_bar: 42 },
+      ["fooBar"],
+      { fooBar: 42 }
+    ],
+    [
+      "does not touch keys not in camelKeys",
+      { other_key: 1, fooBar: 2 },
+      ["fooBar"],
+      { other_key: 1, fooBar: 2 }
+    ],
+    [
+      "does not throw for a single-word key that is present",
+      { registries: [] },
+      ["registries"],
+      { registries: [] }
+    ]
+  ])("%s", (_label, input, keys, expected) => {
+    expect(normalizeConfigKeys(input as Record<string, unknown>, keys)).toEqual(
+      expected
+    );
+  });
+
+  it("renames all matching snake_case keys when multiple camelKeys are given", () => {
+    expect(
+      normalizeConfigKeys({ foo_bar: 1, baz_qux: "x" }, ["fooBar", "bazQux"])
+    ).toEqual({ fooBar: 1, bazQux: "x" });
+  });
+
+  it.each([
+    ["fooBar", { fooBar: 1, foo_bar: 2 }],
+    ["gtmId", { gtmId: "a", gtm_id: "b" }],
+    ["refreshMinInterval", { refreshMinInterval: 30, refresh_min_interval: 60 }]
+  ])(
+    "throws AppSetupError when both %s and its snake_case equivalent are set",
+    (camelKey, input) => {
+      expect(() =>
+        normalizeConfigKeys(input as Record<string, unknown>, [camelKey])
+      ).toThrow(AppSetupError);
+    }
+  );
+
+  it("error message includes both conflicting key names", () => {
+    expect(() =>
+      normalizeConfigKeys({ fooBar: 1, foo_bar: 2 }, ["fooBar"])
+    ).toThrow("'foo_bar' and 'fooBar'");
+  });
+});
+/* eslint-enable camelcase */
 
 // ---------------------------------------------------------------------------
 // getAppConfig — environment and I/O behaviour
@@ -623,7 +692,7 @@ describe("config parsing", () => {
         "  other-lib: https://other.example.com/auth"
       ].join("\n");
       await expect(load(yaml)).rejects.toThrow(
-        "'staticLibraries' and the object form of 'libraries' cannot both be set"
+        "'static_libraries' and the object form of 'libraries' cannot both be set"
       );
     });
   });
@@ -693,52 +762,52 @@ describe("config parsing", () => {
       [
         "null entry",
         "staticLibraries:\n  bad-lib: null",
-        "CONFIG_FILE.staticLibraries['bad-lib'] cannot be null or undefined"
+        "CONFIG_FILE.static_libraries['bad-lib'] cannot be null or undefined"
       ],
       [
         "empty string entry",
         `staticLibraries:\n  bad-lib: ""`,
-        "CONFIG_FILE.staticLibraries['bad-lib'] cannot be an empty string"
+        "CONFIG_FILE.static_libraries['bad-lib'] cannot be an empty string"
       ],
       [
         "whitespace-only string entry",
         `staticLibraries:\n  bad-lib: "   "`,
-        "CONFIG_FILE.staticLibraries['bad-lib'] cannot be an empty string"
+        "CONFIG_FILE.static_libraries['bad-lib'] cannot be an empty string"
       ],
       [
         "object missing authDocUrl",
         "staticLibraries:\n  bad-lib:\n    title: My Library",
-        "CONFIG_FILE.staticLibraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
+        "CONFIG_FILE.static_libraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
       ],
       [
         "object with non-string authDocUrl",
         "staticLibraries:\n  bad-lib:\n    authDocUrl: 12345",
-        "CONFIG_FILE.staticLibraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
+        "CONFIG_FILE.static_libraries['bad-lib'] must have an 'authDocUrl' property with a valid URL string"
       ],
       [
         "object with empty authDocUrl",
         `staticLibraries:\n  bad-lib:\n    authDocUrl: ""`,
-        "CONFIG_FILE.staticLibraries['bad-lib'].authDocUrl cannot be an empty string"
+        "CONFIG_FILE.static_libraries['bad-lib'].authDocUrl cannot be an empty string"
       ],
       [
         "object with non-string title",
         "staticLibraries:\n  bad-lib:\n    authDocUrl: https://example.com/auth\n    title: 123",
-        "CONFIG_FILE.staticLibraries['bad-lib'].title must be a string"
+        "CONFIG_FILE.static_libraries['bad-lib'].title must be a string"
       ],
       [
         "object with empty title",
         `staticLibraries:\n  bad-lib:\n    authDocUrl: https://example.com/auth\n    title: ""`,
-        "CONFIG_FILE.staticLibraries['bad-lib'].title cannot be an empty string"
+        "CONFIG_FILE.static_libraries['bad-lib'].title cannot be an empty string"
       ],
       [
         "numeric entry",
         "staticLibraries:\n  bad-lib: 12345",
-        "CONFIG_FILE.staticLibraries['bad-lib'] must be either a string (auth doc URL) or an object with 'authDocUrl' property"
+        "CONFIG_FILE.static_libraries['bad-lib'] must be either a string (auth doc URL) or an object with 'authDocUrl' property"
       ],
       [
         "boolean entry",
         "staticLibraries:\n  bad-lib: true",
-        "CONFIG_FILE.staticLibraries['bad-lib'] must be either a string (auth doc URL) or an object with 'authDocUrl' property"
+        "CONFIG_FILE.static_libraries['bad-lib'] must be either a string (auth doc URL) or an object with 'authDocUrl' property"
       ]
     ])("throws AppSetupError for %s", async (_label, yaml, expectedMessage) => {
       await expect(load(yaml)).rejects.toThrow(expectedMessage);

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -33,17 +33,16 @@ const RegistryEntrySchema = type({
 
 const RawConfigSchema = type({
   // Intentionally permissive: any non-string value silently defaults.
-  "instance_name?": "unknown",
-  "companion_app?": "string",
-  "show_medium?": "boolean",
-  "bugsnag_api_key?": "string",
-  "gtm_id?": "string",
+  "instanceName?": "unknown",
+  "companionApp?": "string",
+  "showMedium?": "boolean",
+  "bugsnagApiKey?": "string",
+  "gtmId?": "string",
   "registries?": RegistryEntrySchema.array(),
   "libraries?": "string | Record<string, unknown>",
-  "static_libraries?": "Record<string, unknown>",
-  "media_support?": "Record<string, string | Record<string, string>>",
-  // eslint-disable-next-line camelcase
-  "openebooks?": { default_library: "string" }
+  "staticLibraries?": "Record<string, unknown>",
+  "mediaSupport?": "Record<string, string | Record<string, string>>",
+  "openebooks?": { defaultLibrary: "string" }
 });
 
 const DEFAULT_MIN_INTERVAL = 60;
@@ -59,6 +58,31 @@ const VALID_MEDIA_SUPPORT_VALUES = new Set<string>([
 // ---------------------------------------------------------------------------
 // Parsing helpers
 // ---------------------------------------------------------------------------
+
+// Accepts either the camelCase or snake_case form of each listed key, renaming
+// it to camelCase before returning. Throws if both forms are present.
+export function normalizeConfigKeys(
+  obj: Record<string, unknown>,
+  camelKeys: readonly string[]
+): Record<string, unknown> {
+  const out = { ...obj };
+  for (const camelKey of camelKeys) {
+    const snakeKey = camelKey.replace(/([A-Z])/g, c => `_${c.toLowerCase()}`);
+    if (snakeKey === camelKey) continue;
+    const hasSnake = snakeKey in out;
+    const hasCamel = camelKey in out;
+    if (hasSnake && hasCamel) {
+      throw new AppSetupError(
+        `CONFIG_FILE: '${snakeKey}' and '${camelKey}' cannot both be set; use one form only.`
+      );
+    }
+    if (hasSnake) {
+      out[camelKey] = out[snakeKey];
+      delete out[snakeKey];
+    }
+  }
+  return out;
+}
 
 function parseLibraryEntry(
   field: string,
@@ -76,7 +100,9 @@ function parseLibraryEntry(
     return { title: slug, authDocUrl: value };
   }
   if (typeof value === "object" && !Array.isArray(value)) {
-    const entry = value as Record<string, unknown>;
+    const entry = normalizeConfigKeys(value as Record<string, unknown>, [
+      "authDocUrl"
+    ]);
     if (!("authDocUrl" in entry) || typeof entry.authDocUrl !== "string") {
       throw new AppSetupError(
         `${path} must have an 'authDocUrl' property with a valid URL string`
@@ -115,18 +141,46 @@ function parseLibrariesConfig(
 }
 
 function parseYaml(input: Record<string, unknown>): AppConfig {
-  const result = RawConfigSchema(input);
+  const normalized = normalizeConfigKeys(input, [
+    "instanceName",
+    "companionApp",
+    "showMedium",
+    "bugsnagApiKey",
+    "gtmId",
+    "staticLibraries",
+    "mediaSupport"
+  ]);
+  if (Array.isArray(normalized.registries)) {
+    normalized.registries = normalized.registries.map(r =>
+      r !== null && typeof r === "object" && !Array.isArray(r)
+        ? normalizeConfigKeys(r as Record<string, unknown>, [
+            "refreshMinInterval",
+            "refreshMaxInterval"
+          ])
+        : r
+    );
+  }
+  if (
+    normalized.openebooks !== null &&
+    typeof normalized.openebooks === "object"
+  ) {
+    normalized.openebooks = normalizeConfigKeys(
+      normalized.openebooks as Record<string, unknown>,
+      ["defaultLibrary"]
+    );
+  }
+  const result = RawConfigSchema(normalized);
   if (result instanceof type.errors) {
     throw new AppSetupError(`Invalid config file:\n${result.summary}`);
   }
 
   const companionApp =
-    result.companion_app === "openebooks" ? "openebooks" : "simplye";
+    result.companionApp === "openebooks" ? "openebooks" : "simplye";
 
-  const showMedium = result.show_medium !== false;
+  const showMedium = result.showMedium !== false;
 
   const openebooks = result.openebooks
-    ? { defaultLibrary: result.openebooks.default_library }
+    ? { defaultLibrary: result.openebooks.defaultLibrary }
     : null;
 
   const baseRegistries: RegistryConfig[] = (result.registries ?? []).map(r => ({
@@ -163,23 +217,23 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
 
   // Deprecated: object-form `libraries` specifies static libraries inline.
   if (librariesIsObject) {
-    if (result.static_libraries != null) {
+    if (result.staticLibraries != null) {
       throw new AppSetupError(
-        "CONFIG_FILE: 'staticLibraries' and the object form of 'libraries' cannot both be set. " +
-          "Remove 'libraries' and use 'staticLibraries' instead."
+        "CONFIG_FILE: 'static_libraries' and the object form of 'libraries' cannot both be set. " +
+          "Remove 'libraries' and use 'static_libraries' instead."
       );
     }
     console.warn(
       "WARNING: Using an object for 'libraries' to define static libraries is deprecated. " +
-        "Please rename it to 'staticLibraries'. " +
+        "Please rename it to 'static_libraries'. " +
         "See the 'Libraries and Registries Configuration Settings' section in README.md."
     );
   }
 
-  const staticLibraries = result.static_libraries
+  const staticLibraries = result.staticLibraries
     ? parseLibrariesConfig(
         "static_libraries",
-        result.static_libraries as Record<string, unknown>
+        result.staticLibraries as Record<string, unknown>
       )
     : librariesIsObject
       ? parseLibrariesConfig(
@@ -209,20 +263,20 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
       }
     }
   }
-  for (const [mime, level] of Object.entries(result.media_support ?? {})) {
+  for (const [mime, level] of Object.entries(result.mediaSupport ?? {})) {
     validateMediaSupportValue(`media_support['${mime}']`, level);
   }
 
   return {
     instanceName:
-      typeof result.instance_name === "string"
-        ? result.instance_name
+      typeof result.instanceName === "string"
+        ? result.instanceName
         : "Patron Web Catalog",
     registries,
     staticLibraries,
-    mediaSupport: (result.media_support as MediaSupportConfig) ?? {},
-    bugsnagApiKey: result.bugsnag_api_key ?? null,
-    gtmId: result.gtm_id ?? null,
+    mediaSupport: (result.mediaSupport as MediaSupportConfig) ?? {},
+    bugsnagApiKey: result.bugsnagApiKey ?? null,
+    gtmId: result.gtmId ?? null,
     companionApp,
     showMedium,
     openebooks

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -37,10 +37,10 @@ const RawConfigSchema = type({
   "companion_app?": "string",
   "show_medium?": "boolean",
   "bugsnag_api_key?": "string",
-  "gtmId?": "string",
+  "gtm_id?": "string",
   "registries?": RegistryEntrySchema.array(),
   "libraries?": "string | Record<string, unknown>",
-  "staticLibraries?": "Record<string, unknown>",
+  "static_libraries?": "Record<string, unknown>",
   "media_support?": "Record<string, string | Record<string, string>>",
   // eslint-disable-next-line camelcase
   "openebooks?": { default_library: "string" }
@@ -163,7 +163,7 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
 
   // Deprecated: object-form `libraries` specifies static libraries inline.
   if (librariesIsObject) {
-    if (result.staticLibraries != null) {
+    if (result.static_libraries != null) {
       throw new AppSetupError(
         "CONFIG_FILE: 'staticLibraries' and the object form of 'libraries' cannot both be set. " +
           "Remove 'libraries' and use 'staticLibraries' instead."
@@ -176,10 +176,10 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     );
   }
 
-  const staticLibraries = result.staticLibraries
+  const staticLibraries = result.static_libraries
     ? parseLibrariesConfig(
-        "staticLibraries",
-        result.staticLibraries as Record<string, unknown>
+        "static_libraries",
+        result.static_libraries as Record<string, unknown>
       )
     : librariesIsObject
       ? parseLibrariesConfig(
@@ -222,7 +222,7 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     staticLibraries,
     mediaSupport: (result.media_support as MediaSupportConfig) ?? {},
     bugsnagApiKey: result.bugsnag_api_key ?? null,
-    gtmId: result.gtmId ?? null,
+    gtmId: result.gtm_id ?? null,
     companionApp,
     showMedium,
     openebooks


### PR DESCRIPTION
## Description

Consistency updates for configuration file handling:
- All user-facing configuration information (e.g., README, log messages, example configuration) specifies snake_case keys; and
- File/URL parsing accept both snake_case and camelCase values.
- All internal keys are camelCase, to align with JS/TS norms.

## Motivation and Context

Existing config files and documentation used an inconsistent mix of `snake_case`
and `camelCase` keys (e.g. `gtmId` and `staticLibraries` were camelCase while
most other keys were snake_case). This normalizes the user-facing convention to
`snake_case` throughout while preserving backward compatibility with configs
already using the camelCase forms.

[Jira PP-4124]

## How Has This Been Tested?

- New tests for key normalization helper and overall integration with `appConfig`.
- Manual testing in local development environment.
- All checks (tests, type checking, linter) pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/25012769122) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
