### PR TITLE
Reduce excessive registry and auth doc fetches (PP-4342)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ __To have your library added to the demo, register it with NYPL's Library Regist
   - [Environment Variables](#environment-variables)
   - [Manager, Registry, and Application Configurations](#manager--registry--and-application-configurations)
   - [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings)
+  - [Authentication Document Caching](#authentication-document-caching)
 - [Development](#development)
   - [Contributing](#contributing)
   - [Installing Dependencies](#installing-dependencies)
@@ -79,6 +80,7 @@ The app is configured with a YAML file. Point the app at it by setting the `CONF
 | `media_support` | mapping | `{}` | Per-MIME-type rendering mode. See [Media Support](#media-support) below. |
 | `static_libraries` | mapping | — | Static library definitions. See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
 | `registries` | list | `[]` | One or more library registry URLs fetched at runtime. See [Libraries and Registries Configuration Settings](#libraries-and-registries-configuration-settings). |
+| `authentication_documents` | mapping | — | Controls server-side caching of auth documents. See [Authentication Document Caching](#authentication-document-caching). |
 
 #### Deprecated Configuration Options
 
@@ -239,6 +241,25 @@ libraries: https://registry.thepalaceproject.org/libraries
 registries:
   - url: https://registry.thepalaceproject.org/libraries
 ```
+
+## Authentication Document Caching
+
+Each library's authentication document is fetched on demand as pages are generated and cached server-side. The `authentication_documents` section controls how long that cache stays fresh.
+
+```yaml
+authentication_documents:
+  refresh_min_interval: 60    # Minimum seconds between re-fetch attempts (default: 60)
+  refresh_max_interval: 300   # Seconds before a cached auth doc is considered stale (default: 300)
+```
+
+Both keys are optional; omitting the section entirely uses the defaults shown above.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `refresh_min_interval` | `60` | Minimum number of seconds that must pass between successive fetch attempts for the same auth document, even if the cached copy is stale. This prevents hammering a slow or unavailable upstream endpoint. |
+| `refresh_max_interval` | `300` | Number of seconds after the last *successful* fetch before the cached auth document is considered stale and a new fetch is attempted. |
+
+These settings mirror the `refresh_min_interval` / `refresh_max_interval` fields available on each entry in the `registries` list.
 
 # Development
 

--- a/community-config.yml
+++ b/community-config.yml
@@ -109,3 +109,12 @@ static_libraries:
 # Migrate to the 'registries' array format:
 #
 #   libraries: https://registry.thepalaceproject.org/libraries  # DEPRECATED
+#
+# AUTHENTICATION DOCUMENT CACHING
+#
+# Controls how long each library's authentication document is cached server-side.
+# Auth documents are fetched on demand when a library page is first generated via ISR.
+#
+# authentication_documents:
+#   refresh_min_interval: 60   # Minimum seconds between re-fetch attempts (default: 60)
+#   refresh_max_interval: 300  # Seconds before a cached auth doc is considered stale (default: 300)

--- a/src/config/fallbackAppConfig.ts
+++ b/src/config/fallbackAppConfig.ts
@@ -6,7 +6,8 @@ const FALLBACK_APP_CONFIG: AppConfig = {
   companionApp: "simplye",
   showMedium: true,
   bugsnagApiKey: null,
-  openebooks: null
+  openebooks: null,
+  authenticationDocuments: null
 };
 
 export default FALLBACK_APP_CONFIG;

--- a/src/constants/registry.ts
+++ b/src/constants/registry.ts
@@ -22,3 +22,9 @@ export const DEFAULT_REGISTRY_FULL_REFRESH_INTERVAL = 86400;
 
 /** Seconds before an individual registry page fetch is aborted. */
 export const DEFAULT_REGISTRY_FETCH_TIMEOUT = 10;
+
+/** Minimum seconds between auth document re-fetch attempts. */
+export const DEFAULT_AUTH_DOC_REFRESH_MIN_INTERVAL = 60;
+
+/** Maximum seconds since last successful auth document fetch before re-fetching. */
+export const DEFAULT_AUTH_DOC_REFRESH_MAX_INTERVAL = 300;

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -118,6 +118,68 @@ describe("fetchAuthDocument", () => {
     expect(result).toEqual({ cached: true });
   });
 
+  describe("refresh intervals", () => {
+    const T0 = 1_000_000_000; // arbitrary fixed base time in ms
+
+    afterEach(() => jest.restoreAllMocks());
+
+    test("re-fetches when refreshMaxInterval has elapsed", async () => {
+      jest.spyOn(Date, "now").mockReturnValue(T0);
+      fetchMock.mockResponseOnce(JSON.stringify({ v: 1 }));
+      await fetchAuthDocument("/auth-doc", {
+        refreshMinInterval: 5,
+        refreshMaxInterval: 10
+      });
+
+      jest.spyOn(Date, "now").mockReturnValue(T0 + 11_000);
+      fetchMock.mockResponseOnce(JSON.stringify({ v: 2 }));
+      const result = await fetchAuthDocument("/auth-doc", {
+        refreshMinInterval: 5,
+        refreshMaxInterval: 10
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ v: 2 });
+    });
+
+    test("does not re-fetch within refreshMinInterval", async () => {
+      jest.spyOn(Date, "now").mockReturnValue(T0);
+      fetchMock.mockResponseOnce(JSON.stringify({ v: 1 }));
+      await fetchAuthDocument("/auth-doc", {
+        refreshMinInterval: 30,
+        refreshMaxInterval: 10
+      });
+
+      // maxInterval elapsed but minInterval has not
+      jest.spyOn(Date, "now").mockReturnValue(T0 + 15_000);
+      const result = await fetchAuthDocument("/auth-doc", {
+        refreshMinInterval: 30,
+        refreshMaxInterval: 10
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ v: 1 });
+    });
+
+    test("retries a failed first fetch even within refreshMinInterval", async () => {
+      jest.spyOn(Date, "now").mockReturnValue(T0);
+      fetchMock.mockRejectOnce(new Error("down"));
+      await fetchAuthDocument("/auth-doc", { refreshMinInterval: 30 }).catch(
+        () => {}
+      );
+
+      // Still within minInterval but no cached doc — should retry.
+      jest.spyOn(Date, "now").mockReturnValue(T0 + 5_000);
+      fetchMock.mockResponseOnce(JSON.stringify({ recovered: true }));
+      const result = await fetchAuthDocument("/auth-doc", {
+        refreshMinInterval: 30
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ recovered: true });
+    });
+  });
+
   test("coalesces concurrent requests for the same url", async () => {
     fetchMock.mockResponseOnce(JSON.stringify({ coalesced: true }));
     const [r1, r2, r3] = await Promise.all([

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -3,7 +3,8 @@ import { describe, expect, test } from "@jest/globals";
 import {
   fetchAuthDocument,
   buildLibraryData,
-  getAuthDocUrl
+  getAuthDocUrl,
+  resetAuthDocCache
 } from "../getLibraryData";
 import fetchMock from "jest-fetch-mock";
 import ApplicationError, { PageNotFoundError } from "errors";
@@ -91,6 +92,8 @@ describe("getAuthDocUrl", () => {
 });
 
 describe("fetchAuthDocument", () => {
+  beforeEach(() => resetAuthDocCache());
+
   test("calls the auth document url and returns json", async () => {
     fetchMock.mockResponseOnce(
       JSON.stringify({
@@ -103,6 +106,29 @@ describe("fetchAuthDocument", () => {
     expect(json).toEqual({
       some: "json"
     });
+  });
+
+  test("returns cached result without fetching on second call", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ cached: true }));
+    await fetchAuthDocument("/auth-doc");
+    fetchMock.mockClear();
+
+    const result = await fetchAuthDocument("/auth-doc");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ cached: true });
+  });
+
+  test("coalesces concurrent requests for the same url", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ coalesced: true }));
+    const [r1, r2, r3] = await Promise.all([
+      fetchAuthDocument("/concurrent-doc"),
+      fetchAuthDocument("/concurrent-doc"),
+      fetchAuthDocument("/concurrent-doc")
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(r1).toEqual({ coalesced: true });
+    expect(r2).toEqual(r1);
+    expect(r3).toEqual(r1);
   });
 
   test("passes fetch errors through", async () => {

--- a/src/dataflow/getLibraryData.ts
+++ b/src/dataflow/getLibraryData.ts
@@ -1,31 +1,46 @@
-import { AppConfig, LibraryData, LibraryLinks, OPDS1 } from "interfaces";
+import {
+  AppConfig,
+  AuthDocConfig,
+  LibraryData,
+  LibraryLinks,
+  OPDS1
+} from "interfaces";
 import ApplicationError, { PageNotFoundError, ServerError } from "errors";
 import { normalizeAuthMethods } from "utils/auth";
 import { getAppConfig } from "server/appConfig";
 import { getLibraries } from "server/libraryRegistry";
+import {
+  DEFAULT_AUTH_DOC_REFRESH_MIN_INTERVAL,
+  DEFAULT_AUTH_DOC_REFRESH_MAX_INTERVAL
+} from "constants/registry";
 
 // ---------------------------------------------------------------------------
 // Auth document cache
 // ---------------------------------------------------------------------------
 
 /*
- * Caches fetched auth documents by URL for AUTH_DOC_CACHE_TTL_SECONDS.
- * Multiple ISR route rebuilds for the same library (index, loans, book, etc.)
- * all resolve to the same auth document URL; without caching they each issue an
- * independent upstream fetch in quick succession. The cache prevents that burst
- * and also limits load on auth document servers during high-traffic periods.
+ * Caches fetched auth documents by URL. Multiple ISR route rebuilds for the
+ * same library (index, loans, book, etc.) all resolve to the same auth document
+ * URL; without caching they each issue an independent upstream fetch in quick
+ * succession.
+ *
+ * The cache is keyed by URL and stores the last successful fetch time alongside
+ * the last attempt time (whether successful or not). refreshMinInterval prevents
+ * hammering a re-fetch after a failed attempt; refreshMaxInterval controls how
+ * long a cached doc is considered fresh. Both mirror the semantics of the
+ * registry refresh config.
  *
  * pendingAuthDocFetches coalesces concurrent requests for the same URL so that
- * exactly one in-flight fetch exists at a time, matching the pattern used by
- * libraryRegistry.ts for registry crawls.
+ * exactly one in-flight fetch exists at a time.
  *
  * Stored on `global` for the same reason as libraryRegistry.ts: Next.js bundles
  * each route independently, so module-level Maps would not be shared across
  * bundle contexts in the same process.
  */
 interface AuthDocCacheEntry {
-  doc: OPDS1.AuthDocument;
-  fetchedAt: number;
+  doc: OPDS1.AuthDocument | null; // null until first successful fetch
+  lastSuccessfulFetch: number | null; // null until first successful fetch
+  lastAttemptedFetch: number | null; // set before each fetch attempt
 }
 
 interface AuthDocModuleState {
@@ -45,12 +60,34 @@ if (!global.__cpwAuthDocState) {
 }
 
 const { authDocCache, pendingAuthDocFetches } = global.__cpwAuthDocState;
-const AUTH_DOC_CACHE_TTL_SECONDS = 3600;
 
 /** Clears the auth document cache. Intended for use in tests only. */
 export function resetAuthDocCache(): void {
   authDocCache.clear();
   pendingAuthDocFetches.clear();
+}
+
+function shouldRefreshAuthDoc(
+  entry: AuthDocCacheEntry | undefined,
+  config: AuthDocConfig,
+  nowSeconds: number
+): boolean {
+  const minInterval =
+    config.refreshMinInterval ?? DEFAULT_AUTH_DOC_REFRESH_MIN_INTERVAL;
+  const maxInterval =
+    config.refreshMaxInterval ?? DEFAULT_AUTH_DOC_REFRESH_MAX_INTERVAL;
+
+  /*
+   * Throttle re-fetches only when a cached doc exists. Without a cached doc
+   * there is nothing to return, so the minInterval guard is bypassed and we
+   * always attempt a fetch.
+   */
+  if (entry?.lastAttemptedFetch != null && entry.doc != null) {
+    if (nowSeconds - entry.lastAttemptedFetch < minInterval) return false;
+  }
+
+  if (!entry || entry.lastSuccessfulFetch == null) return true;
+  return nowSeconds - entry.lastSuccessfulFetch >= maxInterval;
 }
 
 /**
@@ -80,21 +117,33 @@ export async function getAuthDocUrl(
 
 /**
  * Fetches an auth document from the supplied url and returns it as a parsed
- * AuthDocument. Results are cached for AUTH_DOC_CACHE_TTL_SECONDS; concurrent
- * requests for the same URL share a single in-flight fetch.
+ * AuthDocument. Concurrent requests for the same URL share a single in-flight
+ * fetch. Sequential requests consult shouldRefreshAuthDoc: fresh cached docs are
+ * returned immediately; stale docs trigger a re-fetch.
  */
 export async function fetchAuthDocument(
-  url: string
+  url: string,
+  authDocConfig: AuthDocConfig = {}
 ): Promise<OPDS1.AuthDocument> {
   const now = Date.now() / 1000;
 
-  const cached = authDocCache.get(url);
-  if (cached && now - cached.fetchedAt < AUTH_DOC_CACHE_TTL_SECONDS) {
-    return cached.doc;
-  }
-
   const pending = pendingAuthDocFetches.get(url);
   if (pending) return pending;
+
+  const entry = authDocCache.get(url);
+  if (!shouldRefreshAuthDoc(entry, authDocConfig, now) && entry?.doc != null) {
+    return entry.doc;
+  }
+
+  /*
+   * Set lastAttemptedFetch synchronously so that sequential requests arriving
+   * within refreshMinInterval after this fetch completes are throttled.
+   */
+  authDocCache.set(url, {
+    doc: entry?.doc ?? null,
+    lastSuccessfulFetch: entry?.lastSuccessfulFetch ?? null,
+    lastAttemptedFetch: now
+  });
 
   const fetchPromise = (async () => {
     try {
@@ -104,7 +153,11 @@ export async function fetchAuthDocument(
         throw new ServerError(url, response.status, details);
       }
       const doc: OPDS1.AuthDocument = await response.json();
-      authDocCache.set(url, { doc, fetchedAt: Date.now() / 1000 });
+      authDocCache.set(url, {
+        doc,
+        lastSuccessfulFetch: now,
+        lastAttemptedFetch: now
+      });
       return doc;
     } finally {
       pendingAuthDocFetches.delete(url);

--- a/src/dataflow/getLibraryData.ts
+++ b/src/dataflow/getLibraryData.ts
@@ -1,17 +1,72 @@
-import { LibraryData, LibraryLinks, OPDS1 } from "interfaces";
+import { AppConfig, LibraryData, LibraryLinks, OPDS1 } from "interfaces";
 import ApplicationError, { PageNotFoundError, ServerError } from "errors";
 import { normalizeAuthMethods } from "utils/auth";
 import { getAppConfig } from "server/appConfig";
 import { getLibraries } from "server/libraryRegistry";
 
+// ---------------------------------------------------------------------------
+// Auth document cache
+// ---------------------------------------------------------------------------
+
+/*
+ * Caches fetched auth documents by URL for AUTH_DOC_CACHE_TTL_SECONDS.
+ * Multiple ISR route rebuilds for the same library (index, loans, book, etc.)
+ * all resolve to the same auth document URL; without caching they each issue an
+ * independent upstream fetch in quick succession. The cache prevents that burst
+ * and also limits load on auth document servers during high-traffic periods.
+ *
+ * pendingAuthDocFetches coalesces concurrent requests for the same URL so that
+ * exactly one in-flight fetch exists at a time, matching the pattern used by
+ * libraryRegistry.ts for registry crawls.
+ *
+ * Stored on `global` for the same reason as libraryRegistry.ts: Next.js bundles
+ * each route independently, so module-level Maps would not be shared across
+ * bundle contexts in the same process.
+ */
+interface AuthDocCacheEntry {
+  doc: OPDS1.AuthDocument;
+  fetchedAt: number;
+}
+
+interface AuthDocModuleState {
+  authDocCache: Map<string, AuthDocCacheEntry>;
+  pendingAuthDocFetches: Map<string, Promise<OPDS1.AuthDocument>>;
+}
+
+declare const global: typeof globalThis & {
+  __cpwAuthDocState?: AuthDocModuleState;
+};
+
+if (!global.__cpwAuthDocState) {
+  global.__cpwAuthDocState = {
+    authDocCache: new Map<string, AuthDocCacheEntry>(),
+    pendingAuthDocFetches: new Map<string, Promise<OPDS1.AuthDocument>>()
+  };
+}
+
+const { authDocCache, pendingAuthDocFetches } = global.__cpwAuthDocState;
+const AUTH_DOC_CACHE_TTL_SECONDS = 3600;
+
+/** Clears the auth document cache. Intended for use in tests only. */
+export function resetAuthDocCache(): void {
+  authDocCache.clear();
+  pendingAuthDocFetches.clear();
+}
+
 /**
  * Interprets the app config to return the auth document url.
  * Uses getLibraries so registry-sourced libraries (not present in the static
  * build-time config) are included in the lookup.
+ *
+ * Accepts an already-fetched AppConfig to avoid a redundant getAppConfig()
+ * call when the caller has already loaded it.
  */
-export async function getAuthDocUrl(librarySlug: string): Promise<string> {
-  const appConfig = await getAppConfig();
-  const libraries = await getLibraries(appConfig);
+export async function getAuthDocUrl(
+  librarySlug: string,
+  appConfig?: AppConfig
+): Promise<string> {
+  const config = appConfig ?? (await getAppConfig());
+  const libraries = await getLibraries(config);
 
   const authDocUrl =
     librarySlug in libraries ? libraries[librarySlug]?.authDocUrl : undefined;
@@ -24,19 +79,40 @@ export async function getAuthDocUrl(librarySlug: string): Promise<string> {
 }
 
 /**
- * Fetches an auth document from the supplied url and returns it
- * as a parsed AuthDocument
+ * Fetches an auth document from the supplied url and returns it as a parsed
+ * AuthDocument. Results are cached for AUTH_DOC_CACHE_TTL_SECONDS; concurrent
+ * requests for the same URL share a single in-flight fetch.
  */
 export async function fetchAuthDocument(
   url: string
 ): Promise<OPDS1.AuthDocument> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    const details = await response.json();
-    throw new ServerError(url, response.status, details);
+  const now = Date.now() / 1000;
+
+  const cached = authDocCache.get(url);
+  if (cached && now - cached.fetchedAt < AUTH_DOC_CACHE_TTL_SECONDS) {
+    return cached.doc;
   }
-  const json = await response.json();
-  return json;
+
+  const pending = pendingAuthDocFetches.get(url);
+  if (pending) return pending;
+
+  const fetchPromise = (async () => {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        const details = await response.json();
+        throw new ServerError(url, response.status, details);
+      }
+      const doc: OPDS1.AuthDocument = await response.json();
+      authDocCache.set(url, { doc, fetchedAt: Date.now() / 1000 });
+      return doc;
+    } finally {
+      pendingAuthDocFetches.delete(url);
+    }
+  })();
+
+  pendingAuthDocFetches.set(url, fetchPromise);
+  return fetchPromise;
 }
 
 /**

--- a/src/dataflow/withAppProps.ts
+++ b/src/dataflow/withAppProps.ts
@@ -33,7 +33,7 @@ export default function withAppProps(
         );
 
       const appConfig = await getAppConfig();
-      const authDocUrl = await getAuthDocUrl(librarySlug);
+      const authDocUrl = await getAuthDocUrl(librarySlug, appConfig);
       const authDocument = await fetchAuthDocument(authDocUrl);
       const library = buildLibraryData(authDocument, librarySlug);
       // fetch the static props for the page

--- a/src/dataflow/withAppProps.ts
+++ b/src/dataflow/withAppProps.ts
@@ -34,7 +34,10 @@ export default function withAppProps(
 
       const appConfig = await getAppConfig();
       const authDocUrl = await getAuthDocUrl(librarySlug, appConfig);
-      const authDocument = await fetchAuthDocument(authDocUrl);
+      const authDocument = await fetchAuthDocument(
+        authDocUrl,
+        appConfig.authenticationDocuments ?? undefined
+      );
       const library = buildLibraryData(authDocument, librarySlug);
       // fetch the static props for the page
       const pageResult = (await pageGetStaticProps?.(ctx)) ?? { props: {} };

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -43,8 +43,19 @@ export async function register() {
     }
 
     const { getAppConfig } = await import("server/appConfig");
+    const { getLibraries } = await import("server/libraryRegistry");
     try {
-      await getAppConfig();
+      const appConfig = await getAppConfig();
+      /*
+       * Pre-warm the registry cache before any requests are served.
+       * getLibraries() sets pendingRefreshes synchronously before its first
+       * await, so concurrent first-request handlers (including ISR
+       * getStaticProps workers) find the in-progress crawl and coalesce onto
+       * it via pendingRefreshes rather than starting independent duplicates.
+       * Registry fetch errors are swallowed inside refreshRegistry, so this
+       * call will not throw.
+       */
+      void getLibraries(appConfig);
     } catch (e) {
       // Next.js does not exit on register() errors, so we must do it ourselves.
       console.error(e instanceof Error ? e.message : String(e));

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,6 +21,7 @@ export type AppConfig = {
   mediaSupport: MediaSupportConfig;
   registries?: RegistryConfig[];
   staticLibraries?: LibrariesConfig;
+  authenticationDocuments: AuthDocConfig | null;
   companionApp: "simplye" | "openebooks";
   showMedium: boolean;
   bugsnagApiKey: string | null;
@@ -63,6 +64,12 @@ export interface RegistryConfig {
   refreshMaxInterval?: number; // seconds, default 300
   fullRefreshInterval?: number; // seconds, default 86400 (24 h)
   timeout?: number; // seconds, default 10
+}
+
+/** Global configuration for authentication document caching. */
+export interface AuthDocConfig {
+  refreshMinInterval?: number; // seconds between re-fetch attempts, default 60
+  refreshMaxInterval?: number; // seconds before cached doc is considered stale, default 3600
 }
 
 export interface ComplaintData {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -60,16 +60,16 @@ export type LibrariesConfig = Record<
 /** Per-registry configuration for runtime library fetching. */
 export interface RegistryConfig {
   url: string;
-  refreshMinInterval?: number; // seconds, default 60
-  refreshMaxInterval?: number; // seconds, default 300
-  fullRefreshInterval?: number; // seconds, default 86400 (24 h)
-  timeout?: number; // seconds, default 10
+  refreshMinInterval?: number;
+  refreshMaxInterval?: number;
+  fullRefreshInterval?: number;
+  timeout?: number;
 }
 
 /** Global configuration for authentication document caching. */
 export interface AuthDocConfig {
-  refreshMinInterval?: number; // seconds between re-fetch attempts, default 60
-  refreshMaxInterval?: number; // seconds before cached doc is considered stale, default 3600
+  refreshMinInterval?: number;
+  refreshMaxInterval?: number;
 }
 
 export interface ComplaintData {

--- a/src/server/__tests__/instrumentation.test.ts
+++ b/src/server/__tests__/instrumentation.test.ts
@@ -10,15 +10,21 @@ jest.mock("server/appConfig", () => ({
   getAppConfig: jest.fn()
 }));
 
+jest.mock("server/libraryRegistry", () => ({
+  getLibraries: jest.fn()
+}));
+
 import * as http from "node:http";
 import { EventEmitter } from "node:events";
 import { register } from "../../instrumentation";
 import { getAppConfig } from "server/appConfig";
+import { getLibraries } from "server/libraryRegistry";
 
 type EmitFn = (event: string | symbol, ...args: unknown[]) => boolean;
 const serverProto = http.Server.prototype as unknown as { emit: EmitFn };
 
 const mockGetAppConfig = getAppConfig as jest.Mock;
+const mockGetLibraries = getLibraries as jest.Mock;
 
 const originalEnv = process.env;
 let savedFetch: typeof globalThis.fetch;
@@ -59,6 +65,7 @@ describe("register", () => {
   it("calls getAppConfig when NEXT_RUNTIME is 'nodejs'", async () => {
     process.env.NEXT_RUNTIME = "nodejs";
     mockGetAppConfig.mockResolvedValue({});
+    mockGetLibraries.mockResolvedValue({});
     await register();
     expect(mockGetAppConfig).toHaveBeenCalledTimes(1);
   });
@@ -66,7 +73,35 @@ describe("register", () => {
   it("resolves without error when getAppConfig succeeds", async () => {
     process.env.NEXT_RUNTIME = "nodejs";
     mockGetAppConfig.mockResolvedValue({});
+    mockGetLibraries.mockResolvedValue({});
     await expect(register()).resolves.toBeUndefined();
+  });
+
+  it("calls getLibraries with the appConfig returned by getAppConfig", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    const fakeConfig = { registries: [], staticLibraries: {} };
+    mockGetAppConfig.mockResolvedValue(fakeConfig);
+    mockGetLibraries.mockResolvedValue({});
+    await register();
+    expect(mockGetLibraries).toHaveBeenCalledWith(fakeConfig);
+  });
+
+  it("does not call getLibraries when getAppConfig fails", async () => {
+    process.env.NEXT_RUNTIME = "nodejs";
+    const exitSpy = jest
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    mockGetAppConfig.mockRejectedValue(new Error("bad config"));
+    await register();
+    expect(mockGetLibraries).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it("does not call getLibraries when NEXT_RUNTIME is not 'nodejs'", async () => {
+    delete process.env.NEXT_RUNTIME;
+    await register();
+    expect(mockGetLibraries).not.toHaveBeenCalled();
   });
 
   it("does not patch http.Server.prototype.emit when NEXT_RUNTIME is not 'nodejs'", async () => {
@@ -131,6 +166,7 @@ describe("HTTP request logging", () => {
     logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     process.env.NEXT_RUNTIME = "nodejs";
     mockGetAppConfig.mockResolvedValue({});
+    mockGetLibraries.mockResolvedValue({});
     await register();
   });
 
@@ -207,6 +243,7 @@ describe("outbound fetch logging", () => {
     logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     process.env.NEXT_RUNTIME = "nodejs";
     mockGetAppConfig.mockResolvedValue({});
+    mockGetLibraries.mockResolvedValue({});
     await register();
   });
 

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -34,6 +34,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     showMedium: true,
     openebooks: null,
     mediaSupport: {},
+    authenticationDocuments: null,
     ...overrides
   };
 }

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -31,6 +31,11 @@ const RegistryEntrySchema = type({
   "refreshMaxInterval?": "number"
 });
 
+const AuthDocConfigSchema = type({
+  "refreshMinInterval?": "number",
+  "refreshMaxInterval?": "number"
+});
+
 const RawConfigSchema = type({
   // Intentionally permissive: any non-string value silently defaults.
   "instanceName?": "unknown",
@@ -39,6 +44,7 @@ const RawConfigSchema = type({
   "registries?": RegistryEntrySchema.array(),
   "libraries?": "string | Record<string, unknown>",
   "staticLibraries?": "Record<string, unknown>",
+  "authenticationDocuments?": AuthDocConfigSchema,
   "mediaSupport?": "Record<string, string | Record<string, string>>",
   "openebooks?": { defaultLibrary: "string" }
 });
@@ -146,6 +152,7 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     "bugsnagApiKey",
     "gtmId",
     "staticLibraries",
+    "authenticationDocuments",
     "mediaSupport"
   ]);
 
@@ -175,6 +182,15 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
             "refreshMaxInterval"
           ])
         : r
+    );
+  }
+  if (
+    normalized.authenticationDocuments !== null &&
+    typeof normalized.authenticationDocuments === "object"
+  ) {
+    normalized.authenticationDocuments = normalizeConfigKeys(
+      normalized.authenticationDocuments as Record<string, unknown>,
+      ["refreshMinInterval", "refreshMaxInterval"]
     );
   }
   if (
@@ -284,6 +300,13 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     validateMediaSupportValue(`media_support['${mime}']`, level);
   }
 
+  const authenticationDocuments = result.authenticationDocuments
+    ? {
+        refreshMinInterval: result.authenticationDocuments.refreshMinInterval,
+        refreshMaxInterval: result.authenticationDocuments.refreshMaxInterval
+      }
+    : null;
+
   return {
     instanceName:
       typeof result.instanceName === "string"
@@ -291,6 +314,7 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
         : "Patron Web Catalog",
     registries,
     staticLibraries,
+    authenticationDocuments,
     mediaSupport: (result.mediaSupport as MediaSupportConfig) ?? {},
     bugsnagApiKey: process.env.BUGSNAG_API_KEY ?? null,
     companionApp,

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -44,23 +44,28 @@ interface CrawlResult {
 // ---------------------------------------------------------------------------
 
 /*
- * In-memory cache keyed by registry URL. Persists across API requests within
- * a single server instance. A registry absent from this map has never been
- * fetched (distinct from one with incrementalUrl === null, which means it was
- * fetched but does not advertise an order=modified facet).
+ * Next.js bundles each page and API route independently, so module-level
+ * variables would not be shared across bundle contexts (instrumentation,
+ * api/libraries, ISR page handlers, etc.) running in the same process.
+ * Storing state on `global` gives all bundle instances a single shared object.
  */
-const registryCaches = new Map<string, RegistryState>();
+interface RegistryModuleState {
+  registryCaches: Map<string, RegistryState>;
+  pendingRefreshes: Map<string, Promise<void>>;
+}
 
-/*
- * Tracks crawls that are currently in-progress. Used to coalesce concurrent
- * requests: if a crawl for a URL is already running, latecomers await the
- * same promise rather than returning an empty cache immediately. Without this,
- * the Next.js ISR fallback can fire two simultaneous getStaticProps calls —
- * the first starts the crawl (setting lastAttemptedFetch), and the second
- * sees lastAttemptedFetch within minInterval, skips the refresh, and returns
- * an empty library list, causing a spurious 404 on the very first page load.
- */
-const pendingRefreshes = new Map<string, Promise<void>>();
+declare const global: typeof globalThis & {
+  __cpwRegistryState?: RegistryModuleState;
+};
+
+if (!global.__cpwRegistryState) {
+  global.__cpwRegistryState = {
+    registryCaches: new Map<string, RegistryState>(),
+    pendingRefreshes: new Map<string, Promise<void>>()
+  };
+}
+
+const { registryCaches, pendingRefreshes } = global.__cpwRegistryState;
 
 const emptyState: RegistryState = {
   libraries: {},

--- a/src/test-utils/fixtures/config.ts
+++ b/src/test-utils/fixtures/config.ts
@@ -6,6 +6,7 @@ export const config: AppConfig = {
   companionApp: "simplye",
   showMedium: true,
   openebooks: null,
+  authenticationDocuments: null,
   mediaSupport: {
     "application/epub+zip": "show",
     "application/kepub+zip": "show",

--- a/tests/pages/api/libraries.test.ts
+++ b/tests/pages/api/libraries.test.ts
@@ -41,7 +41,8 @@ const VALID_APP_CONFIG: AppConfig = {
   companionApp: "simplye",
   showMedium: true,
   openebooks: null,
-  mediaSupport: {}
+  mediaSupport: {},
+  authenticationDocuments: null
 };
 
 function makeRes() {


### PR DESCRIPTION
## Description

Two related fixes for redundant network fetches during page generation:

- **Registry cache shared across bundle contexts.** Next.js bundles each page and API route independently, so module-level Maps in `libraryRegistry.ts` were not shared — the instrumentation pre-warm populated one bundle's cache while ISR handlers each held their own empty copy. The fix stores registry state on `global.__cpwRegistryState` so all bundle contexts in the same process share a single cache. The instrumentation hook now also calls `getLibraries()` to pre-warm the registry before any requests are served.

- **Authentication document cache added.** Each ISR route rebuild for the same library (index, loans, book detail, etc.) was fetching the library's authentication document independently. A new server-side cache (also on `global`) stores fetched auth documents with default and configurable TTL (like registry). Concurrent requests for the same URL are coalesced into one in-flight fetch; sequential requests are gated by `refreshMinInterval` (minimum gap between attempts) and `refreshMaxInterval` (staleness threshold), mirroring the semantics already used for registry refresh intervals.

A new `authentication_documents` config section exposes both interval settings. README and `community-config.yml` are updated accordingly.

## Motivation and Context

During ISR page generation, multiple routes are rendered in rapid succession. Without shared caching, each route issued independent fetches to both the library registry and the library's auth document endpoint. This produced redundant network traffic and, in the registry case, could cause spurious (I can use big words, too) 404s on the very first page load when a second simultaneous request saw an empty cache before the first request had finished populating it.

[Jira PP-4342]

## How Has This Been Tested?

- Manual testing and log observation in my local dev environment.
- New unit tests cover the auth document cache: cache hits, TTL-based re-fetch, `refreshMinInterval` throttling, retry after a failed fetch, and coalescing of concurrent requests.
- New instrumentation tests verify that `getLibraries` is called with the loaded config and is skipped when `getAppConfig` fails or when running outside the Node.js runtime.
- All existing new and pre-existing checks pass.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/26294427297) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
