### PR TITLE
Prefer heuristic library short name for slug (PP-4263)

### DIFF
--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -97,7 +97,6 @@ function makePagedFeed(
       links: authDocUrl
         ? [
             {
-              rel: "http://opds-spec.org/auth/document",
               type: "application/vnd.opds.authentication.v1.0+json",
               href: authDocUrl
             }
@@ -250,12 +249,12 @@ describe("fetchRegistryLibraries", () => {
       {
         id: "urn:uuid:abc",
         title: "Library A",
-        authDocUrl: "https://a.example.com/auth"
+        authDocUrl: "https://a.example.com/"
       },
       {
         id: "urn:uuid:def",
         title: "Library B",
-        authDocUrl: "https://b.example.com/auth"
+        authDocUrl: "https://b.example.com/"
       }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
@@ -266,12 +265,12 @@ describe("fetchRegistryLibraries", () => {
       "urn:uuid:abc": {
         id: "urn:uuid:abc",
         title: "Library A",
-        authDocUrl: "https://a.example.com/auth"
+        authDocUrl: "https://a.example.com/"
       },
       "urn:uuid:def": {
         id: "urn:uuid:def",
         title: "Library B",
-        authDocUrl: "https://b.example.com/auth"
+        authDocUrl: "https://b.example.com/"
       }
     });
   });
@@ -284,7 +283,7 @@ describe("fetchRegistryLibraries", () => {
           {
             id: "urn:uuid:p1",
             title: "Page 1 Lib",
-            authDocUrl: "https://p1.example.com/auth"
+            authDocUrl: "https://p1.example.com/"
           }
         ],
         { nextHref: PAGE_2_URL }
@@ -293,7 +292,7 @@ describe("fetchRegistryLibraries", () => {
         {
           id: "urn:uuid:p2",
           title: "Page 2 Lib",
-          authDocUrl: "https://p2.example.com/auth"
+          authDocUrl: "https://p2.example.com/"
         }
       ])
     }) as unknown as typeof fetch;
@@ -311,7 +310,7 @@ describe("fetchRegistryLibraries", () => {
       {
         id: "urn:uuid:abc",
         title: "Library A",
-        authDocUrl: "https://a.example.com/auth"
+        authDocUrl: "https://a.example.com/"
       },
       { id: "urn:uuid:no-auth", title: "No Auth Library" }
     ]);
@@ -347,7 +346,7 @@ describe("fetchRegistryLibraries", () => {
           {
             id: "urn:uuid:p1",
             title: "P1",
-            authDocUrl: "https://p1.example.com/auth"
+            authDocUrl: "https://p1.example.com/"
           }
         ],
         { nextHref: PAGE_2_URL }
@@ -363,9 +362,10 @@ describe("fetchRegistryLibraries", () => {
       {
         id: "valid-library",
         title: "Valid",
-        authDocUrl: "https://v.example.com/auth"
+        authDocUrl: "https://v.example.com/"
       },
-      { id: "", title: "Empty Slug", authDocUrl: "https://b.example.com/auth" }
+      // Empty id: computeSlug falls back to "" via metadata.id, which is invalid.
+      { id: "", title: "Empty Slug", authDocUrl: "https://b.example.com/" }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
     const warnSpy = jest
@@ -419,7 +419,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -440,13 +440,13 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: NEW_TIMESTAMP
         },
         {
           id: "urn:uuid:b",
           title: "B",
-          authDocUrl: "https://b.example.com/auth",
+          authDocUrl: "https://b.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -462,13 +462,13 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:c",
           title: "C (new)",
-          authDocUrl: "https://c.example.com/auth",
+          authDocUrl: "https://c.example.com/",
           updated: NEW_TIMESTAMP
         },
         {
           id: "urn:uuid:a",
           title: "A (old)",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: OLD_TIMESTAMP
         }
       ],
@@ -497,13 +497,13 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: NEW_TIMESTAMP
         },
         {
           id: "urn:uuid:b",
           title: "B",
-          authDocUrl: "https://b.example.com/auth",
+          authDocUrl: "https://b.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -519,7 +519,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: OLD_TIMESTAMP
         }
       ],
@@ -545,13 +545,13 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: NEW_TIMESTAMP
         },
         {
           id: "urn:uuid:b",
           title: "B",
-          authDocUrl: "https://b.example.com/auth",
+          authDocUrl: "https://b.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -569,7 +569,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -591,7 +591,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -619,7 +619,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -639,7 +639,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth"
+          authDocUrl: "https://a.example.com/"
         }
       ]
       // no incrementalFacetHref
