### PR TITLE
Better handling of cancelled/failed redirect logins (PP-3961)

### DIFF
--- a/src/auth/AuthFeedbackPanel.tsx
+++ b/src/auth/AuthFeedbackPanel.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import Button from "components/Button";
+import Stack from "components/Stack";
+import { Text } from "components/Text";
+
+export const AuthFeedbackPanel = ({
+  message,
+  isError = false,
+  onTryAgain
+}: {
+  message: string;
+  isError?: boolean;
+  onTryAgain: () => void;
+}) => (
+  <Stack
+    direction="column"
+    sx={{
+      alignItems: "center",
+      gap: 3,
+      maxWidth: 500,
+      margin: "0 auto",
+      textAlign: "center",
+      textWrap: "balance"
+    }}
+  >
+    <Text sx={isError ? { color: "ui.error", fontSize: 2 } : { fontSize: 2 }}>
+      {message}
+    </Text>
+    <Button onClick={onTryAgain}>Try Again</Button>
+  </Stack>
+);

--- a/src/auth/AuthProtectedRoute.tsx
+++ b/src/auth/AuthProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import useLogin from "auth/useLogin";
 import useUser from "components/context/UserContext";
 import { PageLoader } from "components/LoadingIndicator";
+import { useRouter } from "next/router";
 import React from "react";
 
 /**
@@ -14,12 +15,18 @@ interface Props {
 const AuthProtectedRoute = ({ children }: Props) => {
   const { isLoading, isAuthenticated, token, error } = useUser();
   const { initLogin } = useLogin();
+  const { query } = useRouter();
+
+  // An 'error' query param indicates the IdP redirected back with a failure.
+  // Passing it as loginError prevents the auth handler from immediately
+  // re-redirecting to the IdP, breaking an otherwise infinite loop.
+  const idpError = typeof query.error === "string" ? query.error : undefined;
 
   React.useEffect(() => {
     if ((!token || error) && !isLoading) {
-      initLogin();
+      initLogin(undefined, idpError);
     }
-  }, [initLogin, token, error, isLoading]);
+  }, [initLogin, token, error, isLoading, idpError]);
 
   if (isAuthenticated) {
     return <>{children}</>;

--- a/src/auth/CleverAuthHandler.tsx
+++ b/src/auth/CleverAuthHandler.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { OPDS1 } from "interfaces";
+import { useRouter } from "next/router";
+import { ClientCleverMethod } from "interfaces";
 import LoadingIndicator from "components/LoadingIndicator";
 import Stack from "components/Stack";
 import useUser from "components/context/UserContext";
@@ -7,22 +8,20 @@ import { clientOnly } from "components/ClientOnly";
 import useLoginRedirectUrl from "auth/useLoginRedirect";
 import ApplicationError from "errors";
 import Button from "components/Button";
-import { Text } from "components/Text";
+import extractParam from "dataflow/utils";
+import { useRedirectCancelDetection } from "auth/useRedirectCancelDetection";
+import { AuthFeedbackPanel } from "auth/AuthFeedbackPanel";
 
-// Two sessionStorage flags track redirect state across hard page navigations.
-// CLEVER_REDIRECT_FLAG: set before leaving for Clever.
-// CLEVER_CANCEL_FLAG: set when the user returns without completing auth.
-// When only the redirect flag is set, we show cancel UI and set the cancel flag.
-// When both are set, the user is intentionally navigating back to sign in,
-// so we clear both and proceed with a new redirect.
-const CLEVER_REDIRECT_FLAG = "cpw-clever-redirect";
-const CLEVER_CANCEL_FLAG = "cpw-clever-cancelled";
+export const cleverRedirectFlag = (id: string) => `cpw-clever-redirect-${id}`;
+export const cleverCancelFlag = (id: string) => `cpw-clever-cancelled-${id}`;
 
-const CleverAuthHandler: React.FC<{ method: OPDS1.CleverAuthMethod }> = ({
+const CleverAuthHandler: React.FC<{ method: ClientCleverMethod }> = ({
   method
 }) => {
   const { token } = useUser();
   const { fullSuccessUrl } = useLoginRedirectUrl();
+  const router = useRouter();
+  const loginError = extractParam(router.query, "loginError");
 
   const authenticateHref = method.links?.find(
     link => link.rel === "authenticate"
@@ -35,101 +34,42 @@ const CleverAuthHandler: React.FC<{ method: OPDS1.CleverAuthMethod }> = ({
       )}`
     : undefined;
 
-  const [cancelDetected, setCancelDetected] = React.useState(false);
+  const { cancelDetected, handleTryAgain, handleCancel } =
+    useRedirectCancelDetection({
+      authUrl,
+      redirectFlagKey: cleverRedirectFlag(method.id),
+      cancelFlagKey: cleverCancelFlag(method.id),
+      loginError,
+      token
+    });
 
   React.useEffect(() => {
-    if (token) {
-      sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
-      sessionStorage.removeItem(CLEVER_CANCEL_FLAG);
-      return;
-    }
-    if (!authUrl) {
+    if (!token && !authUrl) {
       throw new ApplicationError({
         title: "Incomplete Library Data",
         detail:
           "The required link with rel 'authenticate' is missing from library data."
       });
     }
+  }, [token, authUrl]);
 
-    const hasRedirectFlag = !!sessionStorage.getItem(CLEVER_REDIRECT_FLAG);
-    const hasCancelFlag = !!sessionStorage.getItem(CLEVER_CANCEL_FLAG);
-
-    if (hasRedirectFlag && !hasCancelFlag) {
-      // First return from Clever without completing auth.
-      sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
-      sessionStorage.setItem(CLEVER_CANCEL_FLAG, "1");
-      setCancelDetected(true);
-      return;
-    }
-
-    if (hasRedirectFlag && hasCancelFlag && !cancelDetected) {
-      // User already saw the cancel screen and is intentionally navigating
-      // back to sign in (e.g. clicked Sign In in the header). Clear both
-      // flags and fall through to redirect.
-      sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
-      sessionStorage.removeItem(CLEVER_CANCEL_FLAG);
-    }
-
-    if (!cancelDetected) {
-      sessionStorage.setItem(CLEVER_REDIRECT_FLAG, "1");
-
-      /*
-       * Safari restores pages from bfcache on browser-back without re-running
-       * React effects. Listen for pageshow so we can detect this case and show
-       * cancel UI instead of leaving the spinner running indefinitely.
-       */
-      const handlePageShow = (event: PageTransitionEvent) => {
-        if (
-          event.persisted &&
-          !!sessionStorage.getItem(CLEVER_REDIRECT_FLAG) &&
-          !sessionStorage.getItem(CLEVER_CANCEL_FLAG)
-        ) {
-          sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
-          sessionStorage.setItem(CLEVER_CANCEL_FLAG, "1");
-          setCancelDetected(true);
-        }
-      };
-      window.addEventListener("pageshow", handlePageShow);
-
-      window.location.href = authUrl;
-
-      return () => {
-        sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
-        window.removeEventListener("pageshow", handlePageShow);
-      };
-    }
-  }, [token, authUrl, cancelDetected]);
-
-  const handleTryAgain = () => {
-    sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
-    sessionStorage.removeItem(CLEVER_CANCEL_FLAG);
-    setCancelDetected(false);
-  };
-
-  const handleCancel = () => {
-    sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
-    sessionStorage.removeItem(CLEVER_CANCEL_FLAG);
-    setCancelDetected(true);
-  };
-
-  if (cancelDetected) {
+  if (loginError) {
     return (
-      <Stack
-        direction="column"
-        sx={{
-          alignItems: "center",
-          gap: 3,
-          maxWidth: 500,
-          margin: "0 auto",
-          textAlign: "center"
-        }}
-      >
-        <Text sx={{ fontSize: 2 }}>Login was cancelled.</Text>
-        <Button onClick={handleTryAgain}>Try Again</Button>
-      </Stack>
+      <AuthFeedbackPanel
+        message={loginError}
+        isError
+        onTryAgain={handleTryAgain}
+      />
     );
   }
-
+  if (cancelDetected) {
+    return (
+      <AuthFeedbackPanel
+        message="Login was cancelled."
+        onTryAgain={handleTryAgain}
+      />
+    );
+  }
   return (
     <Stack direction="column" sx={{ alignItems: "center", gap: 3 }}>
       <Stack direction="column" sx={{ alignItems: "center" }}>

--- a/src/auth/CleverAuthHandler.tsx
+++ b/src/auth/CleverAuthHandler.tsx
@@ -56,6 +56,7 @@ const CleverAuthHandler: React.FC<{ method: OPDS1.CleverAuthMethod }> = ({
 
     if (hasRedirectFlag && !hasCancelFlag) {
       // First return from Clever without completing auth.
+      sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
       sessionStorage.setItem(CLEVER_CANCEL_FLAG, "1");
       setCancelDetected(true);
       return;
@@ -71,15 +72,45 @@ const CleverAuthHandler: React.FC<{ method: OPDS1.CleverAuthMethod }> = ({
 
     if (!cancelDetected) {
       sessionStorage.setItem(CLEVER_REDIRECT_FLAG, "1");
+
+      /*
+       * Safari restores pages from bfcache on browser-back without re-running
+       * React effects. Listen for pageshow so we can detect this case and show
+       * cancel UI instead of leaving the spinner running indefinitely.
+       */
+      const handlePageShow = (event: PageTransitionEvent) => {
+        if (
+          event.persisted &&
+          !!sessionStorage.getItem(CLEVER_REDIRECT_FLAG) &&
+          !sessionStorage.getItem(CLEVER_CANCEL_FLAG)
+        ) {
+          sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
+          sessionStorage.setItem(CLEVER_CANCEL_FLAG, "1");
+          setCancelDetected(true);
+        }
+      };
+      window.addEventListener("pageshow", handlePageShow);
+
       window.location.href = authUrl;
-      // Cleanup runs on normal React unmount (e.g. client-side nav away).
-      // Hard navigation via window.location.href bypasses this, so the flag
-      // persists for the browser-back case.
+
       return () => {
         sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
+        window.removeEventListener("pageshow", handlePageShow);
       };
     }
   }, [token, authUrl, cancelDetected]);
+
+  const handleTryAgain = () => {
+    sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
+    sessionStorage.removeItem(CLEVER_CANCEL_FLAG);
+    setCancelDetected(false);
+  };
+
+  const handleCancel = () => {
+    sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
+    sessionStorage.removeItem(CLEVER_CANCEL_FLAG);
+    setCancelDetected(true);
+  };
 
   if (cancelDetected) {
     return (
@@ -94,23 +125,18 @@ const CleverAuthHandler: React.FC<{ method: OPDS1.CleverAuthMethod }> = ({
         }}
       >
         <Text sx={{ fontSize: 2 }}>Login was cancelled.</Text>
-        <Button
-          onClick={() => {
-            sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
-            sessionStorage.removeItem(CLEVER_CANCEL_FLAG);
-            setCancelDetected(false);
-          }}
-        >
-          Try Again
-        </Button>
+        <Button onClick={handleTryAgain}>Try Again</Button>
       </Stack>
     );
   }
 
   return (
-    <Stack direction="column" sx={{ alignItems: "center" }}>
-      <LoadingIndicator />
-      Logging in with Clever...
+    <Stack direction="column" sx={{ alignItems: "center", gap: 3 }}>
+      <Stack direction="column" sx={{ alignItems: "center" }}>
+        <LoadingIndicator />
+        Logging in with Clever...
+      </Stack>
+      <Button onClick={handleCancel}>Cancel</Button>
     </Stack>
   );
 };

--- a/src/auth/CleverAuthHandler.tsx
+++ b/src/auth/CleverAuthHandler.tsx
@@ -6,6 +6,17 @@ import useUser from "components/context/UserContext";
 import { clientOnly } from "components/ClientOnly";
 import useLoginRedirectUrl from "auth/useLoginRedirect";
 import ApplicationError from "errors";
+import Button from "components/Button";
+import { Text } from "components/Text";
+
+// Two sessionStorage flags track redirect state across hard page navigations.
+// CLEVER_REDIRECT_FLAG: set before leaving for Clever.
+// CLEVER_CANCEL_FLAG: set when the user returns without completing auth.
+// When only the redirect flag is set, we show cancel UI and set the cancel flag.
+// When both are set, the user is intentionally navigating back to sign in,
+// so we clear both and proceed with a new redirect.
+const CLEVER_REDIRECT_FLAG = "cpw-clever-redirect";
+const CLEVER_CANCEL_FLAG = "cpw-clever-cancelled";
 
 const CleverAuthHandler: React.FC<{ method: OPDS1.CleverAuthMethod }> = ({
   method
@@ -24,8 +35,14 @@ const CleverAuthHandler: React.FC<{ method: OPDS1.CleverAuthMethod }> = ({
       )}`
     : undefined;
 
-  // redirect to the auth url
+  const [cancelDetected, setCancelDetected] = React.useState(false);
+
   React.useEffect(() => {
+    if (token) {
+      sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
+      sessionStorage.removeItem(CLEVER_CANCEL_FLAG);
+      return;
+    }
     if (!authUrl) {
       throw new ApplicationError({
         title: "Incomplete Library Data",
@@ -33,10 +50,62 @@ const CleverAuthHandler: React.FC<{ method: OPDS1.CleverAuthMethod }> = ({
           "The required link with rel 'authenticate' is missing from library data."
       });
     }
-    if (!token) {
-      window.location.href = authUrl;
+
+    const hasRedirectFlag = !!sessionStorage.getItem(CLEVER_REDIRECT_FLAG);
+    const hasCancelFlag = !!sessionStorage.getItem(CLEVER_CANCEL_FLAG);
+
+    if (hasRedirectFlag && !hasCancelFlag) {
+      // First return from Clever without completing auth.
+      sessionStorage.setItem(CLEVER_CANCEL_FLAG, "1");
+      setCancelDetected(true);
+      return;
     }
-  }, [token, authUrl]);
+
+    if (hasRedirectFlag && hasCancelFlag && !cancelDetected) {
+      // User already saw the cancel screen and is intentionally navigating
+      // back to sign in (e.g. clicked Sign In in the header). Clear both
+      // flags and fall through to redirect.
+      sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
+      sessionStorage.removeItem(CLEVER_CANCEL_FLAG);
+    }
+
+    if (!cancelDetected) {
+      sessionStorage.setItem(CLEVER_REDIRECT_FLAG, "1");
+      window.location.href = authUrl;
+      // Cleanup runs on normal React unmount (e.g. client-side nav away).
+      // Hard navigation via window.location.href bypasses this, so the flag
+      // persists for the browser-back case.
+      return () => {
+        sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
+      };
+    }
+  }, [token, authUrl, cancelDetected]);
+
+  if (cancelDetected) {
+    return (
+      <Stack
+        direction="column"
+        sx={{
+          alignItems: "center",
+          gap: 3,
+          maxWidth: 500,
+          margin: "0 auto",
+          textAlign: "center"
+        }}
+      >
+        <Text sx={{ fontSize: 2 }}>Login was cancelled.</Text>
+        <Button
+          onClick={() => {
+            sessionStorage.removeItem(CLEVER_REDIRECT_FLAG);
+            sessionStorage.removeItem(CLEVER_CANCEL_FLAG);
+            setCancelDetected(false);
+          }}
+        >
+          Try Again
+        </Button>
+      </Stack>
+    );
+  }
 
   return (
     <Stack direction="column" sx={{ alignItems: "center" }}>

--- a/src/auth/OidcAuthHandler.tsx
+++ b/src/auth/OidcAuthHandler.tsx
@@ -8,7 +8,11 @@ import useLoginRedirectUrl from "auth/useLoginRedirect";
 import { clientOnly } from "components/ClientOnly";
 import extractParam from "dataflow/utils";
 import Button from "components/Button";
-import { Text } from "components/Text";
+import { useRedirectCancelDetection } from "auth/useRedirectCancelDetection";
+import { AuthFeedbackPanel } from "auth/AuthFeedbackPanel";
+
+export const oidcRedirectFlag = (id: string) => `cpw-oidc-redirect-${id}`;
+export const oidcCancelFlag = (id: string) => `cpw-oidc-cancelled-${id}`;
 
 /**
  * The OIDC Auth handler sends you off to an external website to complete
@@ -20,147 +24,36 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
   const { token } = useUser();
   const { fullSuccessUrl } = useLoginRedirectUrl();
   const router = useRouter();
-
-  // Extract login error from query params, if present.
   const loginError = extractParam(router.query, "loginError");
 
-  const urlWithRedirect = `${method.href}&redirect_uri=${encodeURIComponent(
-    fullSuccessUrl
-  )}`;
+  const authUrl = `${method.href}&redirect_uri=${encodeURIComponent(fullSuccessUrl)}`;
 
-  // Two sessionStorage flags track redirect state across hard page navigations.
-  // redirectFlagKey: set before leaving for the OIDC provider.
-  // cancelFlagKey: set when the user returns without completing auth.
-  // When only the redirect flag is set, we show cancel UI and set the cancel flag.
-  // When both are set, the user is intentionally navigating back to sign in,
-  // so we clear both and proceed with a new redirect.
-  const redirectFlagKey = `cpw-oidc-redirect-${method.id}`;
-  const cancelFlagKey = `cpw-oidc-cancelled-${method.id}`;
-  const [cancelDetected, setCancelDetected] = React.useState(false);
+  const { cancelDetected, handleTryAgain, handleCancel } =
+    useRedirectCancelDetection({
+      authUrl,
+      redirectFlagKey: oidcRedirectFlag(method.id),
+      cancelFlagKey: oidcCancelFlag(method.id),
+      loginError,
+      token
+    });
 
-  React.useEffect(() => {
-    if (token) {
-      sessionStorage.removeItem(redirectFlagKey);
-      sessionStorage.removeItem(cancelFlagKey);
-      return;
-    }
-
-    const hasRedirectFlag = !!sessionStorage.getItem(redirectFlagKey);
-    const hasCancelFlag = !!sessionStorage.getItem(cancelFlagKey);
-
-    if (hasRedirectFlag && !hasCancelFlag && !loginError) {
-      // First return from OIDC provider without completing auth.
-      sessionStorage.removeItem(redirectFlagKey);
-      sessionStorage.setItem(cancelFlagKey, "1");
-      setCancelDetected(true);
-      return;
-    }
-
-    if (hasRedirectFlag && hasCancelFlag && !cancelDetected) {
-      // User already saw the cancel screen and is intentionally navigating
-      // back to sign in (e.g. clicked Sign In in the header). Clear both
-      // flags and fall through to redirect.
-      sessionStorage.removeItem(redirectFlagKey);
-      sessionStorage.removeItem(cancelFlagKey);
-    }
-
-    if (urlWithRedirect && !loginError && !cancelDetected) {
-      sessionStorage.setItem(redirectFlagKey, "1");
-
-      /*
-       * Safari restores pages from bfcache on browser-back without re-running
-       * React effects. Listen for pageshow so we can detect this case and show
-       * cancel UI instead of leaving the spinner running indefinitely.
-       */
-      const handlePageShow = (event: PageTransitionEvent) => {
-        if (
-          event.persisted &&
-          !!sessionStorage.getItem(redirectFlagKey) &&
-          !sessionStorage.getItem(cancelFlagKey)
-        ) {
-          sessionStorage.removeItem(redirectFlagKey);
-          sessionStorage.setItem(cancelFlagKey, "1");
-          setCancelDetected(true);
-        }
-      };
-      window.addEventListener("pageshow", handlePageShow);
-
-      window.location.href = urlWithRedirect;
-
-      return () => {
-        sessionStorage.removeItem(redirectFlagKey);
-        window.removeEventListener("pageshow", handlePageShow);
-      };
-    }
-  }, [
-    token,
-    urlWithRedirect,
-    loginError,
-    cancelDetected,
-    redirectFlagKey,
-    cancelFlagKey
-  ]);
-
-  const handleTryAgain = () => {
-    sessionStorage.removeItem(redirectFlagKey);
-    sessionStorage.removeItem(cancelFlagKey);
-    setCancelDetected(false);
-    if (loginError) {
-      const { loginError: _, ...restQuery } = router.query;
-      router.replace(
-        { pathname: router.pathname, query: restQuery },
-        undefined,
-        { shallow: true }
-      );
-    }
-  };
-
-  const handleCancel = () => {
-    sessionStorage.removeItem(redirectFlagKey);
-    sessionStorage.removeItem(cancelFlagKey);
-    setCancelDetected(true);
-  };
-
-  // Display error if present
   if (loginError) {
     return (
-      <Stack
-        direction="column"
-        sx={{
-          alignItems: "center",
-          gap: 3,
-          maxWidth: 500,
-          margin: "0 auto",
-          textAlign: "center",
-          textWrap: "balance"
-        }}
-      >
-        <Text sx={{ color: "ui.error", fontSize: 2 }}>{loginError}</Text>
-        <Button onClick={handleTryAgain}>Try Again</Button>
-      </Stack>
+      <AuthFeedbackPanel
+        message={loginError}
+        isError
+        onTryAgain={handleTryAgain}
+      />
     );
   }
-
-  // Display cancel UI if the user returned without completing auth.
   if (cancelDetected) {
     return (
-      <Stack
-        direction="column"
-        sx={{
-          alignItems: "center",
-          gap: 3,
-          maxWidth: 500,
-          margin: "0 auto",
-          textAlign: "center"
-        }}
-      >
-        <Text sx={{ fontSize: 2 }}>Login was cancelled.</Text>
-        <Button onClick={handleTryAgain}>Try Again</Button>
-      </Stack>
+      <AuthFeedbackPanel
+        message="Login was cancelled."
+        onTryAgain={handleTryAgain}
+      />
     );
   }
-
-  // Show loading state while redirecting
   return (
     <Stack direction="column" sx={{ alignItems: "center", gap: 3 }}>
       <Stack direction="column" sx={{ alignItems: "center" }}>

--- a/src/auth/OidcAuthHandler.tsx
+++ b/src/auth/OidcAuthHandler.tsx
@@ -50,6 +50,7 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
 
     if (hasRedirectFlag && !hasCancelFlag && !loginError) {
       // First return from OIDC provider without completing auth.
+      sessionStorage.removeItem(redirectFlagKey);
       sessionStorage.setItem(cancelFlagKey, "1");
       setCancelDetected(true);
       return;
@@ -65,12 +66,30 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
 
     if (urlWithRedirect && !loginError && !cancelDetected) {
       sessionStorage.setItem(redirectFlagKey, "1");
+
+      /*
+       * Safari restores pages from bfcache on browser-back without re-running
+       * React effects. Listen for pageshow so we can detect this case and show
+       * cancel UI instead of leaving the spinner running indefinitely.
+       */
+      const handlePageShow = (event: PageTransitionEvent) => {
+        if (
+          event.persisted &&
+          !!sessionStorage.getItem(redirectFlagKey) &&
+          !sessionStorage.getItem(cancelFlagKey)
+        ) {
+          sessionStorage.removeItem(redirectFlagKey);
+          sessionStorage.setItem(cancelFlagKey, "1");
+          setCancelDetected(true);
+        }
+      };
+      window.addEventListener("pageshow", handlePageShow);
+
       window.location.href = urlWithRedirect;
-      // Cleanup runs on normal React unmount (e.g. client-side nav away).
-      // Hard navigation via window.location.href bypasses this, so the flag
-      // persists for the browser-back case.
+
       return () => {
         sessionStorage.removeItem(redirectFlagKey);
+        window.removeEventListener("pageshow", handlePageShow);
       };
     }
   }, [
@@ -94,6 +113,12 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
         { shallow: true }
       );
     }
+  };
+
+  const handleCancel = () => {
+    sessionStorage.removeItem(redirectFlagKey);
+    sessionStorage.removeItem(cancelFlagKey);
+    setCancelDetected(true);
   };
 
   // Display error if present
@@ -137,9 +162,12 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
 
   // Show loading state while redirecting
   return (
-    <Stack direction="column" sx={{ alignItems: "center" }}>
-      <LoadingIndicator />
-      Logging in with {method.description}...
+    <Stack direction="column" sx={{ alignItems: "center", gap: 3 }}>
+      <Stack direction="column" sx={{ alignItems: "center" }}>
+        <LoadingIndicator />
+        Logging in with {method.description}...
+      </Stack>
+      <Button onClick={handleCancel}>Cancel</Button>
     </Stack>
   );
 };

--- a/src/auth/OidcAuthHandler.tsx
+++ b/src/auth/OidcAuthHandler.tsx
@@ -28,12 +28,73 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
     fullSuccessUrl
   )}`;
 
+  // Two sessionStorage flags track redirect state across hard page navigations.
+  // redirectFlagKey: set before leaving for the OIDC provider.
+  // cancelFlagKey: set when the user returns without completing auth.
+  // When only the redirect flag is set, we show cancel UI and set the cancel flag.
+  // When both are set, the user is intentionally navigating back to sign in,
+  // so we clear both and proceed with a new redirect.
+  const redirectFlagKey = `cpw-oidc-redirect-${method.id}`;
+  const cancelFlagKey = `cpw-oidc-cancelled-${method.id}`;
+  const [cancelDetected, setCancelDetected] = React.useState(false);
+
   React.useEffect(() => {
-    // Redirect to OIDC provider if not already signed in and no current error.
-    if (!token && urlWithRedirect && !loginError) {
-      window.location.href = urlWithRedirect;
+    if (token) {
+      sessionStorage.removeItem(redirectFlagKey);
+      sessionStorage.removeItem(cancelFlagKey);
+      return;
     }
-  }, [token, urlWithRedirect, loginError]);
+
+    const hasRedirectFlag = !!sessionStorage.getItem(redirectFlagKey);
+    const hasCancelFlag = !!sessionStorage.getItem(cancelFlagKey);
+
+    if (hasRedirectFlag && !hasCancelFlag && !loginError) {
+      // First return from OIDC provider without completing auth.
+      sessionStorage.setItem(cancelFlagKey, "1");
+      setCancelDetected(true);
+      return;
+    }
+
+    if (hasRedirectFlag && hasCancelFlag && !cancelDetected) {
+      // User already saw the cancel screen and is intentionally navigating
+      // back to sign in (e.g. clicked Sign In in the header). Clear both
+      // flags and fall through to redirect.
+      sessionStorage.removeItem(redirectFlagKey);
+      sessionStorage.removeItem(cancelFlagKey);
+    }
+
+    if (urlWithRedirect && !loginError && !cancelDetected) {
+      sessionStorage.setItem(redirectFlagKey, "1");
+      window.location.href = urlWithRedirect;
+      // Cleanup runs on normal React unmount (e.g. client-side nav away).
+      // Hard navigation via window.location.href bypasses this, so the flag
+      // persists for the browser-back case.
+      return () => {
+        sessionStorage.removeItem(redirectFlagKey);
+      };
+    }
+  }, [
+    token,
+    urlWithRedirect,
+    loginError,
+    cancelDetected,
+    redirectFlagKey,
+    cancelFlagKey
+  ]);
+
+  const handleTryAgain = () => {
+    sessionStorage.removeItem(redirectFlagKey);
+    sessionStorage.removeItem(cancelFlagKey);
+    setCancelDetected(false);
+    if (loginError) {
+      const { loginError: _, ...restQuery } = router.query;
+      router.replace(
+        { pathname: router.pathname, query: restQuery },
+        undefined,
+        { shallow: true }
+      );
+    }
+  };
 
   // Display error if present
   if (loginError) {
@@ -50,19 +111,26 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
         }}
       >
         <Text sx={{ color: "ui.error", fontSize: 2 }}>{loginError}</Text>
-        <Button
-          onClick={() => {
-            // Clear error and retry by removing loginError from URL
-            const { loginError: _, ...restQuery } = router.query;
-            router.replace(
-              { pathname: router.pathname, query: restQuery },
-              undefined,
-              { shallow: true }
-            );
-          }}
-        >
-          Try Again
-        </Button>
+        <Button onClick={handleTryAgain}>Try Again</Button>
+      </Stack>
+    );
+  }
+
+  // Display cancel UI if the user returned without completing auth.
+  if (cancelDetected) {
+    return (
+      <Stack
+        direction="column"
+        sx={{
+          alignItems: "center",
+          gap: 3,
+          maxWidth: 500,
+          margin: "0 auto",
+          textAlign: "center"
+        }}
+      >
+        <Text sx={{ fontSize: 2 }}>Login was cancelled.</Text>
+        <Button onClick={handleTryAgain}>Try Again</Button>
       </Stack>
     );
   }

--- a/src/auth/SamlAuthHandler.tsx
+++ b/src/auth/SamlAuthHandler.tsx
@@ -8,7 +8,11 @@ import useLoginRedirectUrl from "auth/useLoginRedirect";
 import { clientOnly } from "components/ClientOnly";
 import extractParam from "dataflow/utils";
 import Button from "components/Button";
-import { Text } from "components/Text";
+import { useRedirectCancelDetection } from "auth/useRedirectCancelDetection";
+import { AuthFeedbackPanel } from "auth/AuthFeedbackPanel";
+
+export const samlRedirectFlag = (id: string) => `cpw-saml-redirect-${id}`;
+export const samlCancelFlag = (id: string) => `cpw-saml-cancelled-${id}`;
 
 /**
  * The SAML Auth handler sends you off to an external website to complete
@@ -20,147 +24,36 @@ const SamlAuthHandler: React.FC<{ method: ClientSamlMethod }> = ({
   const { token } = useUser();
   const { fullSuccessUrl } = useLoginRedirectUrl();
   const router = useRouter();
-
-  // Extract login error from query params, if present.
   const loginError = extractParam(router.query, "loginError");
 
-  const urlWithRedirect = `${method.href}&redirect_uri=${encodeURIComponent(
-    fullSuccessUrl
-  )}`;
+  const authUrl = `${method.href}&redirect_uri=${encodeURIComponent(fullSuccessUrl)}`;
 
-  // Two sessionStorage flags track redirect state across hard page navigations.
-  // redirectFlagKey: set before leaving for the SAML IdP.
-  // cancelFlagKey: set when the user returns without completing auth.
-  // When only the redirect flag is set, we show cancel UI and set the cancel flag.
-  // When both are set, the user is intentionally navigating back to sign in,
-  // so we clear both and proceed with a new redirect.
-  const redirectFlagKey = `cpw-saml-redirect-${method.id}`;
-  const cancelFlagKey = `cpw-saml-cancelled-${method.id}`;
-  const [cancelDetected, setCancelDetected] = React.useState(false);
+  const { cancelDetected, handleTryAgain, handleCancel } =
+    useRedirectCancelDetection({
+      authUrl,
+      redirectFlagKey: samlRedirectFlag(method.id),
+      cancelFlagKey: samlCancelFlag(method.id),
+      loginError,
+      token
+    });
 
-  React.useEffect(() => {
-    if (token) {
-      sessionStorage.removeItem(redirectFlagKey);
-      sessionStorage.removeItem(cancelFlagKey);
-      return;
-    }
-
-    const hasRedirectFlag = !!sessionStorage.getItem(redirectFlagKey);
-    const hasCancelFlag = !!sessionStorage.getItem(cancelFlagKey);
-
-    if (hasRedirectFlag && !hasCancelFlag && !loginError) {
-      // First return from SAML IdP without completing auth.
-      sessionStorage.removeItem(redirectFlagKey);
-      sessionStorage.setItem(cancelFlagKey, "1");
-      setCancelDetected(true);
-      return;
-    }
-
-    if (hasRedirectFlag && hasCancelFlag && !cancelDetected) {
-      // User already saw the cancel screen and is intentionally navigating
-      // back to sign in (e.g. clicked Sign In in the header). Clear both
-      // flags and fall through to redirect.
-      sessionStorage.removeItem(redirectFlagKey);
-      sessionStorage.removeItem(cancelFlagKey);
-    }
-
-    if (urlWithRedirect && !loginError && !cancelDetected) {
-      sessionStorage.setItem(redirectFlagKey, "1");
-
-      /*
-       * Safari restores pages from bfcache on browser-back without re-running
-       * React effects. Listen for pageshow so we can detect this case and show
-       * cancel UI instead of leaving the spinner running indefinitely.
-       */
-      const handlePageShow = (event: PageTransitionEvent) => {
-        if (
-          event.persisted &&
-          !!sessionStorage.getItem(redirectFlagKey) &&
-          !sessionStorage.getItem(cancelFlagKey)
-        ) {
-          sessionStorage.removeItem(redirectFlagKey);
-          sessionStorage.setItem(cancelFlagKey, "1");
-          setCancelDetected(true);
-        }
-      };
-      window.addEventListener("pageshow", handlePageShow);
-
-      window.location.href = urlWithRedirect;
-
-      return () => {
-        sessionStorage.removeItem(redirectFlagKey);
-        window.removeEventListener("pageshow", handlePageShow);
-      };
-    }
-  }, [
-    token,
-    urlWithRedirect,
-    loginError,
-    cancelDetected,
-    redirectFlagKey,
-    cancelFlagKey
-  ]);
-
-  const handleTryAgain = () => {
-    sessionStorage.removeItem(redirectFlagKey);
-    sessionStorage.removeItem(cancelFlagKey);
-    setCancelDetected(false);
-    if (loginError) {
-      const { loginError: _, ...restQuery } = router.query;
-      router.replace(
-        { pathname: router.pathname, query: restQuery },
-        undefined,
-        { shallow: true }
-      );
-    }
-  };
-
-  const handleCancel = () => {
-    sessionStorage.removeItem(redirectFlagKey);
-    sessionStorage.removeItem(cancelFlagKey);
-    setCancelDetected(true);
-  };
-
-  // Display error if present
   if (loginError) {
     return (
-      <Stack
-        direction="column"
-        sx={{
-          alignItems: "center",
-          gap: 3,
-          maxWidth: 500,
-          margin: "0 auto",
-          textAlign: "center",
-          textWrap: "balance"
-        }}
-      >
-        <Text sx={{ color: "ui.error", fontSize: 2 }}>{loginError}</Text>
-        <Button onClick={handleTryAgain}>Try Again</Button>
-      </Stack>
+      <AuthFeedbackPanel
+        message={loginError}
+        isError
+        onTryAgain={handleTryAgain}
+      />
     );
   }
