### PR TITLE
Use central github-actions repo for jira-release-sync

### DIFF
--- a/.github/workflows/jira-release-sync.yml
+++ b/.github/workflows/jira-release-sync.yml
@@ -6,11 +6,8 @@ jobs:
   sync-to-jira:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Sync release to Jira
-        uses: ThePalaceProject/circulation/.github/actions/jira-release-sync@main
+        uses: ThePalaceProject/github-actions/jira-release-sync@v1
         with:
           jira-base-url: ${{ secrets.JIRA_BASE_URL }}
           jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}


### PR DESCRIPTION
## Description

Point the Jira Release Sync workflow at `ThePalaceProject/github-actions/jira-release-sync@v1` instead of the action's old home in the circulation repo. Drop the `actions/checkout@v4` step — the action no longer needs a repo checkout.

## Motivation and Context

The `jira-release-sync` action has been moved into the central `ThePalaceProject/github-actions` repo. Switching to it (pinned at the `v1` tag) keeps this workflow in sync with the canonical action location.

## How Has This Been Tested?

Not yet exercised — verification requires publishing a release. Will be confirmed on the next release event.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.