@@ -662,7 +662,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -677,13 +677,13 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:b",
           title: "B (no date)",
-          authDocUrl: "https://b.example.com/auth",
+          authDocUrl: "https://b.example.com/",
           updated: ""
         },
         {
           id: "urn:uuid:c",
           title: "C (new)",
-          authDocUrl: "https://c.example.com/auth",
+          authDocUrl: "https://c.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -708,7 +708,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:cached",
           title: "Cached",
-          authDocUrl: "https://cached.example.com/auth",
+          authDocUrl: "https://cached.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -732,7 +732,7 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
         {
           id: "urn:uuid:a",
           title: "A",
-          authDocUrl: "https://a.example.com/auth",
+          authDocUrl: "https://a.example.com/",
           updated: NEW_TIMESTAMP
         }
       ],
@@ -781,7 +781,7 @@ describe("getLibraries", () => {
       {
         id: "urn:uuid:reg",
         title: "Registry Lib",
-        authDocUrl: "https://r.example.com/auth"
+        authDocUrl: "https://r.example.com/"
       }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
@@ -798,7 +798,7 @@ describe("getLibraries", () => {
       {
         id: "urn:uuid:shared",
         title: "Registry Version",
-        authDocUrl: "https://r.example.com/auth"
+        authDocUrl: "https://r.example.com/"
       }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
@@ -822,14 +822,14 @@ describe("getLibraries", () => {
       {
         id: "urn:uuid:shared",
         title: "First Registry",
-        authDocUrl: "https://r1.example.com/auth"
+        authDocUrl: "https://r1.example.com/"
       }
     ]);
     const feed2 = makePagedFeed([
       {
         id: "urn:uuid:shared",
         title: "Second Registry",
-        authDocUrl: "https://r2.example.com/auth"
+        authDocUrl: "https://r2.example.com/"
       }
     ]);
 
@@ -862,7 +862,7 @@ describe("getLibraries", () => {
 
   it("does not re-fetch before min interval has elapsed", async () => {
     const feed = makePagedFeed([
-      { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth" }
+      { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/" }
     ]);
     const fetchMock = mockFetchSuccess(feed);
     global.fetch = fetchMock as unknown as typeof fetch;
@@ -910,7 +910,7 @@ describe("concurrent first-fetch coalescing", () => {
       {
         id: "urn:uuid:abc",
         title: "Library A",
-        authDocUrl: "https://a.example.com/auth"
+        authDocUrl: "https://a.example.com/"
       }
     ]);
 
@@ -1018,7 +1018,7 @@ describe("fetch timeout", () => {
   it("clears the timeout after a successful fetch (no timer leak)", async () => {
     jest.useFakeTimers();
     const feed = makePagedFeed([
-      { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/auth" }
+      { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/" }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
 
@@ -1061,7 +1061,7 @@ describe("fetch timeout", () => {
                   {
                     id: "urn:uuid:p1",
                     title: "P1",
-                    authDocUrl: "https://p1.example.com/auth"
+                    authDocUrl: "https://p1.example.com/"
                   }
                 ],
                 { nextHref: PAGE_2_URL }
@@ -1070,7 +1070,7 @@ describe("fetch timeout", () => {
                 {
                   id: "urn:uuid:p2",
                   title: "P2",
-                  authDocUrl: "https://p2.example.com/auth"
+                  authDocUrl: "https://p2.example.com/"
                 }
               ]);
         return Promise.resolve({

--- a/src/utils/__tests__/librarySlug.test.ts
+++ b/src/utils/__tests__/librarySlug.test.ts
@@ -1,11 +1,33 @@
-import { computeSlug, validateSlug } from "../librarySlug";
+import {
+  computeSlug,
+  getRegistryLibraryShortName,
+  validateSlug
+} from "../librarySlug";
 import type { OPDS2 } from "interfaces";
 
-function makeCatalog(id: string): OPDS2.CatalogEntry {
+function makeCatalog(
+  id: string,
+  links: OPDS2.CatalogEntry["links"] = []
+): OPDS2.CatalogEntry {
   return {
     metadata: { id, title: "Test Library", updated: "", description: "" },
-    links: []
+    links
   };
+}
+
+function catalogLink(href: string): OPDS2.Link {
+  return {
+    rel: "http://opds-spec.org/catalog",
+    type: "application/atom+xml;profile=opds-catalog;kind=acquisition",
+    href
+  } as OPDS2.Link;
+}
+
+function authDocLink(href: string): OPDS2.Link {
+  return {
+    type: "application/vnd.opds.authentication.v1.0+json",
+    href
+  } as OPDS2.Link;
 }
 
 // ---------------------------------------------------------------------------
@@ -44,26 +66,107 @@ describe("validateSlug", () => {
 // computeSlug
 // ---------------------------------------------------------------------------
 
-describe("computeSlug", () => {
-  it("returns URN ids unchanged", () => {
-    expect(computeSlug(makeCatalog("urn:uuid:abc123"))).toBe("urn:uuid:abc123");
-    expect(computeSlug(makeCatalog("urn:isbn:0451450523"))).toBe(
-      "urn:isbn:0451450523"
-    );
-    expect(
-      computeSlug(makeCatalog("urn:uuid:3f0b05a0-4b6f-11ee-be56-0242ac120002"))
-    ).toBe("urn:uuid:3f0b05a0-4b6f-11ee-be56-0242ac120002");
+describe("getRegistryLibraryShortName", () => {
+  describe("catalog root link (primary source)", () => {
+    it("returns the first path component of the catalog root link href", () => {
+      const entry = makeCatalog("urn:uuid:abc", [
+        catalogLink("https://example.com/XYZZY/"),
+        authDocLink("https://example.com/XYZZY/authentication_document")
+      ]);
+      expect(getRegistryLibraryShortName(entry)).toBe("XYZZY");
+    });
+
+    it("prefers the catalog root link over the auth document link", () => {
+      const entry = makeCatalog("id", [
+        authDocLink("https://example.com/XYZZY-auth/auth"),
+        catalogLink("https://example.com/XYZZY-catalog/")
+      ]);
+      expect(getRegistryLibraryShortName(entry)).toBe("XYZZY-catalog");
+    });
+
+    it("strips subsequent path segments, keeping only the first component", () => {
+      const entry = makeCatalog("id", [
+        catalogLink("https://example.com/XYZZY/feeds/loans")
+      ]);
+      expect(getRegistryLibraryShortName(entry)).toBe("XYZZY");
+    });
   });
 
-  it("returns non-URN ids unchanged", () => {
+  describe("auth document link (secondary source)", () => {
+    it("matches by type when no rel is present", () => {
+      const entry = makeCatalog("urn:uuid:abc", [
+        authDocLink("https://example.com/XYZZY/authentication_document")
+      ]);
+      expect(getRegistryLibraryShortName(entry)).toBe("XYZZY");
+    });
+
+    it("matches by rel when present", () => {
+      const entry = makeCatalog("urn:uuid:abc", [
+        {
+          rel: "http://opds-spec.org/auth/document",
+          href: "https://example.com/XYZZY/authentication_document"
+        } as OPDS2.Link
+      ]);
+      expect(getRegistryLibraryShortName(entry)).toBe("XYZZY");
+    });
+
+    it("falls back to auth doc link when catalog link has no path component", () => {
+      const entry = makeCatalog("id", [
+        catalogLink("https://example.com/"),
+        authDocLink("https://example.com/XYZZY/auth")
+      ]);
+      expect(getRegistryLibraryShortName(entry)).toBe("XYZZY");
+    });
+  });
+
+  it("returns null when no links are present", () => {
+    expect(
+      getRegistryLibraryShortName(makeCatalog("urn:uuid:abc123"))
+    ).toBeNull();
+  });
+
+  it("returns null when both links have no meaningful path component", () => {
+    const entry = makeCatalog("my-library-id", [
+      catalogLink("https://example.com/"),
+      authDocLink("https://example.com/")
+    ]);
+    expect(getRegistryLibraryShortName(entry)).toBeNull();
+  });
+
+  it("returns null when no links are of the recognized types", () => {
+    const entry = makeCatalog("my-id", [
+      {
+        rel: "self",
+        type: "application/opds+json",
+        href: "https://x.com/foo/"
+      } as OPDS2.Link
+    ]);
+    expect(getRegistryLibraryShortName(entry)).toBeNull();
+  });
+
+  it("returns null when the link href is not an absolute URL", () => {
+    const entry = makeCatalog("id", [authDocLink("/relative/path")]);
+    expect(getRegistryLibraryShortName(entry)).toBeNull();
+  });
+});
+
+describe("computeSlug", () => {
+  it("returns the short name when available", () => {
+    const entry = makeCatalog("urn:uuid:abc", [
+      catalogLink("https://example.com/XYZZY/")
+    ]);
+    expect(computeSlug(entry)).toBe("XYZZY");
+  });
+
+  it("falls back to metadata.id when no short name can be derived", () => {
+    expect(computeSlug(makeCatalog("urn:uuid:abc123"))).toBe("urn:uuid:abc123");
     expect(computeSlug(makeCatalog("my-library"))).toBe("my-library");
-    expect(computeSlug(makeCatalog("library123"))).toBe("library123");
   });
 
   it("produces a slug that passes validateSlug", () => {
-    const slug = computeSlug(
-      makeCatalog("urn:uuid:3f0b05a0-4b6f-11ee-be56-0242ac120002")
-    );
-    expect(validateSlug(slug)).toBe(true);
+    const entry = makeCatalog("urn:uuid:3f0b05a0-4b6f-11ee-be56-0242ac120002", [
+      catalogLink("https://example.com/XYZZY/")
+    ]);
+    expect(validateSlug(computeSlug(entry))).toBe(true);
   });
 });

--- a/src/utils/librarySlug.ts
+++ b/src/utils/librarySlug.ts
@@ -1,4 +1,4 @@
-import type { OPDS2 } from "interfaces";
+import { OPDS2 } from "interfaces";
 
 /**
  * Returns `true` if slug is considered valid.
@@ -10,12 +10,60 @@ export function validateSlug(slug: string): boolean {
   return slug.length > 0;
 }
 
+function firstPathComponent(href: string): string | null {
+  try {
+    const parts = new URL(href).pathname.split("/").filter(p => p.length > 0);
+    const raw = parts[0];
+    if (!raw) return null;
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Heuristically derives a short name for a library from its registry catalog
+ * entry by extracting the first path component of the catalog root link, or
+ * the authentication document link when the catalog link yields no path
+ * component. Returns null when neither link yields a path component.
+ */
+export function getRegistryLibraryShortName(
+  catalogEntry: OPDS2.CatalogEntry
+): string | null {
+  const catalogLink = catalogEntry.links.find(
+    l => l.rel === OPDS2.CatalogRootRelation
+  );
+  if (catalogLink) {
+    const component = firstPathComponent(catalogLink.href);
+    if (component) return component;
+  }
+
+  // TODO: Match only on l.rel === OPDS2.AuthDocumentRelation once the registry
+  // consistently includes a rel attribute on authentication document links.
+  const authDocLink = catalogEntry.links.find(
+    l =>
+      l.rel === OPDS2.AuthDocumentRelation ||
+      l.type === OPDS2.AuthDocumentMediaType
+  );
+  if (authDocLink) {
+    const component = firstPathComponent(authDocLink.href);
+    if (component) return component;
+  }
+
+  return null;
+}
+
 /**
  * Computes the URL slug for a library from its registry catalog entry.
  * The slug is used in URL paths (`/[slug]/`).
  *
- * Currently, the slug is simply the library's registry ID.'
+ * Prefers the library short name derived from link URLs, then falls back
+ * to the library's registry identifier.
  */
 export function computeSlug(catalogEntry: OPDS2.CatalogEntry): string {
-  return catalogEntry.metadata.id;
+  return getRegistryLibraryShortName(catalogEntry) ?? catalogEntry.metadata.id;
 }


### PR DESCRIPTION
## Description

Adds heuristic derivation of each library's slug from its registry catalog entrie. Extracts the first path component of the catalog root link (e.g. `CA0156` from `https://ca.thepalaceproject.org/CA0156/`), falling back to the same part of the authentication document link, and returning `null` if neither yields a value. `computeSlug` calls it and falls back to the registry identifier as before.

## Motivation and Context

We want to use the library short name as the slug, but we don't maintain that value in the registry (let alone include it in the feed). So, for the time being, we heuristically pull it from the first path component of the library catalog or authentication document URL, since that is a safe place to find it for the Palace Manager library catalog servers in The Palace Project hosted environment. 

[Jira PP-4263]

## How Has This Been Tested?

- New/updated tests to cover the new and changed functionality.
- Manual testing in local dev environment.
- All checks pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/25460022748) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.