### PR TITLE
Show forgot password link (PP-4418)

### DIFF
--- a/src/auth/BasicAuthHandler.tsx
+++ b/src/auth/BasicAuthHandler.tsx
@@ -6,6 +6,7 @@ import FormInput from "components/form/FormInput";
 import { modalButtonStyles } from "components/Modal";
 import { ClientBasicMethod } from "interfaces";
 import { generateToken } from "auth/useCredentials";
+import ForgotPasswordLink from "auth/ForgotPasswordLink";
 import useUser from "components/context/UserContext";
 import { ServerError } from "errors";
 import { Keyboard } from "types/opds1";
@@ -107,6 +108,8 @@ const BasicAuthHandler: React.FC<{
       >
         Login
       </Button>
+
+      <ForgotPasswordLink />
     </form>
   );
 };

--- a/src/auth/BasicTokenAuthHandler.tsx
+++ b/src/auth/BasicTokenAuthHandler.tsx
@@ -6,6 +6,7 @@ import FormInput from "components/form/FormInput";
 import { modalButtonStyles } from "components/Modal";
 import { ClientBasicTokenMethod } from "interfaces";
 import { generateToken } from "auth/useCredentials";
+import ForgotPasswordLink from "auth/ForgotPasswordLink";
 import useUser from "components/context/UserContext";
 import ApplicationError, { ServerError } from "errors";
 import { Keyboard } from "types/opds1";
@@ -151,6 +152,8 @@ const BasicTokenAuthHandler: React.FC<{
       >
         Login
       </Button>
+
+      <ForgotPasswordLink />
     </form>
   );
 };

--- a/src/auth/ForgotPasswordLink.tsx
+++ b/src/auth/ForgotPasswordLink.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import useLibraryContext from "components/context/LibraryContext";
+import ExternalLink from "components/ExternalLink";
+
+const ForgotPasswordLink: React.FC = () => {
+  const {
+    libraryLinks: { resetPassword }
+  } = useLibraryContext();
+
+  if (!resetPassword?.href) return null;
+
+  return (
+    <ExternalLink href={resetPassword.href} target="_blank">
+      Forgot your password?
+    </ExternalLink>
+  );
+};
+
+export default ForgotPasswordLink;

--- a/src/auth/ForgotPasswordLink.tsx
+++ b/src/auth/ForgotPasswordLink.tsx
@@ -10,9 +10,7 @@ const ForgotPasswordLink: React.FC = () => {
   if (!resetPassword?.href) return null;
 
   return (
-    <ExternalLink href={resetPassword.href} target="_blank">
-      Forgot your password?
-    </ExternalLink>
+    <ExternalLink href={resetPassword.href}>Forgot your password?</ExternalLink>
   );
 };
 

--- a/src/auth/__tests__/BasicAuthForm.test.tsx
+++ b/src/auth/__tests__/BasicAuthForm.test.tsx
@@ -241,3 +241,34 @@ test("submits with no password input", async () => {
     });
   });
 });
