### PR TITLE
Library home button should navigate to catalog home not library website (PP-4354)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -63,7 +63,7 @@ const HeaderFC: React.FC<{ className?: string }> = ({ className }) => {
 };
 
 const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
-  const { helpWebsite, libraryWebsite } = library.libraryLinks;
+  const { helpWebsite } = library.libraryLinks;
   const libraryName = library.catalogName;
   const { isAuthenticated, isLoading } = useUser();
   const { baseLoginUrl } = useLogin();
@@ -87,6 +87,16 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
           {link.title}
         </AnchorButton>
       ))}
+
+      <NavButton
+        variant="ghost"
+        color="ui.black"
+        href="/"
+        sx={{ whiteSpace: "initial" }}
+      >
+        {`${libraryName} Home`}
+      </NavButton>
+
       {helpWebsite && (
         <AnchorButton
           variant="ghost"
@@ -97,17 +107,7 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
           Help
         </AnchorButton>
       )}
-      {libraryWebsite && (
-        <AnchorButton
-          variant="ghost"
-          color="ui.black"
-          href={libraryWebsite.href}
-          title="help"
-          sx={{ whiteSpace: "initial" }}
-        >
-          {libraryWebsite.title ?? `${libraryName} Home`}
-        </AnchorButton>
-      )}
+
       <NavButton
         variant="ghost"
         color="ui.black"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,7 +27,7 @@ const HeaderFC: React.FC<{ className?: string }> = ({ className }) => {
     >
       <Link
         href="/"
-        aria-label="Library catalog, back to homepage"
+        aria-label="Go to catalog home page"
         sx={{
           display: "flex",
           flexDirection: "column",
@@ -64,7 +64,6 @@ const HeaderFC: React.FC<{ className?: string }> = ({ className }) => {
 
 const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
   const { helpWebsite } = library.libraryLinks;
-  const libraryName = library.catalogName;
   const { isAuthenticated, isLoading } = useUser();
   const { baseLoginUrl } = useLogin();
 
@@ -94,7 +93,7 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
         href="/"
         sx={{ whiteSpace: "initial" }}
       >
-        {`${libraryName} Home`}
+        Catalog
       </NavButton>
 
       {helpWebsite && (
@@ -117,6 +116,7 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
       >
         My Books
       </NavButton>
+
       {isAuthenticated ? (
         <AccountMenu />
       ) : isLoading ? (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -75,6 +75,15 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
         justifyContent: ["center", "flex-end"]
       }}
     >
+      <NavButton
+        variant="ghost"
+        color="ui.black"
+        href="/"
+        sx={{ whiteSpace: "initial" }}
+      >
+        Catalog
+      </NavButton>
+
       {library?.headerLinks?.map(link => (
         <AnchorButton
           variant="ghost"
@@ -86,15 +95,6 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
           {link.title}
         </AnchorButton>
       ))}
-
-      <NavButton
-        variant="ghost"
-        color="ui.black"
-        href="/"
-        sx={{ whiteSpace: "initial" }}
-      >
-        Catalog
-      </NavButton>
 
       {helpWebsite && (
         <AnchorButton

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -1,22 +1,55 @@
 import * as React from "react";
 import { screen, setup } from "../../test-utils";
+import { mockPush } from "test-utils/mockNextRouter";
 import Layout from "../Layout";
 
 describe("Layout nav + structure", () => {
-  test("Library icon button navigates home", () => {
-    setup(<Layout>Child</Layout>);
-    const homeButton = screen.getByLabelText(
-      "Library catalog, back to homepage"
-    );
+  describe("Navbar", () => {
+    test("Library icon button navigates home", async () => {
+      const { user } = setup(<Layout>Child</Layout>);
+      const homeButton = screen.getByLabelText(
+        "Library catalog, back to homepage"
+      );
 
-    // the home button should navigate to "/"
-    expect(homeButton.closest("a")).toHaveAttribute("href", "/testlib");
-  });
+      // the home button should navigate to "/"
+      expect(homeButton.closest("a")).toHaveAttribute("href", "/testlib");
+      await user.click(homeButton);
+      expect(mockPush).toHaveBeenCalledWith(
+        "/testlib",
+        "/testlib",
+        expect.objectContaining({
+          scroll: true,
+          shallow: true,
+          locale: undefined
+        })
+      );
+    });
 
-  test("my books navigates to /loans", () => {
-    setup(<Layout>Child</Layout>);
-    const myBooks = screen.getAllByRole("link", { name: "My Books" });
-    myBooks.forEach(ln => expect(ln).toHaveAttribute("href", "/testlib/loans"));
+    test("Home nav button navigates home", async () => {
+      const { user } = setup(<Layout>Child</Layout>);
+      const homeButton = screen.getByRole("link", {
+        name: "XYZ Public Library Home"
+      });
+      expect(homeButton).toHaveAttribute("href", "/testlib");
+      await user.click(homeButton);
+      expect(mockPush).toHaveBeenCalledWith(
+        "/testlib",
+        "/testlib",
+        expect.objectContaining({
+          scroll: true,
+          shallow: true,
+          locale: undefined
+        })
+      );
+    });
+
+    test("my books navigates to /loans", () => {
+      setup(<Layout>Child</Layout>);
+      const myBooks = screen.getAllByRole("link", { name: "My Books" });
+      myBooks.forEach(ln =>
+        expect(ln).toHaveAttribute("href", "/testlib/loans")
+      );
+    });
   });
 
   test("displays children within main", () => {

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -11,7 +11,7 @@ describe("Layout nav + structure", () => {
         "Go to catalog home page"
       );
 
-      // the home button should navigate to the catalog home page ("/testlib") for t
+      // the home button should navigate to the catalog home page ("/testlib")
       expect(libraryIconButton.closest("a")).toHaveAttribute(
         "href",
         "/testlib"

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -5,15 +5,18 @@ import Layout from "../Layout";
 
 describe("Layout nav + structure", () => {
   describe("Navbar", () => {
-    test("Library icon button navigates home", async () => {
+    test("Library icon button navigates to web catalog home", async () => {
       const { user } = setup(<Layout>Child</Layout>);
-      const homeButton = screen.getByLabelText(
-        "Library catalog, back to homepage"
+      const libraryIconButton = screen.getByLabelText(
+        "Go to catalog home page"
       );
 
-      // the home button should navigate to "/"
-      expect(homeButton.closest("a")).toHaveAttribute("href", "/testlib");
-      await user.click(homeButton);
+      // the home button should navigate to the catalog home page ("/testlib") for t
+      expect(libraryIconButton.closest("a")).toHaveAttribute(
+        "href",
+        "/testlib"
+      );
+      await user.click(libraryIconButton);
       expect(mockPush).toHaveBeenCalledWith(
         "/testlib",
         "/testlib",
@@ -25,13 +28,11 @@ describe("Layout nav + structure", () => {
       );
     });
 
-    test("Home nav button navigates home", async () => {
+    test("Catalog nav button navigates to web catalog home", async () => {
       const { user } = setup(<Layout>Child</Layout>);
-      const homeButton = screen.getByRole("link", {
-        name: "XYZ Public Library Home"
-      });
-      expect(homeButton).toHaveAttribute("href", "/testlib");
-      await user.click(homeButton);
+      const catalogButton = screen.getByRole("link", { name: "Catalog" });
+      expect(catalogButton).toHaveAttribute("href", "/testlib");
+      await user.click(catalogButton);
       expect(mockPush).toHaveBeenCalledWith(
         "/testlib",
         "/testlib",


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
The "[Library] Home" button now directs the user to the web catalog's home page and the label now reads as "Catalog". Previously, the button would direct users externally to the library home page for that instance of the web catalog.

<img width="311" height="49" alt="image" src="https://github.com/user-attachments/assets/0cf5be69-0cd8-4260-bba3-ccf6eda8cc80" />

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The ambiguous naming of the button label confused users as to the destination of the link. Routing to the catalog home page reinforces the intended destination of the link. This change also aligns with the convention that all the nav links in the navbar link within the application.

RAILs testers using RAILs web catalog instances found that following the link to the RAILs organizational website provided an unnecessarily difficult experience for navigating back to the web catalog.

[Jira PP-4354](https://ebce-lyrasis.atlassian.net/browse/PP-4354)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested in Chrome, Firefox, and Safari
- Tested link behavior with mocked Next.js router

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
