### PR TITLE
Unable to navigate to previous page in browser history from login page (PP-4041)

### DIFF
--- a/src/auth/__tests__/Login.test.tsx
+++ b/src/auth/__tests__/Login.test.tsx
@@ -2,7 +2,7 @@ import { AppAuthMethod } from "interfaces";
 import * as React from "react";
 import { screen, setup, fixtures } from "test-utils";
 import Login from "../Login";
-import { mockPush } from "test-utils/mockNextRouter";
+import { mockReplace } from "test-utils/mockNextRouter";
 import { unsupportedAuthMethod } from "test-utils/fixtures";
 
 test("shows warning if there is no auth method configured", async () => {
@@ -75,8 +75,8 @@ test("redirects to /[methodId] when one method configured", () => {
     }
   });
 
-  expect(mockPush).toHaveBeenCalledTimes(1);
-  expect(mockPush).toHaveBeenCalledWith(
+  expect(mockReplace).toHaveBeenCalledTimes(1);
+  expect(mockReplace).toHaveBeenCalledWith(
     {
       pathname: "/[library]/login/[methodId]",
       query: {
@@ -99,8 +99,8 @@ test("redirects to /[methodId] and uses first supported auth method when multipl
   });
 
   // first supported auth method is client-basic-token
-  expect(mockPush).toHaveBeenCalledTimes(1);
-  expect(mockPush).toHaveBeenCalledWith(
+  expect(mockReplace).toHaveBeenCalledTimes(1);
+  expect(mockReplace).toHaveBeenCalledWith(
     {
       pathname: "/[library]/login/[methodId]",
       query: {
@@ -128,8 +128,8 @@ test("filters out unsupported method and redirects to first supported auth metho
   });
 
   // first supported auth method is client-basic-token
-  expect(mockPush).toHaveBeenCalledTimes(1);
-  expect(mockPush).toHaveBeenCalledWith(
+  expect(mockReplace).toHaveBeenCalledTimes(1);
+  expect(mockReplace).toHaveBeenCalledWith(
     {
       pathname: "/[library]/login/[methodId]",
       query: {
@@ -158,8 +158,8 @@ test("strips performSignOut from login URL query params", () => {
     }
   });
 
-  expect(mockPush).toHaveBeenCalledTimes(1);
-  const [loginUrl] = mockPush.mock.calls[0];
+  expect(mockReplace).toHaveBeenCalledTimes(1);
+  const [loginUrl] = mockReplace.mock.calls[0];
   expect((loginUrl as any).query).not.toHaveProperty("performSignOut");
 });
 
@@ -177,8 +177,8 @@ test("preserves nextUrl query param on redirection", () => {
     }
   });
 
-  expect(mockPush).toHaveBeenCalledTimes(1);
-  expect(mockPush).toHaveBeenCalledWith(
+  expect(mockReplace).toHaveBeenCalledTimes(1);
+  expect(mockReplace).toHaveBeenCalledWith(
     {
       pathname: "/[library]/login/[methodId]",
       query: {

--- a/src/auth/useLogin.ts
+++ b/src/auth/useLogin.ts
@@ -1,10 +1,13 @@
 import * as React from "react";
-import { useRouter } from "next/router";
+import { useRouter, type NextRouter } from "next/router";
 import { LOGIN_REDIRECT_QUERY_PARAM } from "utils/constants";
 import { UrlObject } from "url";
 import { IS_SERVER } from "utils/env";
 import useLibraryContext from "components/context/LibraryContext";
 import * as _ from "lodash";
+
+/** A navigate function — `router.push` or `router.replace` from `next/router`. */
+type Navigate = NextRouter["push"] | NextRouter["replace"];
 
 export default function useLogin() {
   const { query, replace, asPath, isReady } = useRouter();
@@ -53,11 +56,16 @@ export default function useLogin() {
   // an error can be passed in from a previous login attempt to show on
   // the login screen. It will be passed to the page as a url query param.
   const initLogin = React.useCallback(
-    (methodId?: string, error?: string, useCurrentPageAsRedirect = true) => {
+    (
+      methodId?: string,
+      error?: string,
+      useCurrentPageAsRedirect = true,
+      navigate: Navigate = replace
+    ) => {
       const urlObject = getLoginUrl(methodId, error, useCurrentPageAsRedirect);
       if (!IS_SERVER) {
         // redirect to the login page
-        replace(urlObject, undefined, { shallow: true });
+        navigate(urlObject, undefined, { shallow: true });
       }
     },
     [replace, getLoginUrl]

--- a/src/auth/useLogin.ts
+++ b/src/auth/useLogin.ts
@@ -7,7 +7,7 @@ import useLibraryContext from "components/context/LibraryContext";
 import * as _ from "lodash";
 
 export default function useLogin() {
-  const { query, push, asPath, isReady } = useRouter();
+  const { query, replace, asPath, isReady } = useRouter();
   const { slug } = useLibraryContext();
 
   const getLoginUrl = React.useCallback(
@@ -57,10 +57,10 @@ export default function useLogin() {
       const urlObject = getLoginUrl(methodId, error, useCurrentPageAsRedirect);
       if (!IS_SERVER) {
         // redirect to the login page
-        push(urlObject, undefined, { shallow: true });
+        replace(urlObject, undefined, { shallow: true });
       }
     },
-    [push, getLoginUrl]
+    [replace, getLoginUrl]
   );
 
   // the login url without any method selected

--- a/src/components/__tests__/BorrowOrReserve.test.tsx
+++ b/src/components/__tests__/BorrowOrReserve.test.tsx
@@ -10,7 +10,7 @@ import {
 import BorrowOrReserve from "components/BorrowOrReserve";
 import * as fetch from "dataflow/opds1/fetch";
 import { ServerError } from "errors";
-import { mockPush } from "test-utils/mockNextRouter";
+import { mockReplace } from "test-utils/mockNextRouter";
 
 test("shows correct button for borrowable book", async () => {
   setup(<BorrowOrReserve isBorrow url="/url" />);
@@ -69,7 +69,7 @@ test("redirects to login when not signed in", async () => {
   const button = await screen.findByRole("button", {
     name: "Borrow this book"
   });
-  expect(mockPush).toHaveBeenCalledTimes(0);
+  expect(mockReplace).toHaveBeenCalledTimes(0);
 
   await user.click(button);
 
@@ -85,7 +85,7 @@ test("redirects to login when not signed in", async () => {
   expect(mockedFetchBook).not.toHaveBeenCalled();
 
   // redirects to login
-  expect(mockPush).toHaveBeenCalledWith(
+  expect(mockReplace).toHaveBeenCalledWith(
     {
       pathname: "/[library]/login",
       query: { library: "testlib", nextUrl: "/testlib" }

--- a/src/components/__tests__/BorrowOrReserve.test.tsx
+++ b/src/components/__tests__/BorrowOrReserve.test.tsx
@@ -10,7 +10,7 @@ import {
 import BorrowOrReserve from "components/BorrowOrReserve";
 import * as fetch from "dataflow/opds1/fetch";
 import { ServerError } from "errors";
-import { mockPush } from "test-utils/mockNextRouter";
+import { mockPush, mockReplace } from "test-utils/mockNextRouter";
 
 test("shows correct button for borrowable book", async () => {
   setup(<BorrowOrReserve isBorrow url="/url" />);
@@ -84,6 +84,11 @@ test("redirects to login when not signed in", async () => {
   // doesn't call the borrow book
   expect(mockedFetchBook).not.toHaveBeenCalled();
 
+  /**
+   * To ensure browser history is properly maintained,
+   * assert that the Next.js router pushes a new entry onto the stack
+   * and does not replace (as it does for other redirections to login)
+   */
   // redirects to login
   expect(mockPush).toHaveBeenCalledWith(
     {
@@ -93,6 +98,8 @@ test("redirects to login when not signed in", async () => {
     undefined,
     { shallow: true }
   );
+
+  expect(mockReplace).not.toHaveBeenCalled();
 });
 
 test("catches and displays server errors", async () => {

--- a/src/components/__tests__/BorrowOrReserve.test.tsx
+++ b/src/components/__tests__/BorrowOrReserve.test.tsx
@@ -10,7 +10,7 @@ import {
 import BorrowOrReserve from "components/BorrowOrReserve";
 import * as fetch from "dataflow/opds1/fetch";
 import { ServerError } from "errors";
-import { mockReplace } from "test-utils/mockNextRouter";
+import { mockPush } from "test-utils/mockNextRouter";
 
 test("shows correct button for borrowable book", async () => {
   setup(<BorrowOrReserve isBorrow url="/url" />);
@@ -69,7 +69,7 @@ test("redirects to login when not signed in", async () => {
   const button = await screen.findByRole("button", {
     name: "Borrow this book"
   });
-  expect(mockReplace).toHaveBeenCalledTimes(0);
+  expect(mockPush).toHaveBeenCalledTimes(0);
 
   await user.click(button);
 
@@ -85,7 +85,7 @@ test("redirects to login when not signed in", async () => {
   expect(mockedFetchBook).not.toHaveBeenCalled();
 
   // redirects to login
-  expect(mockReplace).toHaveBeenCalledWith(
+  expect(mockPush).toHaveBeenCalledWith(
     {
       pathname: "/[library]/login",
       query: { library: "testlib", nextUrl: "/testlib" }

--- a/src/hooks/useBorrow.ts
+++ b/src/hooks/useBorrow.ts
@@ -7,10 +7,10 @@ import useLogin from "auth/useLogin";
 import { useRouter } from "next/router";
 
 export default function useBorrow(isBorrow: boolean) {
-  const router = useRouter();
   const { catalogUrl } = useLibraryContext();
   const { setBook, token } = useUser();
-  const { getLoginUrl } = useLogin();
+  const { initLogin } = useLogin();
+  const { push } = useRouter();
   const isUnmounted = React.useRef(false);
   const [isLoading, setLoading] = React.useState(false);
   const { error, handleError, setErrorString, clearError } = useError();
@@ -21,9 +21,9 @@ export default function useBorrow(isBorrow: boolean) {
   const borrowOrReserve = async (url: string) => {
     clearError();
     if (!token) {
-      // Use push (not initLogin's replace) so the book page is preserved in
+      // Use push (not initLogin's replace default) so the book page is preserved in
       // history and the back button returns here after sign-in or cancel.
-      router.push(getLoginUrl(), undefined, { shallow: true });
+      initLogin(undefined, undefined, true, push);
       setErrorString("You must be signed in to borrow this book.");
       return;
     }

--- a/src/hooks/useBorrow.ts
+++ b/src/hooks/useBorrow.ts
@@ -4,11 +4,13 @@ import useUser from "components/context/UserContext";
 import useLibraryContext from "components/context/LibraryContext";
 import useError from "hooks/useError";
 import useLogin from "auth/useLogin";
+import { useRouter } from "next/router";
 
 export default function useBorrow(isBorrow: boolean) {
+  const router = useRouter();
   const { catalogUrl } = useLibraryContext();
   const { setBook, token } = useUser();
-  const { initLogin } = useLogin();
+  const { getLoginUrl } = useLogin();
   const isUnmounted = React.useRef(false);
   const [isLoading, setLoading] = React.useState(false);
   const { error, handleError, setErrorString, clearError } = useError();
@@ -19,7 +21,9 @@ export default function useBorrow(isBorrow: boolean) {
   const borrowOrReserve = async (url: string) => {
     clearError();
     if (!token) {
-      initLogin();
+      // Use push (not initLogin's replace) so the book page is preserved in
+      // history and the back button returns here after sign-in or cancel.
+      router.push(getLoginUrl(), undefined, { shallow: true });
       setErrorString("You must be signed in to borrow this book.");
       return;
     }

--- a/src/test-utils/mockNextRouter.tsx
+++ b/src/test-utils/mockNextRouter.tsx
@@ -16,6 +16,14 @@ export const mockPush = jest
 >;
 Router.push = mockPush;
 
+export const mockReplace = jest
+  .fn()
+  .mockImplementation(async () => true) as jest.MockedFunction<
+  typeof Router.replace
+>;
+
+Router.replace = mockReplace;
+
 export const MockNextRouterContextProvider: React.FC<{
   router?: Partial<NextRouter>;
   children?: React.ReactNode;
@@ -32,7 +40,7 @@ export const MockNextRouterContextProvider: React.FC<{
     // default as path is the home page
     asPath = `/${libraryData.slug}`,
     push = mockPush,
-    replace = jest.fn().mockImplementation(async () => true),
+    replace = mockReplace,
     reload = jest.fn().mockImplementation(() => null),
     back = jest.fn().mockImplementation(() => null),
     prefetch = jest.fn().mockImplementation(async () => undefined),


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Updates how the Next.js Router updates the browser's history stack when redirecting to the login screen based on the user's supported authentication method.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When the `initLogin` function is called within an auth component designed to redirect  to the login page(`Login`, `Catch401`, or `AuthProtectedRoute`), the router previously pushed the derived login URL onto the browser's history stack. This would result in two separate entries in the history stack for the login screen. The login hooks update the URL to accommodate the supported auth type, but this does not visually change what's rendered for the user. So when a user goes backward in the history stack, they remain on the login page. 

Previous behavior
Step | Stack | Behavior
-- | -- | --
User clicks "Sign In" | [home, /login] | /login mounts
Login.tsx effect fires | [home, /login, /login/[methodId] | initLogin(methodId) pushes /login/[methodId]
User hits back | [home, /login] | /login mounts again
Login.tsx effect re-fires | [home, /login, /login/[methodId] | Pushes again, keeps user on login screen

New behavior
Step | Stack | Behavior
-- | -- | --
User clicks "Sign In" | [home, /login] | /login mounts
Login.tsx effect fires | [home, /login/basic] | replace overwrites /login
User hits back | [home] | User goes home

However, views that are reachable without authentication don't need to have their locations replaced within the browser history. `BookDetails` renders a "Borrow" button that redirects to the login screen. 

Previous behavior
Step | Stack with replace | Behavior
-- | -- | --
User on book detail | [home, /book/123] |  
Clicks Borrow without token → initLogin() | [home, /login/basic] | /book/123 is gone
Hits back | [home] | User is incorrectly sent home

To prevent this behavior, non-authenticated views should `push` instead of `replace` because their previous locations are not only meant for redirection. 

Step | Stack with push | Behavior
-- | -- | --
User on book detail | [home, /book/123] |  
Clicks Borrow without token → initLogin() | [home, /book/123, /login/basic] | book details remains on stack
Hits back | [home, /book/123] | User returns to book details

[Jira PP-4041](https://ebce-lyrasis.atlassian.net/browse/PP-4041)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Updated tests that mock the replace call on the Router
- Manually tested navigating from book details to authenticated routes that utilize `initLogin`
1. `AuthProtectedRoute` -> `/[library]/loans`
2. `Login` -> `/[library]/login`
3. `useCredentials` -> `/[library]/book/[bookUrl]?error={ title, detail}`
4. `Catch401` -> manually thrown `ServerError`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