+
+describe("Forgot password link", () => {
+  test("displays forgot password link when library provides a reset url", async () => {
+    setup(<BasicAuthHandler method={method} />, {
+      library: {
+        libraryLinks: {
+          resetPassword: {
+            rel: OPDS1.PasswordResetLinkRel,
+            href: "https://example.com/reset"
+          }
+        }
+      }
+    });
+
+    const link = await screen.findByRole("link", {
+      name: /forgot your password/i
+    });
+    expect(link).toHaveAttribute("href", "https://example.com/reset");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  test("does not display forgot password link when no reset url is provided", async () => {
+    setup(<BasicAuthHandler method={method} />);
+
+    await screen.findByLabelText("Barcode input");
+    expect(
+      screen.queryByRole("link", { name: /forgot your password/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/auth/__tests__/BasicTokenAuthHandler.test.tsx
+++ b/src/auth/__tests__/BasicTokenAuthHandler.test.tsx
@@ -334,3 +334,34 @@ test("displays error when credentials are invalid", async () => {
   // Credentials should not be set
   expect(Cookie.set).not.toHaveBeenCalled();
 });
+
+describe("Forgot password link", () => {
+  test("displays forgot password link when library provides a reset url", async () => {
+    setup(<BasicTokenAuthHandler method={basicTokenAuthMethod} />, {
+      library: {
+        libraryLinks: {
+          resetPassword: {
+            rel: OPDS1.PasswordResetLinkRel,
+            href: "https://example.com/reset"
+          }
+        }
+      }
+    });
+
+    const link = await screen.findByRole("link", {
+      name: /forgot your password/i
+    });
+    expect(link).toHaveAttribute("href", "https://example.com/reset");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  test("does not display forgot password link when no reset url is provided", async () => {
+    setup(<BasicTokenAuthHandler method={basicTokenAuthMethod} />);
+
+    await screen.findByLabelText("Barcode input");
+    expect(
+      screen.queryByRole("link", { name: /forgot your password/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -8,7 +8,7 @@ const ExternalLink: React.FC<React.ComponentPropsWithoutRef<"a">> = ({
 }) => (
   <AnchorButton
     variant="link"
-    target="__blank"
+    target="_blank"
     rel="noopener noreferrer"
     {...props}
   >

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -30,7 +30,7 @@ test("shows external links when present in state w/ apropriate attributes", () =
     expect(lnk).toBeInTheDocument();
     expect(lnk).toHaveAttribute("href", "/wherever");
     expect(lnk).toHaveAttribute("rel", "noopener noreferrer");
-    expect(lnk).toHaveAttribute("target", "__blank");
+    expect(lnk).toHaveAttribute("target", "_blank");
   };
   expectExternalLink("Library Homepage (Opens in a new tab)");
   expectExternalLink("Need a library card? (Opens in a new tab)");

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -326,6 +326,10 @@ describe("buildLibraryData", () => {
         href: "/register"
       },
       {
+        rel: OPDS1.PasswordResetLinkRel,
+        href: "/reset-password"
+      },
+      {
         rel: "logo",
         href: "/logo"
       },
@@ -381,6 +385,10 @@ describe("buildLibraryData", () => {
       helpEmail: {
         rel: "help",
         href: "helpEmail"
+      },
+      resetPassword: {
+        rel: OPDS1.PasswordResetLinkRel,
+        href: "/reset-password"
       }
     });
 

--- a/src/dataflow/getLibraryData.ts
+++ b/src/dataflow/getLibraryData.ts
@@ -264,6 +264,8 @@ function parseLinks(links: OPDS1.AuthDocumentLink[] | undefined): LibraryLinks {
         if (link.type === OPDS1.HTMLMediaType)
           return { ...links, helpWebsite: link };
         return { ...links, helpEmail: link };
+      case OPDS1.PasswordResetLinkRel:
+        return { ...links, resetPassword: link };
       case "register":
       case "logo":
       case "navigation":

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -85,6 +85,7 @@ export type LibraryLinks = {
   about?: OPDS1.Link;
   privacyPolicy?: OPDS1.Link;
   registration?: OPDS1.Link;
+  resetPassword?: OPDS1.Link;
 };
 
 /**

--- a/src/types/opds1.ts
+++ b/src/types/opds1.ts
@@ -168,11 +168,14 @@ export const CatalogRootRel = "start";
 export const ShelfLinkRel = "http://opds-spec.org/shelf";
 export const UserProfileLinkRel =
   "http://librarysimplified.org/terms/rel/user-profile";
+export const PasswordResetLinkRel =
+  "http://librarysimplified.org/terms/rel/patron-password-reset";
 type AuthDocLinkRelations =
   | typeof SelfRel
   | typeof CatalogRootRel
   | typeof ShelfLinkRel
   | typeof UserProfileLinkRel
+  | typeof PasswordResetLinkRel
   | "navigation"
   | "logo"
   | "register"


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Add a "Forgot your password?" link to the CPW sign-in screen, matching the existing behavior in the Palace iOS and Android apps.

<img width="362" height="294" alt="image" src="https://github.com/user-attachments/assets/cd994d9d-5336-4b51-a49f-09e4d3a8b41f" />


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Palace mobile apps (iOS and Android) already expose a "Forgot your password?" button on the sign-in screen when the selected library has a reset password link provided in its authentication document. Tapping the button opens a web browser to a password reset screen, where the patron can request a reset link and complete the flow.

CPW does not currently offer any equivalent affordance. Patrons who forget their password while signing in through the web have no in-product path to recover the account — they have to contact library staff or know to navigate to the reset URL directly.

[Jira PP-4418](https://ebce-lyrasis.atlassian.net/browse/PP-4418) adds the same "Forgot your password?" entry point to CPW's sign-in screen. Clicking the link opens a password reset page in a new browser tab.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested in latest versions of Firefox, Chrome, and Safari
- Added unit tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
