### PR TITLE
Move Bugsnag / GTM configuration to environment variables (PP-4266)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,17 @@ The app is configured with a YAML file. Point the app at it by setting the `CONF
 | `instance_name` | string | `"Patron Web Catalog"` | Name used in error tracking and debug output. Not patron-facing. |
 | `companion_app` | `"simplye"` \| `"openebooks"` | `"simplye"` | Selects which companion mobile app to reference in redirect prompts. |
 | `show_medium` | boolean | `true` | Whether to display the medium (e-book, audiobook, etc.) label on book cards. |
-| `bugsnag_api_key` | string | — | Bugsnag project API key. Omit to disable error tracking. |
-| `gtm_id` | string | — | Google Tag Manager container ID (e.g. `GTM-XXXX`). Omit to disable analytics. |
 | `media_support` | mapping | `{}` | Per-MIME-type rendering mode. See [Media Support](#media-support) below. |
 | `static_libraries` | mapping | — | Static library definitions. See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
 | `registries` | list | `[]` | One or more library registry URLs fetched at runtime. See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
-| `libraries` | mapping or string | — | **Deprecated.** Use `static_libraries` (mapping) or `registries` (string). See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
+
+#### Deprecated Configuration Options
+
+| Key | Description                                                                                                                                                         |
+|-----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `bugsnag_api_key` | Use the `BUGSNAG_API_KEY` environment variable instead. The value for this key is ignored.                                                                          |
+| `gtm_id` | Use the `GTM_ID` environment variable instead. The value for this key is ignored.                                                                                   |
+| `libraries` | Use `static_libraries` (mapping) or `registries` (string). See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
 
 ### Media Support
 
@@ -113,7 +118,9 @@ The app can then be run with `npm run start`, and it will pick up the env from y
 
 The following environment variables can be set to further configure the application.
 
-- Set `AXE_TEST=true` to run the application with `react-axe` enabled (only works when `NODE_ENV` is "development").
+- Set `BUGSNAG_API_KEY` to your Bugsnag project API key to enable error tracking. If unset, Bugsnag is disabled.
+- Set `GTM_ID` to your Google Tag Manager container ID (format: `GTM-XXXXXXXX`) to enable web analytics. If unset, GTM is not loaded.
+- Set `REACT_AXE=true` to run the application with `react-axe` enabled (only works when `NODE_ENV` is "development").
 - Set `ANALYZE=true` to generate bundle analysis files inside `.next/analyze` which will show bundle sizes for server and client, as well as composition.
 
 ## Manager, Registry, and Application Configurations

--- a/community-config.yml
+++ b/community-config.yml
@@ -49,11 +49,11 @@ media_support:
 # default is "simplye"
 companion_app: simplye
 
-# BUGSNAG: defines the bugsnag api key to integrate error tracking
-# bugsnag_api_key: xxx
+# BUGSNAG: set the BUGSNAG_API_KEY environment variable to integrate error tracking.
+# (Setting bugsnag_api_key in this file is deprecated and will be ignored.)
 
-# GOOGLE TAG MANAGER: defines the google tag manager id to integrate web analytics
-# gtm_id: xxx
+# GOOGLE TAG MANAGER: set the GTM_ID environment variable to integrate web analytics.
+# (Setting gtm_id in this file is deprecated and will be ignored.)
 
 # There are also some environment variables that can be set in the .env.local
 # file. They are set there because they're for development, not production

--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,8 @@ log(`APP_VERSION: ${APP_VERSION}`);
 log(`NODE_ENV: ${NODE_ENV}`);
 log(`RELEASE_STAGE: ${RELEASE_STAGE}`);
 log(`BUILD_ID: ${BUILD_ID}`);
+log(`BUGSNAG_API_KEY: ${process.env.BUGSNAG_API_KEY ?? "(not set)"}`);
+log(`GTM_ID: ${process.env.GTM_ID ?? "(not set)"}`);
 
 const config = {
   output: "standalone",

--- a/src/analytics/GoogleTagManager.tsx
+++ b/src/analytics/GoogleTagManager.tsx
@@ -1,28 +1,35 @@
 import * as React from "react";
-import Head from "next/head";
 
 type Props = { gtmId: string | null | undefined };
 
+// GTM container IDs are always in the form GTM-XXXXXXXX (uppercase alphanumeric).
+const GTM_ID_RE = /^GTM-[A-Z0-9]+$/;
+
 export const GTMScript: React.FC<Props> = ({ gtmId }) => {
   if (!gtmId) return null;
+  if (!GTM_ID_RE.test(gtmId)) {
+    console.error(
+      `GTM_ID "${gtmId}" is not a valid GTM container ID (expected GTM-XXXXXXXX). ` +
+        "GTM will not be loaded."
+    );
+    return null;
+  }
   return (
-    <Head>
-      <script
-        dangerouslySetInnerHTML={{
-          __html:
-            `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':` +
-            `new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],` +
-            `j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=` +
-            `'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);` +
-            `})(window,document,'script','dataLayer','${gtmId}');`
-        }}
-      />
-    </Head>
+    <script
+      dangerouslySetInnerHTML={{
+        __html:
+          `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':` +
+          `new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],` +
+          `j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=` +
+          `'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);` +
+          `})(window,document,'script','dataLayer','${gtmId}');`
+      }}
+    />
   );
 };
 
 export const GTMNoscript: React.FC<Props> = ({ gtmId }) => {
-  if (!gtmId) return null;
+  if (!gtmId || !GTM_ID_RE.test(gtmId)) return null;
   return (
     <noscript
       dangerouslySetInnerHTML={{

--- a/src/analytics/__tests__/GoogleTagManager.test.tsx
+++ b/src/analytics/__tests__/GoogleTagManager.test.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import { render } from "test-utils";
+import { GTMScript, GTMNoscript } from "../GoogleTagManager";
+
+const INVALID_IDS = [
+  ["lowercase", "gtm-abc123"],
+  ["missing prefix", "ABC123"],
+  ["with spaces", "GTM-ABC 123"],
+  ["with special chars", "GTM-<script>"]
+] as const;
+
+describe("GTMScript", () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""]
+  ])("renders nothing and does not error when gtmId is %s", (_label, gtmId) => {
+    const { container } = render(<GTMScript gtmId={gtmId} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  test.each(INVALID_IDS)(
+    "renders nothing and logs an error for invalid format: %s",
+    (_label, gtmId) => {
+      const { container } = render(<GTMScript gtmId={gtmId} />);
+      expect(container).toBeEmptyDOMElement();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("is not a valid GTM container ID")
+      );
+    }
+  );
+
+  it("renders a script tag and does not error with a valid GTM id", () => {
+    const { container } = render(<GTMScript gtmId="GTM-ABC123" />);
+    const script = container.querySelector("script");
+    expect(script).not.toBeNull();
+    expect(script?.innerHTML).toContain("GTM-ABC123");
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("GTMNoscript", () => {
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""]
+  ])("renders nothing when gtmId is %s", (_label, gtmId) => {
+    const { container } = render(<GTMNoscript gtmId={gtmId} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test.each(INVALID_IDS)(
+    "renders nothing for invalid format: %s",
+    (_label, gtmId) => {
+      const { container } = render(<GTMNoscript gtmId={gtmId} />);
+      expect(container).toBeEmptyDOMElement();
+    }
+  );
+
+  it("renders a noscript iframe with a valid GTM id", () => {
+    const { container } = render(<GTMNoscript gtmId="GTM-ABC123" />);
+    const noscript = container.querySelector("noscript");
+    expect(noscript).not.toBeNull();
+    expect(noscript?.innerHTML).toContain("GTM-ABC123");
+  });
+});

--- a/src/components/context/__tests__/AppConfigContext.test.tsx
+++ b/src/components/context/__tests__/AppConfigContext.test.tsx
@@ -45,7 +45,6 @@ describe("useAppConfig", () => {
 
   test.each<[string, Partial<AppConfig>]>([
     ["instanceName", { instanceName: "Custom Library" }],
-    ["gtmId", { gtmId: "GTM-XXXX" }],
     ["bugsnagApiKey", { bugsnagApiKey: "abc123" }],
     ["companionApp", { companionApp: "openebooks" }],
     ["showMedium", { showMedium: false }]

--- a/src/config/__tests__/fallbackAppConfig.test.ts
+++ b/src/config/__tests__/fallbackAppConfig.test.ts
@@ -5,7 +5,6 @@ describe("FALLBACK_APP_CONFIG", () => {
     ["instanceName", ""],
     ["companionApp", "simplye"],
     ["showMedium", true],
-    ["gtmId", null],
     ["bugsnagApiKey", null],
     ["openebooks", null]
   ])("%s defaults to %p", (field, expected) => {

--- a/src/config/fallbackAppConfig.ts
+++ b/src/config/fallbackAppConfig.ts
@@ -5,7 +5,6 @@ const FALLBACK_APP_CONFIG: AppConfig = {
   mediaSupport: {},
   companionApp: "simplye",
   showMedium: true,
-  gtmId: null,
   bugsnagApiKey: null,
   openebooks: null
 };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,7 +23,6 @@ export type AppConfig = {
   staticLibraries?: LibrariesConfig;
   companionApp: "simplye" | "openebooks";
   showMedium: boolean;
-  gtmId: string | null;
   bugsnagApiKey: string | null;
   openebooks: OpenEbooksConfig | null;
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,6 @@ import { BreadcrumbProvider } from "components/context/BreadcrumbContext";
 import AppConfigContext from "components/context/AppConfigContext";
 import { initBugsnag } from "analytics/bugsnag";
 import { setMediaSupportConfig } from "utils/fulfill";
-import { GTMScript, GTMNoscript } from "analytics/GoogleTagManager";
 import type { AppConfig } from "interfaces";
 import FALLBACK_APP_CONFIG from "config/fallbackAppConfig";
 
@@ -47,10 +46,6 @@ const MyApp = (props: AppProps) => {
 
   return (
     <AppConfigContext.Provider value={appConfig}>
-      <GTMScript gtmId={appConfig.gtmId} />
-      {/* Note: GTM recommends placing this immediately after <body>, but _document.tsx
-          has no access to runtime config. It still appears in SSR HTML and functions correctly. */}
-      <GTMNoscript gtmId={appConfig.gtmId} />
       <ErrorBoundary>
         <BreadcrumbProvider>
           <Component {...pageProps} />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,12 +1,18 @@
 import * as React from "react";
 import Document, { Html, Head, Main, NextScript } from "next/document";
+import { GTMScript, GTMNoscript } from "analytics/GoogleTagManager";
 
 class MyDocument extends Document {
   render() {
+    // process.env.GTM_ID is accessible here because _document.tsx is server-only.
+    const gtmId = process.env.GTM_ID ?? null;
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <GTMScript gtmId={gtmId} />
+        </Head>
         <body>
+          <GTMNoscript gtmId={gtmId} />
           <Main />
           <NextScript />
         </body>

--- a/src/server/__tests__/appConfig.test.ts
+++ b/src/server/__tests__/appConfig.test.ts
@@ -392,26 +392,59 @@ describe("config parsing", () => {
   // --- bugsnagApiKey ---
 
   describe("bugsnagApiKey", () => {
-    it("is null when absent", async () => {
+    it("is null when BUGSNAG_API_KEY env var is not set", async () => {
+      delete process.env.BUGSNAG_API_KEY;
       expect((await load(MINIMAL_YAML)).bugsnagApiKey).toBeNull();
     });
 
-    it("uses the string value of bugsnag_api_key", async () => {
-      expect((await load(`bugsnag_api_key: abc123`)).bugsnagApiKey).toBe(
-        "abc123"
-      );
+    it("reads from the BUGSNAG_API_KEY env var", async () => {
+      process.env.BUGSNAG_API_KEY = "env-key-123";
+      expect((await load(MINIMAL_YAML)).bugsnagApiKey).toBe("env-key-123");
+    });
+
+    describe("deprecation warning when bugsnag_api_key is in config file", () => {
+      test.each<[string, string | undefined, string | null]>([
+        ["env var set — uses env var", "env-key", "env-key"],
+        ["env var absent — bugsnagApiKey is null", undefined, null]
+      ])("%s", async (_label, envValue, expectedKey) => {
+        if (envValue !== undefined) {
+          process.env.BUGSNAG_API_KEY = envValue;
+        } else {
+          delete process.env.BUGSNAG_API_KEY;
+        }
+        const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const config = await load("bugsnag_api_key: yaml-key");
+        expect(spy).toHaveBeenCalledWith(
+          expect.stringContaining("BUGSNAG_API_KEY")
+        );
+        if (envValue === undefined) {
+          expect(spy).toHaveBeenCalledWith(
+            expect.stringContaining("Bugsnag will not be configured")
+          );
+        } else {
+          expect(spy).not.toHaveBeenCalledWith(
+            expect.stringContaining("Bugsnag will not be configured")
+          );
+        }
+        expect(config.bugsnagApiKey).toBe(expectedKey);
+        spy.mockRestore();
+      });
     });
   });
 
-  // --- gtmId ---
+  // --- gtmId (deprecated) ---
 
-  describe("gtmId", () => {
-    it("is null when absent", async () => {
-      expect((await load(MINIMAL_YAML)).gtmId).toBeNull();
+  describe("gtmId (deprecated)", () => {
+    it("does not appear in config when absent", async () => {
+      expect(await load(MINIMAL_YAML)).not.toHaveProperty("gtmId");
     });
 
-    it("uses the string value of gtmId", async () => {
-      expect((await load(`gtmId: GTM-XXXX`)).gtmId).toBe("GTM-XXXX");
+    it("logs a deprecation warning and ignores the value when gtm_id is set", async () => {
+      const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const config = await load("gtm_id: GTM-XXXX");
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining("GTM_ID"));
+      expect(config).not.toHaveProperty("gtmId");
+      spy.mockRestore();
     });
   });
 
@@ -821,8 +854,6 @@ describe("config parsing", () => {
       "instance_name: Test Instance",
       "companion_app: openebooks",
       "show_medium: false",
-      "bugsnag_api_key: key-abc",
-      "gtm_id: GTM-TEST",
       "static_libraries:",
       "  my-lib:",
       "    auth_doc_url: https://example.com/auth",
@@ -841,8 +872,6 @@ describe("config parsing", () => {
       "instanceName: Test Instance",
       "companionApp: openebooks",
       "showMedium: false",
-      "bugsnagApiKey: key-abc",
-      "gtmId: GTM-TEST",
       "staticLibraries:",
       "  my-lib:",
       "    authDocUrl: https://example.com/auth",
@@ -863,12 +892,10 @@ describe("config parsing", () => {
     ])(
       "parses all top-level keys from %s YAML into identical config",
       async (_form, yaml) => {
-        expect(await load(yaml)).toEqual({
+        expect(await load(yaml)).toMatchObject({
           instanceName: "Test Instance",
           companionApp: "openebooks",
           showMedium: false,
-          bugsnagApiKey: "key-abc",
-          gtmId: "GTM-TEST",
           staticLibraries: {
             "my-lib": {
               title: "My Library",

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -29,7 +29,6 @@ const INCREMENTAL_URL = `${REGISTRY_URL}?order=modified`;
 function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {
     instanceName: "Test",
-    gtmId: null,
     bugsnagApiKey: null,
     companionApp: "simplye",
     showMedium: true,

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -36,8 +36,6 @@ const RawConfigSchema = type({
   "instanceName?": "unknown",
   "companionApp?": "string",
   "showMedium?": "boolean",
-  "bugsnagApiKey?": "string",
-  "gtmId?": "string",
   "registries?": RegistryEntrySchema.array(),
   "libraries?": "string | Record<string, unknown>",
   "staticLibraries?": "Record<string, unknown>",
@@ -150,6 +148,25 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     "staticLibraries",
     "mediaSupport"
   ]);
+
+  if ("bugsnagApiKey" in normalized) {
+    const envIsSet = Boolean(process.env.BUGSNAG_API_KEY);
+    console.warn(
+      "CONFIG_FILE: 'bugsnag_api_key' / 'bugsnagApiKey' is deprecated. " +
+        "Set the BUGSNAG_API_KEY environment variable instead. " +
+        "The value in the config file is ignored." +
+        (envIsSet
+          ? ""
+          : " BUGSNAG_API_KEY is not set — Bugsnag will not be configured.")
+    );
+  }
+  if ("gtmId" in normalized) {
+    console.warn(
+      "CONFIG_FILE: 'gtm_id' / 'gtmId' is deprecated. " +
+        "Set the GTM_ID environment variable instead. " +
+        "The value in the config file is ignored."
+    );
+  }
   if (Array.isArray(normalized.registries)) {
     normalized.registries = normalized.registries.map(r =>
       r !== null && typeof r === "object" && !Array.isArray(r)
@@ -275,8 +292,7 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     registries,
     staticLibraries,
     mediaSupport: (result.mediaSupport as MediaSupportConfig) ?? {},
-    bugsnagApiKey: result.bugsnagApiKey ?? null,
-    gtmId: result.gtmId ?? null,
+    bugsnagApiKey: process.env.BUGSNAG_API_KEY ?? null,
     companionApp,
     showMedium,
     openebooks

--- a/src/test-utils/fixtures/config.ts
+++ b/src/test-utils/fixtures/config.ts
@@ -2,7 +2,6 @@ import { AppConfig } from "interfaces";
 
 export const config: AppConfig = {
   instanceName: "Test Instance",
-  gtmId: null,
   bugsnagApiKey: null,
   companionApp: "simplye",
   showMedium: true,

--- a/tests/pages/api/libraries.test.ts
+++ b/tests/pages/api/libraries.test.ts
@@ -37,7 +37,6 @@ const mockGetAppConfig = getAppConfig as jest.MockedFunction<
 
 const VALID_APP_CONFIG: AppConfig = {
   instanceName: "Test",
-  gtmId: null,
   bugsnagApiKey: null,
   companionApp: "simplye",
   showMedium: true,


### PR DESCRIPTION
## Description

Moves `bugsnag_api_key` and `gtm_id` out of the YAML config file and into environment variables (`BUGSNAG_API_KEY` and `GTM_ID`). The YAML keys are still accepted but emit a deprecation warning and are ignored; their values are never used.

As part of this change, Google Tag Manager (GTM) injection moves from `_app.tsx` (where it previousely read `gtmId` from the app config object passed via `pageProps`) to `_document.tsx` (where `process.env.GTM_ID` is read directly, server-side). The new setup uses the correct placements per GTM's own recommendations — the script tag belongs in `<head>` and the `<noscript>` fallback belongs as the first element in `<body>`.

Additional hardening:
- `GTMScript` and `GTMNoscript` now validate the GTM container ID format (`GTM-[A-Z0-9]+`). A truthy but malformed value causes `GTMScript` to log a `console.error` and render nothing, rather than silently injecting a broken or potentially unsafe script.
- The Bugsnag deprecation warning includes a note when `BUGSNAG_API_KEY` is also absent, so operators know Bugsnag will not be configured (not just that the YAML value is ignored).
- The `GTMScript` component no longer wraps its output in `next/head`, which is unsupported inside `_document.tsx`.

## Motivation and Context

- Keeping the Bugsnag API key and GTM ID in the YAML config file meant they could not be delivered before the first request. For the Bugsnag API key, this meant that reporting could not be available for functions that occurred before the first request. 
- For GTM config, delayed availability meant that we could not locate the GTM-related elements in the recommended locations in the DOM.

[Jira PP-4266]

## How Has This Been Tested?

- Manual testing in my development environment.
- New and updated unit tests cover all changed behavior.
- All checks pass locally.
- CI checks pass.


## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