-
-  // Display cancel UI if the user returned without completing auth.
   if (cancelDetected) {
     return (
-      <Stack
-        direction="column"
-        sx={{
-          alignItems: "center",
-          gap: 3,
-          maxWidth: 500,
-          margin: "0 auto",
-          textAlign: "center"
-        }}
-      >
-        <Text sx={{ fontSize: 2 }}>Login was cancelled.</Text>
-        <Button onClick={handleTryAgain}>Try Again</Button>
-      </Stack>
+      <AuthFeedbackPanel
+        message="Login was cancelled."
+        onTryAgain={handleTryAgain}
+      />
     );
   }
-
-  // Show loading state while redirecting
   return (
     <Stack direction="column" sx={{ alignItems: "center", gap: 3 }}>
       <Stack direction="column" sx={{ alignItems: "center" }}>

--- a/src/auth/SamlAuthHandler.tsx
+++ b/src/auth/SamlAuthHandler.tsx
@@ -50,6 +50,7 @@ const SamlAuthHandler: React.FC<{ method: ClientSamlMethod }> = ({
 
     if (hasRedirectFlag && !hasCancelFlag && !loginError) {
       // First return from SAML IdP without completing auth.
+      sessionStorage.removeItem(redirectFlagKey);
       sessionStorage.setItem(cancelFlagKey, "1");
       setCancelDetected(true);
       return;
@@ -65,12 +66,30 @@ const SamlAuthHandler: React.FC<{ method: ClientSamlMethod }> = ({
 
     if (urlWithRedirect && !loginError && !cancelDetected) {
       sessionStorage.setItem(redirectFlagKey, "1");
+
+      /*
+       * Safari restores pages from bfcache on browser-back without re-running
+       * React effects. Listen for pageshow so we can detect this case and show
+       * cancel UI instead of leaving the spinner running indefinitely.
+       */
+      const handlePageShow = (event: PageTransitionEvent) => {
+        if (
+          event.persisted &&
+          !!sessionStorage.getItem(redirectFlagKey) &&
+          !sessionStorage.getItem(cancelFlagKey)
+        ) {
+          sessionStorage.removeItem(redirectFlagKey);
+          sessionStorage.setItem(cancelFlagKey, "1");
+          setCancelDetected(true);
+        }
+      };
+      window.addEventListener("pageshow", handlePageShow);
+
       window.location.href = urlWithRedirect;
-      // Cleanup runs on normal React unmount (e.g. client-side nav away).
-      // Hard navigation via window.location.href bypasses this, so the flag
-      // persists for the browser-back case.
+
       return () => {
         sessionStorage.removeItem(redirectFlagKey);
+        window.removeEventListener("pageshow", handlePageShow);
       };
     }
   }, [
@@ -94,6 +113,12 @@ const SamlAuthHandler: React.FC<{ method: ClientSamlMethod }> = ({
         { shallow: true }
       );
     }
+  };
+
+  const handleCancel = () => {
+    sessionStorage.removeItem(redirectFlagKey);
+    sessionStorage.removeItem(cancelFlagKey);
+    setCancelDetected(true);
   };
 
   // Display error if present
@@ -137,9 +162,12 @@ const SamlAuthHandler: React.FC<{ method: ClientSamlMethod }> = ({
 
   // Show loading state while redirecting
   return (
-    <Stack direction="column" sx={{ alignItems: "center" }}>
-      <LoadingIndicator />
-      Logging in with {method.description}...
+    <Stack direction="column" sx={{ alignItems: "center", gap: 3 }}>
+      <Stack direction="column" sx={{ alignItems: "center" }}>
+        <LoadingIndicator />
+        Logging in with {method.description}...
+      </Stack>
+      <Button onClick={handleCancel}>Cancel</Button>
     </Stack>
   );
 };

--- a/src/auth/SamlAuthHandler.tsx
+++ b/src/auth/SamlAuthHandler.tsx
@@ -17,7 +17,7 @@ import { Text } from "components/Text";
 const SamlAuthHandler: React.FC<{ method: ClientSamlMethod }> = ({
   method
 }) => {
-  const { token, signOut } = useUser();
+  const { token } = useUser();
   const { fullSuccessUrl } = useLoginRedirectUrl();
   const router = useRouter();
 
@@ -28,12 +28,73 @@ const SamlAuthHandler: React.FC<{ method: ClientSamlMethod }> = ({
     fullSuccessUrl
   )}`;
 
+  // Two sessionStorage flags track redirect state across hard page navigations.
+  // redirectFlagKey: set before leaving for the SAML IdP.
+  // cancelFlagKey: set when the user returns without completing auth.
+  // When only the redirect flag is set, we show cancel UI and set the cancel flag.
+  // When both are set, the user is intentionally navigating back to sign in,
+  // so we clear both and proceed with a new redirect.
+  const redirectFlagKey = `cpw-saml-redirect-${method.id}`;
+  const cancelFlagKey = `cpw-saml-cancelled-${method.id}`;
+  const [cancelDetected, setCancelDetected] = React.useState(false);
+
   React.useEffect(() => {
-    // Redirect to SAML provider if not already signed in and no current error.
-    if (!token && urlWithRedirect && !loginError) {
-      window.location.href = urlWithRedirect;
+    if (token) {
+      sessionStorage.removeItem(redirectFlagKey);
+      sessionStorage.removeItem(cancelFlagKey);
+      return;
     }
-  }, [token, signOut, urlWithRedirect, loginError]);
+
+    const hasRedirectFlag = !!sessionStorage.getItem(redirectFlagKey);
+    const hasCancelFlag = !!sessionStorage.getItem(cancelFlagKey);
+
+    if (hasRedirectFlag && !hasCancelFlag && !loginError) {
+      // First return from SAML IdP without completing auth.
+      sessionStorage.setItem(cancelFlagKey, "1");
+      setCancelDetected(true);
+      return;
+    }
+
+    if (hasRedirectFlag && hasCancelFlag && !cancelDetected) {
+      // User already saw the cancel screen and is intentionally navigating
+      // back to sign in (e.g. clicked Sign In in the header). Clear both
+      // flags and fall through to redirect.
+      sessionStorage.removeItem(redirectFlagKey);
+      sessionStorage.removeItem(cancelFlagKey);
+    }
+
+    if (urlWithRedirect && !loginError && !cancelDetected) {
+      sessionStorage.setItem(redirectFlagKey, "1");
+      window.location.href = urlWithRedirect;
+      // Cleanup runs on normal React unmount (e.g. client-side nav away).
+      // Hard navigation via window.location.href bypasses this, so the flag
+      // persists for the browser-back case.
+      return () => {
+        sessionStorage.removeItem(redirectFlagKey);
+      };
+    }
+  }, [
+    token,
+    urlWithRedirect,
+    loginError,
+    cancelDetected,
+    redirectFlagKey,
+    cancelFlagKey
+  ]);
+
+  const handleTryAgain = () => {
+    sessionStorage.removeItem(redirectFlagKey);
+    sessionStorage.removeItem(cancelFlagKey);
+    setCancelDetected(false);
+    if (loginError) {
+      const { loginError: _, ...restQuery } = router.query;
+      router.replace(
+        { pathname: router.pathname, query: restQuery },
+        undefined,
+        { shallow: true }
+      );
+    }
+  };
 
   // Display error if present
   if (loginError) {
@@ -50,19 +111,26 @@ const SamlAuthHandler: React.FC<{ method: ClientSamlMethod }> = ({
         }}
       >
         <Text sx={{ color: "ui.error", fontSize: 2 }}>{loginError}</Text>
-        <Button
-          onClick={() => {
-            // Clear error and retry by removing loginError from URL
-            const { loginError: _, ...restQuery } = router.query;
-            router.replace(
-              { pathname: router.pathname, query: restQuery },
-              undefined,
-              { shallow: true }
-            );
-          }}
-        >
-          Try Again
-        </Button>
+        <Button onClick={handleTryAgain}>Try Again</Button>
+      </Stack>
+    );
+  }
+
+  // Display cancel UI if the user returned without completing auth.
+  if (cancelDetected) {
+    return (
+      <Stack
+        direction="column"
+        sx={{
+          alignItems: "center",
+          gap: 3,
+          maxWidth: 500,
+          margin: "0 auto",
+          textAlign: "center"
+        }}
+      >
+        <Text sx={{ fontSize: 2 }}>Login was cancelled.</Text>
+        <Button onClick={handleTryAgain}>Try Again</Button>
       </Stack>
     );
   }

--- a/src/auth/__tests__/AuthProtectedRoute.test.tsx
+++ b/src/auth/__tests__/AuthProtectedRoute.test.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+import { render, waitFor } from "test-utils";
+import AuthProtectedRoute from "../AuthProtectedRoute";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("renders children when authenticated", () => {
+  const utils = render(
+    <AuthProtectedRoute>
+      <div>Protected content</div>
+    </AuthProtectedRoute>,
+    { user: { isAuthenticated: true, token: "some-token", isLoading: false } }
+  );
+
+  expect(utils.getByText("Protected content")).toBeInTheDocument();
+});
+
+test("shows loading state while auth is in progress", () => {
+  const utils = render(
+    <AuthProtectedRoute>
+      <div>Protected content</div>
+    </AuthProtectedRoute>,
+    { user: { isAuthenticated: false, isLoading: true } }
+  );
+
+  expect(utils.getByText("Loading...")).toBeInTheDocument();
+  expect(utils.queryByText("Protected content")).not.toBeInTheDocument();
+});
+
+test("redirects unauthenticated user to login", async () => {
+  const mockReplace = jest.fn();
+
+  render(
+    <AuthProtectedRoute>
+      <div>Protected content</div>
+    </AuthProtectedRoute>,
+    {
+      user: { token: undefined, isAuthenticated: false, isLoading: false },
+      router: { replace: mockReplace }
+    }
+  );
+
+  await waitFor(() => {
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: "/[library]/login",
+        query: expect.objectContaining({ library: "testlib" })
+      }),
+      undefined,
+      { shallow: true }
+    );
+  });
+  // error param from IdP must not travel into the login URL
+  expect(mockReplace.mock.calls[0][0].query).not.toHaveProperty("error");
+});
+
+test("passes IdP error to login URL when query.error is present", async () => {
+  const mockReplace = jest.fn();
+
+  render(
+    <AuthProtectedRoute>
+      <div>Protected content</div>
+    </AuthProtectedRoute>,
+    {
+      user: { token: undefined, isAuthenticated: false, isLoading: false },
+      router: {
+        replace: mockReplace,
+        query: { error: "access_denied", library: "testlib" }
+      }
+    }
+  );
+
+  await waitFor(() => {
+    expect(mockReplace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: "/[library]/login",
+        query: expect.objectContaining({ loginError: "access_denied" })
+      }),
+      undefined,
+      { shallow: true }
+    );
+  });
+  // the raw IdP error param must be stripped, not forwarded as-is
+  expect(mockReplace.mock.calls[0][0].query).not.toHaveProperty("error");
+});
+
+test("does not redirect when authenticated", async () => {
+  const mockReplace = jest.fn();
+
+  render(
+    <AuthProtectedRoute>
+      <div>Protected content</div>
+    </AuthProtectedRoute>,
+    {
+      user: { isAuthenticated: true, token: "some-token", isLoading: false },
+      router: { replace: mockReplace }
+    }
+  );
+
+  // Allow effects to flush
+  await waitFor(() => {
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/src/auth/__tests__/CleverAuthHandler.test.tsx
+++ b/src/auth/__tests__/CleverAuthHandler.test.tsx
@@ -1,5 +1,6 @@
 import ApplicationError from "errors";
 import * as React from "react";
+import { act } from "@testing-library/react";
 import { fixtures, screen, setup, waitFor } from "test-utils";
 import CleverAuthHandler from "../CleverAuthHandler";
 
@@ -112,4 +113,46 @@ test("proceeds with redirect when navigating back to sign in after cancel", asyn
   await waitFor(() => {
     expect(window.location.href).toContain("oauth_authenticate");
   });
+});
+
+test("shows cancel UI when Safari restores page from bfcache after redirect", async () => {
+  const utils = setup(
+    <CleverAuthHandler method={fixtures.cleverAuthMethod} />,
+    { user: { token: undefined } }
+  );
+
+  // Wait for the effect to run and set the redirect flag.
+  await waitFor(() => {
+    expect(sessionStorage.getItem("cpw-clever-redirect")).toBe("1");
+  });
+
+  // Simulate Safari restoring this page from bfcache.
+  act(() => {
+    const event = new Event("pageshow");
+    Object.defineProperty(event, "persisted", { value: true });
+    window.dispatchEvent(event);
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+});
+
+test('clicking "Cancel" while redirecting shows cancel UI', async () => {
+  const utils = setup(
+    <CleverAuthHandler method={fixtures.cleverAuthMethod} />,
+    { user: { token: undefined } }
+  );
+
+  await waitFor(() => {
+    expect(utils.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  await utils.user.click(utils.getByRole("button", { name: "Cancel" }));
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
 });

--- a/src/auth/__tests__/CleverAuthHandler.test.tsx
+++ b/src/auth/__tests__/CleverAuthHandler.test.tsx
@@ -2,7 +2,13 @@ import ApplicationError from "errors";
 import * as React from "react";
 import { act } from "@testing-library/react";
 import { fixtures, screen, setup, waitFor } from "test-utils";
-import CleverAuthHandler from "../CleverAuthHandler";
+import CleverAuthHandler, {
+  cleverRedirectFlag,
+  cleverCancelFlag
+} from "../CleverAuthHandler";
+
+const cleverRedirectKey = cleverRedirectFlag(fixtures.cleverAuthMethod.id);
+const cleverCancelKey = cleverCancelFlag(fixtures.cleverAuthMethod.id);
 
 test("shows loader while redirecting", () => {
   setup(<CleverAuthHandler method={fixtures.cleverAuthMethod} />);
@@ -51,7 +57,7 @@ test("throws error if there is no authenticate link in library data", async () =
 });
 
 test("shows cancel UI when user returns after pressing back from Clever", async () => {
-  sessionStorage.setItem("cpw-clever-redirect", "1");
+  sessionStorage.setItem(cleverRedirectKey, "1");
 
   const utils = setup(
     <CleverAuthHandler method={fixtures.cleverAuthMethod} />,
@@ -67,7 +73,7 @@ test("shows cancel UI when user returns after pressing back from Clever", async 
 });
 
 test("does not redirect to Clever when cancel is detected", async () => {
-  sessionStorage.setItem("cpw-clever-redirect", "1");
+  sessionStorage.setItem(cleverRedirectKey, "1");
 
   setup(<CleverAuthHandler method={fixtures.cleverAuthMethod} />, {
     user: { token: undefined }
@@ -80,7 +86,7 @@ test("does not redirect to Clever when cancel is detected", async () => {
 });
 
 test('clicking "Try Again" after Clever cancel clears flags and redirects', async () => {
-  sessionStorage.setItem("cpw-clever-redirect", "1");
+  sessionStorage.setItem(cleverRedirectKey, "1");
 
   const utils = setup(
     <CleverAuthHandler method={fixtures.cleverAuthMethod} />,
@@ -103,8 +109,8 @@ test('clicking "Try Again" after Clever cancel clears flags and redirects', asyn
 test("proceeds with redirect when navigating back to sign in after cancel", async () => {
   // Simulates the user seeing cancel UI and then clicking "Sign In" in the header,
   // which causes the handler to remount with both flags already set.
-  sessionStorage.setItem("cpw-clever-redirect", "1");
-  sessionStorage.setItem("cpw-clever-cancelled", "1");
+  sessionStorage.setItem(cleverRedirectKey, "1");
+  sessionStorage.setItem(cleverCancelKey, "1");
 
   setup(<CleverAuthHandler method={fixtures.cleverAuthMethod} />, {
     user: { token: undefined }
@@ -123,7 +129,7 @@ test("shows cancel UI when Safari restores page from bfcache after redirect", as
 
   // Wait for the effect to run and set the redirect flag.
   await waitFor(() => {
-    expect(sessionStorage.getItem("cpw-clever-redirect")).toBe("1");
+    expect(sessionStorage.getItem(cleverRedirectKey)).toBe("1");
   });
 
   // Simulate Safari restoring this page from bfcache.
@@ -137,6 +143,65 @@ test("shows cancel UI when Safari restores page from bfcache after redirect", as
     expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
   });
   expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+});
+
+test("displays error message when loginError query param is present", () => {
+  const utils = setup(
+    <CleverAuthHandler method={fixtures.cleverAuthMethod} />,
+    {
+      router: {
+        query: {
+          loginError:
+            "Invalid Credentials: The patron account associated with this Clever authentication could not be found."
+        }
+      },
+      user: { token: undefined }
+    }
+  );
+
+  expect(
+    utils.getByText(
+      "Invalid Credentials: The patron account associated with this Clever authentication could not be found."
+    )
+  ).toBeInTheDocument();
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+});
+
+test("does not redirect to Clever when error is present", () => {
+  setup(<CleverAuthHandler method={fixtures.cleverAuthMethod} />, {
+    router: { query: { loginError: "Authentication failed" } },
+    user: { token: undefined }
+  });
+
+  expect(window.location.href).toBe("http://test-domain.com/");
+});
+
+test('clicking "Try Again" clears error and attempts Clever redirect', async () => {
+  const mockReplace = jest.fn();
+  const utils = setup(
+    <CleverAuthHandler method={fixtures.cleverAuthMethod} />,
+    {
+      router: {
+        query: { loginError: "Authentication failed", library: "testlib" },
+        pathname: "/[library]/login/[methodId]",
+        replace: mockReplace
+      },
+      user: { token: undefined }
+    }
+  );
+
+  await utils.user.click(utils.getByRole("button", { name: "Try Again" }));
+
+  await waitFor(() => {
+    expect(mockReplace).toHaveBeenCalledWith(
+      {
+        pathname: "/[library]/login/[methodId]",
+        query: { library: "testlib" }
+      },
+      undefined,
+      { shallow: true }
+    );
+  });
 });
 
 test('clicking "Cancel" while redirecting shows cancel UI', async () => {

--- a/src/auth/__tests__/CleverAuthHandler.test.tsx
+++ b/src/auth/__tests__/CleverAuthHandler.test.tsx
@@ -13,6 +13,7 @@ beforeEach(() => {
   const location = new URL("http://test-domain.com");
   delete (window as any).location;
   (window as any).location = location;
+  sessionStorage.clear();
 });
 
 test("redirects to proper auth url", async () => {
@@ -46,4 +47,69 @@ test("throws error if there is no authenticate link in library data", async () =
       )
     ).toThrowError(ApplicationError);
   }
+});
+
+test("shows cancel UI when user returns after pressing back from Clever", async () => {
+  sessionStorage.setItem("cpw-clever-redirect", "1");
+
+  const utils = setup(
+    <CleverAuthHandler method={fixtures.cleverAuthMethod} />,
+    {
+      user: { token: undefined }
+    }
+  );
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+});
+
+test("does not redirect to Clever when cancel is detected", async () => {
+  sessionStorage.setItem("cpw-clever-redirect", "1");
+
+  setup(<CleverAuthHandler method={fixtures.cleverAuthMethod} />, {
+    user: { token: undefined }
+  });
+
+  // Give effects time to run; href should remain unchanged.
+  await waitFor(() => {
+    expect(window.location.href).toBe("http://test-domain.com/");
+  });
+});
+
+test('clicking "Try Again" after Clever cancel clears flags and redirects', async () => {
+  sessionStorage.setItem("cpw-clever-redirect", "1");
+
+  const utils = setup(
+    <CleverAuthHandler method={fixtures.cleverAuthMethod} />,
+    {
+      user: { token: undefined }
+    }
+  );
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+
+  await utils.user.click(utils.getByRole("button", { name: "Try Again" }));
+
+  await waitFor(() => {
+    expect(window.location.href).toContain("oauth_authenticate");
+  });
+});
+
+test("proceeds with redirect when navigating back to sign in after cancel", async () => {
+  // Simulates the user seeing cancel UI and then clicking "Sign In" in the header,
+  // which causes the handler to remount with both flags already set.
+  sessionStorage.setItem("cpw-clever-redirect", "1");
+  sessionStorage.setItem("cpw-clever-cancelled", "1");
+
+  setup(<CleverAuthHandler method={fixtures.cleverAuthMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(window.location.href).toContain("oauth_authenticate");
+  });
 });

--- a/src/auth/__tests__/OidcAuthHandler.test.tsx
+++ b/src/auth/__tests__/OidcAuthHandler.test.tsx
@@ -4,6 +4,9 @@ import OidcAuthHandler from "../OidcAuthHandler";
 
 // we import the unwrapped render here because we don't need the context providers
 
+const oidcRedirectKey = `cpw-oidc-redirect-${fixtures.clientOidcMethod.id}`;
+const oidcCancelKey = `cpw-oidc-cancelled-${fixtures.clientOidcMethod.id}`;
+
 test("shows loader while redirecting", () => {
   const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />);
   expect(
@@ -16,6 +19,7 @@ beforeEach(() => {
   const location = new URL("http://test-domain.com");
   delete (window as any).location;
   (window as any).location = location;
+  sessionStorage.clear();
 });
 
 test("redirects to proper auth url", async () => {
@@ -97,5 +101,64 @@ test('clicking "Try Again" clears error and attempts OIDC redirect', async () =>
       undefined,
       { shallow: true }
     );
+  });
+});
+
+test("shows cancel UI when user returns after pressing back from OIDC provider", async () => {
+  sessionStorage.setItem(oidcRedirectKey, "1");
+
+  const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+});
+
+test("does not redirect to OIDC provider when cancel is detected", async () => {
+  sessionStorage.setItem(oidcRedirectKey, "1");
+
+  render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+    user: { token: undefined }
+  });
+
+  // Give effects time to run; href should remain unchanged.
+  await waitFor(() => {
+    expect(window.location.href).toBe("http://test-domain.com/");
+  });
+});
+
+test('clicking "Try Again" after cancel clears flags and redirects', async () => {
+  sessionStorage.setItem(oidcRedirectKey, "1");
+
+  const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+
+  utils.getByRole("button", { name: "Try Again" }).click();
+
+  await waitFor(() => {
+    expect(window.location.href).toContain("oidc-auth.com");
+  });
+});
+
+test("proceeds with redirect when navigating back to sign in after cancel", async () => {
+  // Simulates the user seeing cancel UI and then clicking "Sign In" in the header,
+  // which causes the handler to remount with both flags already set.
+  sessionStorage.setItem(oidcRedirectKey, "1");
+  sessionStorage.setItem(oidcCancelKey, "1");
+
+  render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(window.location.href).toContain("oidc-auth.com");
   });
 });

--- a/src/auth/__tests__/OidcAuthHandler.test.tsx
+++ b/src/auth/__tests__/OidcAuthHandler.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { act } from "@testing-library/react";
 import { fixtures, render, waitFor } from "test-utils";
 import OidcAuthHandler from "../OidcAuthHandler";
 
@@ -161,4 +162,44 @@ test("proceeds with redirect when navigating back to sign in after cancel", asyn
   await waitFor(() => {
     expect(window.location.href).toContain("oidc-auth.com");
   });
+});
+
+test("shows cancel UI when Safari restores page from bfcache after redirect", async () => {
+  const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+    user: { token: undefined }
+  });
+
+  // Wait for the effect to run and set the redirect flag.
+  await waitFor(() => {
+    expect(sessionStorage.getItem(oidcRedirectKey)).toBe("1");
+  });
+
+  // Simulate Safari restoring this page from bfcache.
+  act(() => {
+    const event = new Event("pageshow");
+    Object.defineProperty(event, "persisted", { value: true });
+    window.dispatchEvent(event);
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+});
+
+test('clicking "Cancel" while redirecting shows cancel UI', async () => {
+  const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(utils.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  utils.getByRole("button", { name: "Cancel" }).click();
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
 });

--- a/src/auth/__tests__/OidcAuthHandler.test.tsx
+++ b/src/auth/__tests__/OidcAuthHandler.test.tsx
@@ -1,12 +1,15 @@
 import * as React from "react";
 import { act } from "@testing-library/react";
-import { fixtures, render, waitFor } from "test-utils";
-import OidcAuthHandler from "../OidcAuthHandler";
+import { fixtures, render, setup, waitFor } from "test-utils";
+import OidcAuthHandler, {
+  oidcRedirectFlag,
+  oidcCancelFlag
+} from "../OidcAuthHandler";
 
 // we import the unwrapped render here because we don't need the context providers
 
-const oidcRedirectKey = `cpw-oidc-redirect-${fixtures.clientOidcMethod.id}`;
-const oidcCancelKey = `cpw-oidc-cancelled-${fixtures.clientOidcMethod.id}`;
+const oidcRedirectKey = oidcRedirectFlag(fixtures.clientOidcMethod.id);
+const oidcCancelKey = oidcCancelFlag(fixtures.clientOidcMethod.id);
 
 test("shows loader while redirecting", () => {
   const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />);
@@ -78,7 +81,7 @@ test("does not redirect to OIDC provider when error is present", () => {
 
 test('clicking "Try Again" clears error and attempts OIDC redirect', async () => {
   const mockReplace = jest.fn();
-  const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+  const utils = setup(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
     router: {
       query: {
         loginError: "Authentication failed",
@@ -90,8 +93,7 @@ test('clicking "Try Again" clears error and attempts OIDC redirect', async () =>
     user: { token: undefined }
   });
 
-  const tryAgainButton = utils.getByRole("button", { name: "Try Again" });
-  tryAgainButton.click();
+  await utils.user.click(utils.getByRole("button", { name: "Try Again" }));
 
   await waitFor(() => {
     expect(mockReplace).toHaveBeenCalledWith(
@@ -134,7 +136,7 @@ test("does not redirect to OIDC provider when cancel is detected", async () => {
 test('clicking "Try Again" after cancel clears flags and redirects', async () => {
   sessionStorage.setItem(oidcRedirectKey, "1");
 
-  const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+  const utils = setup(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
     user: { token: undefined }
   });
 
@@ -142,7 +144,7 @@ test('clicking "Try Again" after cancel clears flags and redirects', async () =>
     expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
   });
 
-  utils.getByRole("button", { name: "Try Again" }).click();
+  await utils.user.click(utils.getByRole("button", { name: "Try Again" }));
 
   await waitFor(() => {
     expect(window.location.href).toContain("oidc-auth.com");
@@ -188,7 +190,7 @@ test("shows cancel UI when Safari restores page from bfcache after redirect", as
 });
 
 test('clicking "Cancel" while redirecting shows cancel UI', async () => {
-  const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+  const utils = setup(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
     user: { token: undefined }
   });
 
@@ -196,7 +198,7 @@ test('clicking "Cancel" while redirecting shows cancel UI', async () => {
     expect(utils.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
-  utils.getByRole("button", { name: "Cancel" }).click();
+  await utils.user.click(utils.getByRole("button", { name: "Cancel" }));
 
   await waitFor(() => {
     expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();

--- a/src/auth/__tests__/SamlAuthHandler.test.tsx
+++ b/src/auth/__tests__/SamlAuthHandler.test.tsx
@@ -1,12 +1,15 @@
 import * as React from "react";
 import { act } from "@testing-library/react";
-import { fixtures, render, waitFor } from "test-utils";
-import SamlAuthHandler from "../SamlAuthHandler";
+import { fixtures, render, setup, waitFor } from "test-utils";
+import SamlAuthHandler, {
+  samlRedirectFlag,
+  samlCancelFlag
+} from "../SamlAuthHandler";
 
 // we import the unwrapped render here because we don't need the context providers
 
-const samlRedirectKey = `cpw-saml-redirect-${fixtures.clientSamlMethod.id}`;
-const samlCancelKey = `cpw-saml-cancelled-${fixtures.clientSamlMethod.id}`;
+const samlRedirectKey = samlRedirectFlag(fixtures.clientSamlMethod.id);
+const samlCancelKey = samlCancelFlag(fixtures.clientSamlMethod.id);
 
 test("shows loader while redirecting", () => {
   const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />);
@@ -76,7 +79,7 @@ test("does not redirect to SAML IdP when error is present", () => {
 
 test('clicking "Try Again" clears error and attempts SAML redirect', async () => {
   const mockReplace = jest.fn();
-  const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+  const utils = setup(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
     router: {
       query: {
         loginError: "Authentication failed",
@@ -88,8 +91,7 @@ test('clicking "Try Again" clears error and attempts SAML redirect', async () =>
     user: { token: undefined }
   });
 
-  const tryAgainButton = utils.getByRole("button", { name: "Try Again" });
-  tryAgainButton.click();
+  await utils.user.click(utils.getByRole("button", { name: "Try Again" }));
 
   await waitFor(() => {
     expect(mockReplace).toHaveBeenCalledWith(
@@ -132,7 +134,7 @@ test("does not redirect to SAML IdP when cancel is detected", async () => {
 test('clicking "Try Again" after cancel clears flags and redirects', async () => {
   sessionStorage.setItem(samlRedirectKey, "1");
 
-  const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+  const utils = setup(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
     user: { token: undefined }
   });
 
@@ -140,7 +142,7 @@ test('clicking "Try Again" after cancel clears flags and redirects', async () =>
     expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
   });
 
-  utils.getByRole("button", { name: "Try Again" }).click();
+  await utils.user.click(utils.getByRole("button", { name: "Try Again" }));
 
   await waitFor(() => {
     expect(window.location.href).toContain("saml-auth.com");
@@ -186,7 +188,7 @@ test("shows cancel UI when Safari restores page from bfcache after redirect", as
 });
 
 test('clicking "Cancel" while redirecting shows cancel UI', async () => {
-  const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+  const utils = setup(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
     user: { token: undefined }
   });
 
@@ -194,7 +196,7 @@ test('clicking "Cancel" while redirecting shows cancel UI', async () => {
     expect(utils.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
-  utils.getByRole("button", { name: "Cancel" }).click();
+  await utils.user.click(utils.getByRole("button", { name: "Cancel" }));
 
   await waitFor(() => {
     expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();

--- a/src/auth/__tests__/SamlAuthHandler.test.tsx
+++ b/src/auth/__tests__/SamlAuthHandler.test.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { act } from "@testing-library/react";
 import { fixtures, render, waitFor } from "test-utils";
 import SamlAuthHandler from "../SamlAuthHandler";
 
@@ -159,4 +160,44 @@ test("proceeds with redirect when navigating back to sign in after cancel", asyn
   await waitFor(() => {
     expect(window.location.href).toContain("saml-auth.com");
   });
+});
+
+test("shows cancel UI when Safari restores page from bfcache after redirect", async () => {
+  const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+    user: { token: undefined }
+  });
+
+  // Wait for the effect to run and set the redirect flag.
+  await waitFor(() => {
+    expect(sessionStorage.getItem(samlRedirectKey)).toBe("1");
+  });
+
+  // Simulate Safari restoring this page from bfcache.
+  act(() => {
+    const event = new Event("pageshow");
+    Object.defineProperty(event, "persisted", { value: true });
+    window.dispatchEvent(event);
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+});
+
+test('clicking "Cancel" while redirecting shows cancel UI', async () => {
+  const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(utils.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  utils.getByRole("button", { name: "Cancel" }).click();
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
 });

--- a/src/auth/__tests__/SamlAuthHandler.test.tsx
+++ b/src/auth/__tests__/SamlAuthHandler.test.tsx
@@ -4,6 +4,9 @@ import SamlAuthHandler from "../SamlAuthHandler";
 
 // we import the unwrapped render here because we don't need the context providers
 
+const samlRedirectKey = `cpw-saml-redirect-${fixtures.clientSamlMethod.id}`;
+const samlCancelKey = `cpw-saml-cancelled-${fixtures.clientSamlMethod.id}`;
+
 test("shows loader while redirecting", () => {
   const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />);
   expect(utils.getByText("Logging in with SAML IdP 0...")).toBeInTheDocument();
@@ -14,6 +17,7 @@ beforeEach(() => {
   const location = new URL("http://test-domain.com");
   delete (window as any).location;
   (window as any).location = location;
+  sessionStorage.clear();
 });
 
 test("redirects to proper auth url", async () => {
@@ -95,5 +99,64 @@ test('clicking "Try Again" clears error and attempts SAML redirect', async () =>
       undefined,
       { shallow: true }
     );
+  });
+});
+
+test("shows cancel UI when user returns after pressing back from SAML IdP", async () => {
+  sessionStorage.setItem(samlRedirectKey, "1");
+
+  const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+});
+
+test("does not redirect to SAML IdP when cancel is detected", async () => {
+  sessionStorage.setItem(samlRedirectKey, "1");
+
+  render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+    user: { token: undefined }
+  });
+
+  // Give effects time to run; href should remain unchanged.
+  await waitFor(() => {
+    expect(window.location.href).toBe("http://test-domain.com/");
+  });
+});
+
+test('clicking "Try Again" after cancel clears flags and redirects', async () => {
+  sessionStorage.setItem(samlRedirectKey, "1");
+
+  const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+
+  utils.getByRole("button", { name: "Try Again" }).click();
+
+  await waitFor(() => {
+    expect(window.location.href).toContain("saml-auth.com");
+  });
+});
+
+test("proceeds with redirect when navigating back to sign in after cancel", async () => {
+  // Simulates the user seeing cancel UI and then clicking "Sign In" in the header,
+  // which causes the handler to remount with both flags already set.
+  sessionStorage.setItem(samlRedirectKey, "1");
+  sessionStorage.setItem(samlCancelKey, "1");
+
+  render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(window.location.href).toContain("saml-auth.com");
   });
 });

--- a/src/auth/useRedirectCancelDetection.ts
+++ b/src/auth/useRedirectCancelDetection.ts
@@ -27,11 +27,13 @@ export function useRedirectCancelDetection({
   handleCancel: () => void;
 } {
   const router = useRouter();
-  const [cancelDetected, setCancelDetected] = React.useState(
-    () =>
+  const [cancelDetected, setCancelDetected] = React.useState(() => {
+    if (typeof window === "undefined") return false;
+    return (
       !sessionStorage.getItem(redirectFlagKey) &&
       !!sessionStorage.getItem(cancelFlagKey)
-  );
+    );
+  });
 
   React.useEffect(() => {
     if (token) {

--- a/src/auth/useRedirectCancelDetection.ts
+++ b/src/auth/useRedirectCancelDetection.ts
@@ -1,0 +1,122 @@
+import * as React from "react";
+import { useRouter } from "next/router";
+
+/*
+ * Two sessionStorage flags track redirect state across hard page navigations.
+ * redirectFlagKey: set before leaving for the external provider.
+ * cancelFlagKey: set when the user returns without completing auth.
+ * When only the redirect flag is set, we show cancel UI and set the cancel flag.
+ * When both are set, the user is intentionally navigating back to sign in,
+ * so we clear both and proceed with a new redirect.
+ */
+export function useRedirectCancelDetection({
+  authUrl,
+  redirectFlagKey,
+  cancelFlagKey,
+  loginError,
+  token
+}: {
+  authUrl: string | undefined;
+  redirectFlagKey: string;
+  cancelFlagKey: string;
+  loginError: string | undefined;
+  token: string | undefined;
+}): {
+  cancelDetected: boolean;
+  handleTryAgain: () => void;
+  handleCancel: () => void;
+} {
+  const router = useRouter();
+  const [cancelDetected, setCancelDetected] = React.useState(
+    () =>
+      !sessionStorage.getItem(redirectFlagKey) &&
+      !!sessionStorage.getItem(cancelFlagKey)
+  );
+
+  React.useEffect(() => {
+    if (token) {
+      sessionStorage.removeItem(redirectFlagKey);
+      sessionStorage.removeItem(cancelFlagKey);
+      return;
+    }
+
+    const hasRedirectFlag = !!sessionStorage.getItem(redirectFlagKey);
+    const hasCancelFlag = !!sessionStorage.getItem(cancelFlagKey);
+
+    if (hasRedirectFlag && !hasCancelFlag && !loginError) {
+      // First return from the provider without completing auth.
+      sessionStorage.removeItem(redirectFlagKey);
+      sessionStorage.setItem(cancelFlagKey, "1");
+      setCancelDetected(true);
+      return;
+    }
+
+    if (hasRedirectFlag && hasCancelFlag && !cancelDetected) {
+      // User already saw the cancel screen and is intentionally navigating
+      // back to sign in (e.g. clicked Sign In in the header). Clear both
+      // flags and fall through to redirect.
+      sessionStorage.removeItem(redirectFlagKey);
+      sessionStorage.removeItem(cancelFlagKey);
+    }
+
+    if (authUrl && !loginError && !cancelDetected) {
+      sessionStorage.setItem(redirectFlagKey, "1");
+
+      /*
+       * Safari restores pages from bfcache on browser-back without re-running
+       * React effects. Listen for pageshow so we can detect this case and show
+       * cancel UI instead of leaving the spinner running indefinitely.
+       */
+      const handlePageShow = (event: PageTransitionEvent) => {
+        if (
+          event.persisted &&
+          !!sessionStorage.getItem(redirectFlagKey) &&
+          !sessionStorage.getItem(cancelFlagKey)
+        ) {
+          sessionStorage.removeItem(redirectFlagKey);
+          sessionStorage.setItem(cancelFlagKey, "1");
+          setCancelDetected(true);
+        }
+      };
+      window.addEventListener("pageshow", handlePageShow);
+
+      window.location.href = authUrl;
+
+      return () => {
+        window.removeEventListener("pageshow", handlePageShow);
+      };
+    }
+  }, [
+    token,
+    authUrl,
+    loginError,
+    cancelDetected,
+    redirectFlagKey,
+    cancelFlagKey
+  ]);
+
+  const handleTryAgain = React.useCallback(() => {
+    sessionStorage.removeItem(redirectFlagKey);
+    sessionStorage.removeItem(cancelFlagKey);
+    setCancelDetected(false);
+    if (loginError) {
+      // The URL still contains loginError until the router replace resolves.
+      // The effect's !loginError guard prevents an immediate redirect in the
+      // interim re-render while the navigation is in flight.
+      const { loginError: _, ...restQuery } = router.query;
+      router.replace(
+        { pathname: router.pathname, query: restQuery },
+        undefined,
+        { shallow: true }
+      );
+    }
+  }, [redirectFlagKey, cancelFlagKey, loginError, router]);
+
+  const handleCancel = React.useCallback(() => {
+    sessionStorage.removeItem(redirectFlagKey);
+    sessionStorage.removeItem(cancelFlagKey);
+    setCancelDetected(true);
+  }, [redirectFlagKey, cancelFlagKey]);
+
+  return { cancelDetected, handleTryAgain, handleCancel };
+}


### PR DESCRIPTION
## Description

Adds cancel-detection and error-recovery to the SAML, OIDC, and Clever auth redirect handlers, preventing infinite redirect loops when a login attempt is cancelled or fails.

When a patron initiates an external auth login, the handler redirects to an identity provider via a hard browser navigation. Previously, returning to the app without completing auth — via browser back, closing a popup, or an IdP-side failure — caused the handler to immediately redirect again, trapping the patron in a loop.

Key changes:
- **Auth-failure loop fix**: When an IdP redirects back to a protected page with an error parameter, that error is now passed through to the login handler, which displays it as an error message rather than triggering another redirect.
- **Browser-back cancel detection**: sessionStorage flags track the redirect lifecycle. When a user returns to the login page without completing auth, the cancelled message ("Login was cancelled.") is shown with a "Try Again" option rather than immediately re-redirecting.
- **Intentional re-navigation**: When a user on the cancel screen navigates back to the sign-in page (e.g. via the header or the "Try Again" option), the flags are cleared and a fresh redirect proceeds normally.

Special cases:
- **Safari `bfcache` support**: Safari restores pages from its back-forward cache without re-running React effects. A special event listener detects this case so that the cancelled message can be displayed correctly.
- **Cancel button**: A cancel button has been added to allow the user to manually abort and stop the spinner. This is kind of a catch all, but I went down that path because of an issue I ran into with my daily driver ARC Browser:
  - **Popup overlay support (ARC browser)**: ARC's "Little Arc" feature opens external URLs as an in-browser overlay, leaving the main page mounted in spinner state with no standard DOM event to detect closure. An explicit "Cancel" button on the spinner lets the patron manually abort.


## Motivation and Context

Users attempting to log in via redirect-based authentication -- SAML, OIDC, or Clever -- who cancelled mid-flow or failed to authenticate could become trapped in an infinite redirect loop without an obvious way out. 

[Jira PP-3961]

## How Has This Been Tested?

- New unit tests for the improved functionality.
- Manual testing in Firefox, Helium, Safari, and ARC.
- All checks pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/25837388753) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
