### PR TITLE
Update visual prominence of external reader buttons (PP-4355)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "@types/history": "^4.7.8",
         "@types/jest": "^26.0.15",
         "@types/js-cookie": "^2.2.6",
+        "@types/lodash": "^4.17.24",
         "@types/node": "^18.19.15",
         "@types/pako": "^1.0.1",
         "@types/react": "^18.3.12",
@@ -5024,6 +5025,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/history": "^4.7.8",
     "@types/jest": "^26.0.15",
     "@types/js-cookie": "^2.2.6",
+    "@types/lodash": "^4.17.24",
     "@types/node": "^18.19.15",
     "@types/pako": "^1.0.1",
     "@types/react": "^18.3.12",

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -21,10 +21,7 @@ import useSWRInfinite from "swr/infinite";
 import useUser from "components/context/UserContext";
 import Stack from "components/Stack";
 import FulfillmentButton from "components/FulfillmentButton";
-import {
-  getFulfillmentFromLink,
-  shouldRedirectToCompanionApp
-} from "utils/fulfill";
+import { getFulfillmentFromLink } from "utils/fulfill";
 import BookStatus from "components/BookStatus";
 import Link from "./Link";
 import { useAppConfig } from "components/context/AppConfigContext";
@@ -241,12 +238,10 @@ const BookListCTA: React.FC<{ book: AnyBook }> = ({ book }) => {
 
   if (bookIsFulfillable(book)) {
     // we will show a fulfillment button if there is only one option
-    // and we are not supposed to redirect the user to the companion app
+    // we want to surface any internal or external web reader links,
+    // so no need to hide links even if we want to redirect user to companion app
     const showableLinks = book.fulfillmentLinks.filter(
       link => link.supportLevel === "show"
-    );
-    const shouldRedirectUser = shouldRedirectToCompanionApp(
-      book.fulfillmentLinks
     );
 
     const showableFulfillments = showableLinks.map(
@@ -257,7 +252,7 @@ const BookListCTA: React.FC<{ book: AnyBook }> = ({ book }) => {
 
     return (
       <Stack>
-        {singleFulfillment && !shouldRedirectUser && (
+        {singleFulfillment && (
           <FulfillmentButton
             details={singleFulfillment}
             book={book}

--- a/src/components/BookStatus.tsx
+++ b/src/components/BookStatus.tsx
@@ -1,19 +1,11 @@
 import * as React from "react";
 import { MediumIcon } from "components/MediumIndicator";
 import { AnyBook } from "interfaces";
-import { availabilityString, bookIsFulfillable } from "utils/book";
+import { availabilityString } from "utils/book";
 import { ScreenReaderOnly, Text } from "components/Text";
-import { shouldRedirectToCompanionApp } from "utils/fulfill";
-import SvgPhone from "icons/Phone";
 
 const BookStatus: React.FC<{ book: AnyBook }> = ({ book }) => {
   const { status } = book;
-
-  const redirectUser = bookIsFulfillable(book)
-    ? shouldRedirectToCompanionApp(book.fulfillmentLinks)
-    : false;
-
-  const action = book.format === "Audiobook" ? "Listen" : "Read";
 
   const str =
     status === "borrowable"
@@ -24,20 +16,13 @@ const BookStatus: React.FC<{ book: AnyBook }> = ({ book }) => {
           ? "Reserved"
           : status === "on-hold"
             ? "Ready to Borrow"
-            : status === "fulfillable" && !redirectUser
-              ? `Ready to ${action}!`
-              : "Unsupported";
+            : "Unsupported";
 
   return (
     <div>
-      {(status !== "fulfillable" ||
-        (status === "fulfillable" && !redirectUser)) && (
+      {status !== "fulfillable" && (
         <div sx={{ display: "flex", alignItems: "center" }}>
-          {redirectUser ? (
-            <SvgPhone sx={{ fontSize: 24 }} />
-          ) : (
-            <MediumIcon book={book} sx={{ mr: 1 }} />
-          )}
+          <MediumIcon book={book} sx={{ mr: 1 }} />
           <Text variant="text.body.bold" sx={{ fontWeight: 600 }}>
             <ScreenReaderOnly>Book Status: </ScreenReaderOnly>
             {str}

--- a/src/components/BookStatus.tsx
+++ b/src/components/BookStatus.tsx
@@ -5,18 +5,13 @@ import { availabilityString, bookIsFulfillable } from "utils/book";
 import { ScreenReaderOnly, Text } from "components/Text";
 import { shouldRedirectToCompanionApp } from "utils/fulfill";
 import SvgPhone from "icons/Phone";
-import { useAppConfig } from "components/context/AppConfigContext";
 
 const BookStatus: React.FC<{ book: AnyBook }> = ({ book }) => {
-  const { companionApp } = useAppConfig();
   const { status } = book;
 
   const redirectUser = bookIsFulfillable(book)
     ? shouldRedirectToCompanionApp(book.fulfillmentLinks)
     : false;
-
-  const companionAppName =
-    companionApp === "openebooks" ? "Open eBooks" : "Palace";
 
   const action = book.format === "Audiobook" ? "Listen" : "Read";
 
@@ -29,23 +24,26 @@ const BookStatus: React.FC<{ book: AnyBook }> = ({ book }) => {
           ? "Reserved"
           : status === "on-hold"
             ? "Ready to Borrow"
-            : status === "fulfillable"
-              ? `Ready to ${action}${redirectUser ? ` in ${companionAppName}` : ""}!`
+            : status === "fulfillable" && !redirectUser
+              ? `Ready to ${action}!`
               : "Unsupported";
 
   return (
     <div>
-      <div sx={{ display: "flex", alignItems: "center" }}>
-        {redirectUser ? (
-          <SvgPhone sx={{ fontSize: 24 }} />
-        ) : (
-          <MediumIcon book={book} sx={{ mr: 1 }} />
-        )}
-        <Text variant="text.body.bold" sx={{ fontWeight: 600 }}>
-          <ScreenReaderOnly>Book Status: </ScreenReaderOnly>
-          {str}
-        </Text>
-      </div>
+      {(status !== "fulfillable" ||
+        (status === "fulfillable" && !redirectUser)) && (
+        <div sx={{ display: "flex", alignItems: "center" }}>
+          {redirectUser ? (
+            <SvgPhone sx={{ fontSize: 24 }} />
+          ) : (
+            <MediumIcon book={book} sx={{ mr: 1 }} />
+          )}
+          <Text variant="text.body.bold" sx={{ fontWeight: 600 }}>
+            <ScreenReaderOnly>Book Status: </ScreenReaderOnly>
+            {str}
+          </Text>
+        </div>
+      )}
       <AvailabilityString book={book} />
     </div>
   );

--- a/src/components/BookStatus.tsx
+++ b/src/components/BookStatus.tsx
@@ -7,7 +7,7 @@ import { ScreenReaderOnly, Text } from "components/Text";
 const BookStatus: React.FC<{ book: AnyBook }> = ({ book }) => {
   const { status } = book;
 
-  const str =
+  const unfillableReason =
     status === "borrowable"
       ? "Available to borrow"
       : status === "reservable"
@@ -25,7 +25,7 @@ const BookStatus: React.FC<{ book: AnyBook }> = ({ book }) => {
           <MediumIcon book={book} sx={{ mr: 1 }} />
           <Text variant="text.body.bold" sx={{ fontWeight: 600 }}>
             <ScreenReaderOnly>Book Status: </ScreenReaderOnly>
-            {str}
+            {unfillableReason}
           </Text>
         </div>
       )}

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -7,7 +7,7 @@ import LoadingIndicator from "components/LoadingIndicator";
 import { Text } from "components/Text";
 import { FontAwesomeIconProps } from "@fortawesome/react-fontawesome";
 
-export type ButtonVariant = "filled" | "ghost" | "link";
+export type ButtonVariant = "filled" | "ghost" | "link" | "outlined";
 export type IconButtonVariant = "input";
 export type ButtonSize = "sm" | "md" | "lg";
 type ButtonOwnProps = {
@@ -166,7 +166,7 @@ export const InputIconButton = ({
 };
 
 const defaultVariant = "filled";
-const defaultColor = "brand.primary";
+const defaultColor = "ui.black";
 const defaultSize = "md";
 
 export default Button;

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -5,7 +5,7 @@ import { ButtonSize, ButtonVariant, IconButtonVariant } from "./index";
 export const sizes = {
   sm: {},
   md: {
-    height: 32,
+    height: 40,
     minWidth: 32,
     fontSize: "-1",
     px: 3
@@ -77,7 +77,7 @@ export const styleProps = (
       const textColor = color === "ui.white" ? "ui.black" : "ui.white";
       return {
         // sets the text style
-        variant: "text.body.regular",
+        variant: "text.body.medium",
         ...buttonBase,
         ...sizes[size],
         bg: color,
@@ -134,6 +134,25 @@ export const styleProps = (
           color
         }
       };
+
+    case "outlined": {
+      return {
+        variant: "text.body.medium",
+        ...buttonBase,
+        ...sizes[size],
+        borderWidth: 1,
+        borderColor: color,
+        borderStyle: "solid",
+        bg: "ui.white",
+        color: color,
+        fill: color,
+        "&:focus,&:hover": {
+          bg: lightness(color, 0.9),
+          color: color,
+          textDecoration: "none"
+        }
+      };
+    }
 
     default:
       throw new Error(`You chose an unimplemented Button Variant: ${variant}`);

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -1,5 +1,5 @@
 import { SystemStyleObject } from "@styled-system/css";
-import { darken, lightness } from "@theme-ui/color";
+import { lightness } from "@theme-ui/color";
 import { ButtonSize, ButtonVariant, IconButtonVariant } from "./index";
 
 export const sizes = {
@@ -84,7 +84,7 @@ export const styleProps = (
         color: textColor,
         fill: textColor,
         "&:focus,&:hover": {
-          bg: darken(color, 0.05),
+          bg: lightness(color, 0.2),
           color: textColor,
           textDecoration: "none"
         },
@@ -92,7 +92,7 @@ export const styleProps = (
           boxShadow: "focus"
         },
         "&:active": {
-          bg: darken(color, 0.1)
+          bg: lightness(color, 0.2)
         },
         "&:disabled": {
           bg: "ui.gray.light",

--- a/src/components/CancelOrReturn.tsx
+++ b/src/components/CancelOrReturn.tsx
@@ -46,13 +46,6 @@ const CancelOrReturn: React.FC<{
       loading={loading}
       loadingText={loadingText}
       variant="outlined"
-      // variant="ghost"
-      // color="ui.gray.light"
-      // sx={{
-      //   bg: "ui.gray.light",
-      //   color: "ui.gray.dark",
-      //   "&:hover,&:focus": { color: "ui.gray.dark" }
-      // }}
     >
       {text}
     </Button>

--- a/src/components/CancelOrReturn.tsx
+++ b/src/components/CancelOrReturn.tsx
@@ -45,13 +45,14 @@ const CancelOrReturn: React.FC<{
       onClick={() => cancelReservation(revokeUrl)}
       loading={loading}
       loadingText={loadingText}
-      variant="ghost"
-      color="ui.gray.light"
-      sx={{
-        bg: "ui.gray.light",
-        color: "ui.gray.dark",
-        "&:hover,&:focus": { color: "ui.gray.dark" }
-      }}
+      variant="outlined"
+      // variant="ghost"
+      // color="ui.gray.light"
+      // sx={{
+      //   bg: "ui.gray.light",
+      //   color: "ui.gray.dark",
+      //   "&:hover,&:focus": { color: "ui.gray.dark" }
+      // }}
     >
       {text}
     </Button>

--- a/src/components/FulfillmentButton.tsx
+++ b/src/components/FulfillmentButton.tsx
@@ -61,7 +61,6 @@ function getButtonStyles(isPrimaryAction: boolean) {
   return isPrimaryAction
     ? ({
         variant: "filled",
-        // color: "brand.primary"
         color: "ui.black"
       } as const)
     : ({

--- a/src/components/FulfillmentButton.tsx
+++ b/src/components/FulfillmentButton.tsx
@@ -61,7 +61,8 @@ function getButtonStyles(isPrimaryAction: boolean) {
   return isPrimaryAction
     ? ({
         variant: "filled",
-        color: "brand.primary"
+        // color: "brand.primary"
+        color: "ui.black"
       } as const)
     : ({
         variant: "ghost",

--- a/src/components/MediumIndicator.tsx
+++ b/src/components/MediumIndicator.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { Text } from "./Text";
 import { bookMediumMap, getMedium } from "utils/book";
-import { AnyBook } from "interfaces";
+import { AnyBook, BookMediumName } from "interfaces";
+import { Badge } from "theme-ui";
 
 const MediumIndicator: React.FC<{ book: AnyBook; className?: string }> = ({
   book,
@@ -14,7 +15,9 @@ const MediumIndicator: React.FC<{ book: AnyBook; className?: string }> = ({
   const mediumInfo = bookMediumMap[medium];
   return (
     <Text sx={{ display: "flex", alignItems: "center" }} className={className}>
-      <MediumIcon sx={{ mr: 1 }} book={book} />
+      <Badge sx={badgeStyleProps(mediumInfo.name)} mr={2}>
+        <MediumIcon book={book} />
+      </Badge>
       {mediumInfo.name}
     </Text>
   );
@@ -36,4 +39,26 @@ export const MediumIcon: React.FC<{ book: AnyBook; className?: string }> = ({
   return MediumSvg ? (
     <MediumSvg aria-hidden="true" className={className} {...rest} />
   ) : null;
+};
+
+const badgeStyleProps = (mediumName: BookMediumName) => {
+  switch (mediumName) {
+    case "Audiobook": {
+      return {
+        background: "ui.blue.light",
+        color: "ui.white"
+      };
+    }
+
+    case "Book":
+    case "eBook": {
+      return {
+        background: "ui.green.success",
+        color: "ui.white"
+      };
+    }
+
+    default:
+      throw new Error(`You chose an unimplemented Medium Icon: ${mediumName}`);
+  }
 };

--- a/src/components/PreviewButton.tsx
+++ b/src/components/PreviewButton.tsx
@@ -23,12 +23,7 @@ const PreviewButton: React.FC<{ previewUrl?: string | null }> = ({
   if (!previewUrl) return null;
 
   return (
-    <Button
-      variant="outlined"
-      // color="ui.gray.extraDark"
-      iconLeft={SvgExternalLink}
-      onClick={open}
-    >
+    <Button variant="outlined" iconLeft={SvgExternalLink} onClick={open}>
       Preview
     </Button>
   );

--- a/src/components/PreviewButton.tsx
+++ b/src/components/PreviewButton.tsx
@@ -24,8 +24,8 @@ const PreviewButton: React.FC<{ previewUrl?: string | null }> = ({
 
   return (
     <Button
-      variant="ghost"
-      color="ui.gray.extraDark"
+      variant="outlined"
+      // color="ui.gray.extraDark"
       iconLeft={SvgExternalLink}
       onClick={open}
     >

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -77,7 +77,8 @@ const Search: React.FC<SearchProps> = ({ className, ...props }) => {
         sx={{
           borderRight: "none",
           borderTopRightRadius: 0,
-          borderBottomRightRadius: 0
+          borderBottomRightRadius: 0,
+          borderRadius: "8px 0 0 8px"
         }}
         {...props}
       />
@@ -86,7 +87,8 @@ const Search: React.FC<SearchProps> = ({ className, ...props }) => {
         color="ui.black"
         sx={{
           height: "initial",
-          flex: "1 0 auto"
+          flex: "1 0 auto",
+          borderRadius: "0 8px 8px 0"
         }}
         iconLeft={SvgSearch}
       >

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
  */
 
 const styles = {
-  borderRadius: 1,
+  borderRadius: 3,
   border: "solid",
   px: 2,
   py: 1,

--- a/src/components/__tests__/BookListItem.test.tsx
+++ b/src/components/__tests__/BookListItem.test.tsx
@@ -321,6 +321,7 @@ describe("FulfillableBook", () => {
       availability: undefined
     });
     setup(<BookListItem book={withoutAvailability} />);
-    expect(screen.queryByText("Ready to Read!")).toBeInTheDocument();
+    // BookStatus no longer displays this status text
+    expect(screen.queryByText("Ready to Read!")).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/BookListItem.test.tsx
+++ b/src/components/__tests__/BookListItem.test.tsx
@@ -56,7 +56,7 @@ describe("BorrowableBook", () => {
     });
 
     // click borrow
-    fireEvent.click(screen.getByText("Borrow this book"));
+    fireEvent.click(screen.getByText("Borrow"));
     expect(mockFetchBook).toHaveBeenCalledTimes(1);
     expect(mockFetchBook).toHaveBeenCalledWith(
       "/borrow",
@@ -108,7 +108,7 @@ describe("OnHoldBook", () => {
     });
 
     // click borrow
-    fireEvent.click(screen.getByText("Borrow this book"));
+    fireEvent.click(screen.getByText("Borrow"));
     expect(mockFetchBook).toHaveBeenCalledTimes(1);
     expect(mockFetchBook).toHaveBeenCalledWith(
       "/borrow",
@@ -149,7 +149,7 @@ describe("ReservableBook", () => {
   test("displays reserve button", () => {
     setup(<BookListItem book={reservableBook} />);
     const reserveButton = screen.getByRole("button", {
-      name: "Reserve this book"
+      name: "Reserve"
     });
     expect(reserveButton).toBeInTheDocument();
   });
@@ -167,7 +167,7 @@ describe("ReservableBook", () => {
     });
 
     // click borrow
-    fireEvent.click(screen.getByText("Reserve this book"));
+    fireEvent.click(screen.getByText("Reserve"));
     expect(mockFetchBook).toHaveBeenCalledTimes(1);
     expect(mockFetchBook).toHaveBeenCalledWith(
       "/reserve",
@@ -321,6 +321,6 @@ describe("FulfillableBook", () => {
       availability: undefined
     });
     setup(<BookListItem book={withoutAvailability} />);
-    expect(screen.getByText("Ready to Read!")).toBeInTheDocument();
+    expect(screen.queryByText("Ready to Read!")).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/BookListItem.test.tsx
+++ b/src/components/__tests__/BookListItem.test.tsx
@@ -321,7 +321,6 @@ describe("FulfillableBook", () => {
       availability: undefined
     });
     setup(<BookListItem book={withoutAvailability} />);
-    // BookStatus no longer displays this status text
-    expect(screen.queryByText("Ready to Read!")).not.toBeInTheDocument();
+    expect(screen.queryByText("Book Availability:")).not.toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/BorrowOrReserve.test.tsx
+++ b/src/components/__tests__/BorrowOrReserve.test.tsx
@@ -14,17 +14,13 @@ import { mockPush, mockReplace } from "test-utils/mockNextRouter";
 
 test("shows correct button for borrowable book", async () => {
   setup(<BorrowOrReserve isBorrow borrowUrl="/url" />);
-  await screen.findByRole("button", { name: "Borrow this book" });
-  expect(
-    screen.getByRole("button", { name: "Borrow this book" })
-  ).toBeInTheDocument();
+  await screen.findByRole("button", { name: "Borrow" });
+  expect(screen.getByRole("button", { name: "Borrow" })).toBeInTheDocument();
 });
 
 test("shows reserve button for reservable book", () => {
   setup(<BorrowOrReserve isBorrow={false} borrowUrl="/url" />);
-  expect(
-    screen.getByRole("button", { name: "Reserve this book" })
-  ).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Reserve" })).toBeInTheDocument();
 });
 
 /**
@@ -41,7 +37,7 @@ test("borrowing calls correct url with token", async () => {
   setup(<BorrowOrReserve isBorrow borrowUrl="/url" />);
 
   const button = await screen.findByRole("button", {
-    name: "Borrow this book"
+    name: "Borrow"
   });
 
   fireEvent.click(button);
@@ -67,7 +63,7 @@ test("redirects to login when not signed in", async () => {
   });
 
   const button = await screen.findByRole("button", {
-    name: "Borrow this book"
+    name: "Borrow"
   });
   expect(mockPush).toHaveBeenCalledTimes(0);
 
@@ -100,7 +96,7 @@ test("redirects to login when not signed in", async () => {
 test("calls set book after borrowing", async () => {
   const { user } = setup(<BorrowOrReserve isBorrow borrowUrl="/url" />);
   const button = await screen.findByRole("button", {
-    name: "Borrow this book"
+    name: "Borrow"
   });
 
   mockedFetchBook.mockResolvedValueOnce(fixtures.fulfillableBook);
@@ -120,9 +116,7 @@ describe("Preview button (via BorrowOrReserveOrPreview)", () => {
         previewUrl="/preview"
       />
     );
-    expect(
-      screen.getByRole("button", { name: "Borrow this book" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Borrow" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Preview" })).toBeInTheDocument();
   });
 
@@ -154,9 +148,7 @@ describe("Preview button (via BorrowOrReserveOrPreview)", () => {
         previewUrl="/preview"
       />
     );
-    expect(
-      screen.getByRole("button", { name: "Reserve this book" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reserve" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Preview" })).toBeInTheDocument();
   });
 });

--- a/src/components/__tests__/BorrowOrReserveOrPreview.test.tsx
+++ b/src/components/__tests__/BorrowOrReserveOrPreview.test.tsx
@@ -24,17 +24,13 @@ test("renders borrow button and preview button when both urls provided", () => {
       previewUrl="https://example.com/preview"
     />
   );
-  expect(
-    screen.getByRole("button", { name: "Borrow this book" })
-  ).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Borrow" })).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "Preview" })).toBeInTheDocument();
 });
 
 test("preview button does not render when preview url is excluded", () => {
   setup(<BorrowOrReserveOrPreview isBorrow borrowUrl="/borrow" />);
-  expect(
-    screen.queryByRole("button", { name: "Borrow this book" })
-  ).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "Borrow" })).toBeInTheDocument();
   expect(
     screen.queryByRole("button", { name: "Preview" })
   ).not.toBeInTheDocument();
@@ -44,9 +40,7 @@ test("preview button does not render when preview url is null", () => {
   setup(
     <BorrowOrReserveOrPreview isBorrow borrowUrl="/borrow" previewUrl={null} />
   );
-  expect(
-    screen.queryByRole("button", { name: "Borrow this book" })
-  ).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "Borrow" })).toBeInTheDocument();
   expect(
     screen.queryByRole("button", { name: "Preview" })
   ).not.toBeInTheDocument();
@@ -60,7 +54,7 @@ describe("BorrowOrReserve error handling", () => {
     );
 
     const button = await screen.findByRole("button", {
-      name: "Borrow this book"
+      name: "Borrow"
     });
     await user.click(button);
 
@@ -74,7 +68,7 @@ describe("BorrowOrReserve error handling", () => {
       <BorrowOrReserveOrPreview isBorrow borrowUrl="/url" />
     );
     const button = await screen.findByRole("button", {
-      name: "Borrow this book"
+      name: "Borrow"
     });
 
     mockedFetchBook.mockRejectedValueOnce(
@@ -99,7 +93,7 @@ describe("BorrowOrReserve error handling", () => {
       <BorrowOrReserveOrPreview isBorrow borrowUrl="/url" />
     );
     const button = await screen.findByRole("button", {
-      name: "Borrow this book"
+      name: "Borrow"
     });
 
     mockedFetchBook.mockRejectedValueOnce(new Error("You messed up!"));

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`LinkButton renders correct element 1`] = `
 .emotion-0 {
   font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-size: 0.875rem;
-  font-weight: 300;
+  font-weight: 500;
   line-height: 1.5;
   display: inline-flex;
   -webkit-appearance: none;
@@ -25,12 +25,12 @@ exports[`LinkButton renders correct element 1`] = `
   padding-left: 16px;
   padding-right: 16px;
   border: 0;
-  border-radius: 2px;
+  border-radius: 8px;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
-  background-color: var(--theme-ui-colors-brand-primary);
-  height: 32px;
+  background-color: var(--theme-ui-colors-ui-black);
+  height: 40px;
   min-width: 32px;
   color: var(--theme-ui-colors-ui-white);
   fill: var(--theme-ui-colors-ui-white);
@@ -38,7 +38,7 @@ exports[`LinkButton renders correct element 1`] = `
 
 .emotion-0:focus,
 .emotion-0:hover {
-  background-color: #2d6da3;
+  background-color: #000;
   color: var(--theme-ui-colors-ui-white);
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -49,7 +49,7 @@ exports[`LinkButton renders correct element 1`] = `
 }
 
 .emotion-0:active {
-  background-color: #285f8f;
+  background-color: #000;
 }
 
 .emotion-0:disabled {
@@ -73,7 +73,7 @@ exports[`NavButton renders correct element 1`] = `
   color: var(--theme-ui-colors-ui-white);
   font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-size: 0.875rem;
-  font-weight: 300;
+  font-weight: 500;
   line-height: 1.5;
   display: inline-flex;
   -webkit-appearance: none;
@@ -94,10 +94,10 @@ exports[`NavButton renders correct element 1`] = `
   padding-left: 16px;
   padding-right: 16px;
   border: 0;
-  border-radius: 2px;
+  border-radius: 8px;
   cursor: pointer;
-  background-color: var(--theme-ui-colors-brand-primary);
-  height: 32px;
+  background-color: var(--theme-ui-colors-ui-black);
+  height: 40px;
   min-width: 32px;
   fill: var(--theme-ui-colors-ui-white);
 }
@@ -110,7 +110,7 @@ exports[`NavButton renders correct element 1`] = `
 
 .emotion-0:focus,
 .emotion-0:hover {
-  background-color: #2d6da3;
+  background-color: #000;
   color: var(--theme-ui-colors-ui-white);
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -121,7 +121,7 @@ exports[`NavButton renders correct element 1`] = `
 }
 
 .emotion-0:active {
-  background-color: #285f8f;
+  background-color: #000;
 }
 
 .emotion-0:disabled {
@@ -142,7 +142,7 @@ exports[`variants filled (default) 1`] = `
 .emotion-0 {
   font-family: 'Open Sans',Helvetica,Arial,sans-serif;
   font-size: 0.875rem;
-  font-weight: 300;
+  font-weight: 500;
   line-height: 1.5;
   display: inline-flex;
   -webkit-appearance: none;
@@ -163,12 +163,12 @@ exports[`variants filled (default) 1`] = `
   padding-left: 16px;
   padding-right: 16px;
   border: 0;
-  border-radius: 2px;
+  border-radius: 8px;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
-  background-color: var(--theme-ui-colors-brand-primary);
-  height: 32px;
+  background-color: var(--theme-ui-colors-ui-black);
+  height: 40px;
   min-width: 32px;
   color: var(--theme-ui-colors-ui-white);
   fill: var(--theme-ui-colors-ui-white);
@@ -176,7 +176,7 @@ exports[`variants filled (default) 1`] = `
 
 .emotion-0:focus,
 .emotion-0:hover {
-  background-color: #2d6da3;
+  background-color: #000;
   color: var(--theme-ui-colors-ui-white);
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -187,7 +187,7 @@ exports[`variants filled (default) 1`] = `
 }
 
 .emotion-0:active {
-  background-color: #285f8f;
+  background-color: #000;
 }
 
 .emotion-0:disabled {
@@ -229,21 +229,21 @@ exports[`variants ghost 1`] = `
   padding-left: 16px;
   padding-right: 16px;
   border: 0;
-  border-radius: 2px;
+  border-radius: 8px;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: transparent;
-  height: 32px;
+  height: 40px;
   min-width: 32px;
-  color: var(--theme-ui-colors-brand-primary);
-  fill: var(--theme-ui-colors-brand-primary);
+  color: var(--theme-ui-colors-ui-black);
+  fill: var(--theme-ui-colors-ui-black);
 }
 
 .emotion-0:focus,
 .emotion-0:hover {
-  background-color: #d7e7f4;
-  color: var(--theme-ui-colors-brand-primary);
+  background-color: #e6e6e6;
+  color: var(--theme-ui-colors-ui-black);
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -281,7 +281,7 @@ exports[`variants link 1`] = `
   padding-left: 16px;
   padding-right: 16px;
   border: 0;
-  border-radius: 2px;
+  border-radius: 8px;
   cursor: pointer;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -290,13 +290,13 @@ exports[`variants link 1`] = `
   font-size: 1rem;
   font-weight: 300;
   line-height: 1.5;
-  color: var(--theme-ui-colors-brand-primary);
+  color: var(--theme-ui-colors-ui-black);
   padding: 0;
-  fill: var(--theme-ui-colors-brand-primary);
+  fill: var(--theme-ui-colors-ui-black);
 }
 
 .emotion-0:hover {
-  color: var(--theme-ui-colors-brand-primary);
+  color: var(--theme-ui-colors-ui-black);
 }
 
 <button

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`LinkButton renders correct element 1`] = `
 
 .emotion-0:focus,
 .emotion-0:hover {
-  background-color: #000;
+  background-color: #333;
   color: var(--theme-ui-colors-ui-white);
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -49,7 +49,7 @@ exports[`LinkButton renders correct element 1`] = `
 }
 
 .emotion-0:active {
-  background-color: #000;
+  background-color: #333;
 }
 
 .emotion-0:disabled {
@@ -110,7 +110,7 @@ exports[`NavButton renders correct element 1`] = `
 
 .emotion-0:focus,
 .emotion-0:hover {
-  background-color: #000;
+  background-color: #333;
   color: var(--theme-ui-colors-ui-white);
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -121,7 +121,7 @@ exports[`NavButton renders correct element 1`] = `
 }
 
 .emotion-0:active {
-  background-color: #000;
+  background-color: #333;
 }
 
 .emotion-0:disabled {
@@ -176,7 +176,7 @@ exports[`variants filled (default) 1`] = `
 
 .emotion-0:focus,
 .emotion-0:hover {
-  background-color: #000;
+  background-color: #333;
   color: var(--theme-ui-colors-ui-white);
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -187,7 +187,7 @@ exports[`variants filled (default) 1`] = `
 }
 
 .emotion-0:active {
-  background-color: #000;
+  background-color: #333;
 }
 
 .emotion-0:disabled {

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TextInput renders properly and passes styles through 1`] = `
 .emotion-0 {
-  border-radius: 2px;
+  border-radius: 8px;
   border: 1px solid #bdbdbd;
   padding-left: 8px;
   padding-right: 8px;
@@ -48,7 +48,7 @@ exports[`TextInput renders properly and passes styles through 1`] = `
 
 exports[`type textarea renders properly and passes styles throug 1`] = `
 .emotion-0 {
-  border-radius: 2px;
+  border-radius: 8px;
   border: 1px solid #bdbdbd;
   padding-left: 8px;
   padding-right: 8px;

--- a/src/components/__tests__/__snapshots__/form.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/form.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`renders as expected 1`] = `
 }
 
 .emotion-1 {
-  border-radius: 2px;
+  border-radius: 8px;
   border: 1px solid #bdbdbd;
   padding-left: 8px;
   padding-right: 8px;

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -116,7 +116,7 @@ const AccessCard: React.FC<{
   const companionAppName =
     companionApp === "openebooks" ? "Open eBooks" : "the Palace App";
 
-  const bookStatus = `${isFulfillableInWebCatalog ? "Also available" : "Available"} to ${action} in ${companionAppName}.`;
+  const bookStatus = `${isFulfillableInWebCatalog && redirectUser ? "Also available" : "Available"} to ${action}${redirectUser ? ` in ${companionAppName}` : ""}.`;
 
   return (
     <>

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as _ from "lodash";
 import {
   bookIsBorrowable,
   bookIsReservable,
@@ -18,6 +19,7 @@ import {
 } from "utils/fulfill";
 import BookStatus from "components/BookStatus";
 import { AnyBook, FulfillableBook, FulfillmentLink } from "interfaces";
+import { useAppConfig } from "components/context/AppConfigContext";
 
 const FulfillmentCard: React.FC<{ book: AnyBook }> = ({ book }) => {
   return (
@@ -96,26 +98,31 @@ const AccessCard: React.FC<{
   book: FulfillableBook;
   links: readonly FulfillmentLink[];
 }> = ({ book, links }) => {
+  const { companionApp } = useAppConfig();
   const fulfillments = getFulfillmentsFromBook(book);
 
-  // visually prioritize internal fulfillments (mirrors apps)
-  const internalFulfillments = fulfillments.filter(
-    details => details.type === "read-online-internal"
-  );
-  const otherFulfillments = fulfillments.filter(
-    details => details.type !== "read-online-internal"
+  // visually prioritize internal and external readers (mirrors apps)
+  const [webCatalogFulfillments, otherFulfillments] = _.partition(
+    fulfillments,
+    details =>
+      ["read-online-internal", "read-online-external"].includes(details.type)
   );
 
-  const isFulfillableInternally = internalFulfillments.length > 0;
+  const isFulfillableInWebCatalog = webCatalogFulfillments.length > 0;
   const hasOtherFulfillments = otherFulfillments.length > 0;
 
   const redirectUser = shouldRedirectToCompanionApp(links);
+  const action = book.format === "Audiobook" ? "listen to" : "read";
+  const companionAppName =
+    companionApp === "openebooks" ? "Open eBooks" : "the Palace App";
+
+  const bookStatus = `${isFulfillableInWebCatalog ? "Also available" : "Available"} to ${action} in ${companionAppName}.`;
 
   return (
     <>
-      {isFulfillableInternally ? (
+      {isFulfillableInWebCatalog ? (
         <Stack sx={{ flexWrap: "wrap" }}>
-          {internalFulfillments.map(details => (
+          {webCatalogFulfillments.map(details => (
             <FulfillmentButton
               isPrimaryAction
               key={details.id}
@@ -138,6 +145,9 @@ const AccessCard: React.FC<{
           text="Return"
         />
       )}
+
+      <Text variant="text.body.italic">{bookStatus}</Text>
+
       {hasOtherFulfillments && redirectUser && (
         <Text variant="text.body.italic">
           If you would rather read on your computer, you can:

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -68,7 +68,7 @@ describe("BorrowableBook", () => {
       user: { isAuthenticated: true }
     });
     const borrowButton = await screen.findByRole("button", {
-      name: "Borrow this book"
+      name: "Borrow"
     });
     expect(borrowButton).toBeInTheDocument();
 
@@ -109,7 +109,7 @@ describe("OnHoldBook", () => {
     setup(<FulfillmentCard book={onHoldBook} />, {
       user: { isAuthenticated: true }
     });
-    const borrowButton = await screen.findByText("Borrow this book");
+    const borrowButton = await screen.findByText("Borrow");
     expect(borrowButton).toBeInTheDocument();
 
     // click borrow
@@ -186,9 +186,7 @@ describe("ReservableBook", () => {
       copies: undefined
     });
     setup(<FulfillmentCard book={bookWithQueue} />);
-    expect(
-      screen.getByRole("button", { name: "Reserve this book" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reserve" })).toBeInTheDocument();
     expect(screen.getByText("Unavailable")).toBeInTheDocument();
   });
 
@@ -202,7 +200,7 @@ describe("ReservableBook", () => {
     setup(<FulfillmentCard book={reservableBook} />, {
       user: { isAuthenticated: true }
     });
-    const reserveButton = await screen.findByText("Reserve this book");
+    const reserveButton = await screen.findByText("Reserve");
     expect(reserveButton).toBeInTheDocument();
 
     // click borrow
@@ -374,7 +372,7 @@ describe("FulfillableBook", () => {
     expect(mockSetBook).toHaveBeenCalledWith(unborrowed, downloadableBook.id);
   });
 
-  test("shows read online button for external read online links", async () => {
+  test("shows read button for external web reader links", async () => {
     const readOnlineBook = mergeBook<FulfillableBook>({
       status: "fulfillable",
       revokeUrl: "/revoke",
@@ -389,12 +387,12 @@ describe("FulfillableBook", () => {
     setup(<FulfillmentCard book={readOnlineBook} />);
 
     const readOnline = await screen.findByRole("button", {
-      name: "Read Online"
+      name: "Read"
     });
     expect(readOnline).toBeInTheDocument();
   });
 
-  test("external read online tracks open_book event", async () => {
+  test("external web reader link tracks open_book event", async () => {
     const mockTab = makeMockTab();
     window.open = jest.fn().mockReturnValue(mockTab);
 
@@ -412,7 +410,7 @@ describe("FulfillableBook", () => {
     });
     setup(<FulfillmentCard book={readOnlineBook} />);
     const readOnline = await screen.findByRole("button", {
-      name: "Read Online"
+      name: "Read"
     });
 
     // no calls until we click the button
@@ -429,7 +427,7 @@ describe("FulfillableBook", () => {
 
     setup(<FulfillmentCard book={externalReadOnlineBook} />);
     const readOnline = await screen.findByRole("button", {
-      name: "Read Online"
+      name: "Read"
     });
 
     fireEvent.click(readOnline);
@@ -451,7 +449,7 @@ describe("FulfillableBook", () => {
 
     setup(<FulfillmentCard book={externalReadOnlineBook} />);
     const readOnline = await screen.findByRole("button", {
-      name: "Read Online"
+      name: "Read"
     });
 
     fireEvent.click(readOnline);
@@ -475,7 +473,7 @@ describe("FulfillableBook", () => {
 
     setup(<FulfillmentCard book={externalReadOnlineBook} />);
     const readOnline = await screen.findByRole("button", {
-      name: "Read Online"
+      name: "Read"
     });
 
     fireEvent.click(readOnline);
@@ -491,12 +489,11 @@ describe("FulfillableBook", () => {
 
   test("correct title and subtitle without redirect", () => {
     setup(<FulfillmentCard book={downloadableBook} />);
-    expect(screen.getByText("Ready to Read!")).toBeInTheDocument();
     expect(
       screen.getByText(`You have this book on loan until ${MOCK_DATE_STRING}.`)
     ).toBeInTheDocument();
     expect(
-      screen.queryByText("Ready to Read in Palace!")
+      screen.queryByText("Also available to read in the Palace App.")
     ).not.toBeInTheDocument();
   });
   const bookWithRedirect = mergeBook<FulfillableBook>({
@@ -515,8 +512,9 @@ describe("FulfillableBook", () => {
       companionApp: "simplye"
     });
     setup(<FulfillmentCard book={bookWithRedirect} />);
-    expect(screen.queryByText("Ready to Read!")).not.toBeInTheDocument();
-    expect(screen.getByText("Ready to Read in Palace!")).toBeInTheDocument();
+    expect(
+      screen.getByText("Available to read in the Palace App.")
+    ).toBeInTheDocument();
     expect(
       screen.getByText("If you would rather read on your computer, you can:")
     ).toBeInTheDocument();
@@ -527,7 +525,7 @@ describe("FulfillableBook", () => {
     mockConfig({ companionApp: "openebooks" });
     setup(<FulfillmentCard book={bookWithRedirect} />);
     expect(
-      screen.getByText("Ready to Read in Open eBooks!")
+      screen.getByText("Available to read in Open eBooks.")
     ).toBeInTheDocument();
   });
 
@@ -589,7 +587,7 @@ describe("FulfillableBook", () => {
     });
 
     setup(<FulfillmentCard book={bookWithIndirect} />);
-    const downloadButton = await screen.findByText("Read Online");
+    const downloadButton = await screen.findByText("Read");
     expect(downloadButton).toBeInTheDocument();
 
     fireEvent.click(downloadButton);
@@ -652,6 +650,68 @@ describe("FulfillableBook", () => {
 
     // we try the rejected url without headers
     expect(fetchMock).toHaveBeenCalledWith("/new-location");
+  });
+
+  describe("book status", () => {
+    test("should prompt users to read on the Palace App when a book has no internal or external web reader links present", () => {
+      const book = mergeBook<FulfillableBook>({
+        status: "fulfillable",
+        revokeUrl: "/revoke",
+        fulfillmentLinks: [
+          {
+            url: "/epub",
+            contentType: "application/epub+zip",
+            supportLevel: "redirect-and-show"
+          }
+        ]
+      });
+      setup(<FulfillmentCard book={book} />);
+      expect(
+        screen.getByText("Available to read in the Palace App.")
+      ).toBeInTheDocument();
+    });
+
+    test("should prompt users to read online or in the Palace App when a book can be read in an external web reader or downloaded", () => {
+      const book = mergeBook<FulfillableBook>({
+        status: "fulfillable",
+        revokeUrl: "/revoke",
+        fulfillmentLinks: [
+          {
+            url: "/epub",
+            contentType: "application/epub+zip",
+            supportLevel: "redirect"
+          },
+          {
+            url: "/overdrive-read-online",
+            contentType: `text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"`,
+            supportLevel: "show"
+          }
+        ]
+      });
+      setup(<FulfillmentCard book={book} />);
+      expect(
+        screen.getByText("Also available to read in the Palace App.")
+      ).toBeInTheDocument();
+    });
+
+    test("should also render text from BookStatus component if only an external web reader link is provided", () => {
+      const book = mergeBook<FulfillableBook>({
+        status: "fulfillable",
+        revokeUrl: "/revoke",
+        fulfillmentLinks: [
+          {
+            url: "/overdrive-read-online",
+            contentType: `text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"`,
+            supportLevel: "show"
+          }
+        ]
+      });
+      setup(<FulfillmentCard book={book} />);
+      expect(screen.getByText("Ready to Read!")).toBeInTheDocument();
+      expect(
+        screen.getByText("Also available to read in the Palace App.")
+      ).toBeInTheDocument();
+    });
   });
 });
 

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -653,7 +653,7 @@ describe("FulfillableBook", () => {
   });
 
   describe("book access status", () => {
-    test("should prompt users to read on the Palace App when a book has a redirect links", () => {
+    test("should prompt users to read on the Palace App when a book has a redirect link", () => {
       const book = mergeBook<FulfillableBook>({
         status: "fulfillable",
         revokeUrl: "/revoke",
@@ -712,7 +712,7 @@ describe("FulfillableBook", () => {
       ).toBeInTheDocument();
     });
 
-    test("should alert user that that book is available to read when only a show link", () => {
+    test("should alert user that that book is available to read when only a show link is present", () => {
       const book = mergeBook<FulfillableBook>({
         status: "fulfillable",
         revokeUrl: "/revoke",

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -535,7 +535,7 @@ describe("FulfillableBook", () => {
       availability: undefined
     });
     setup(<FulfillmentCard book={withoutAvailability} />);
-    expect(screen.getByText("Ready to Read!")).toBeInTheDocument();
+    expect(screen.getByText("Available to read.")).toBeInTheDocument();
   });
 
   test("shows download options", async () => {
@@ -652,8 +652,8 @@ describe("FulfillableBook", () => {
     expect(fetchMock).toHaveBeenCalledWith("/new-location");
   });
 
-  describe("book status", () => {
-    test("should prompt users to read on the Palace App when a book has no internal or external web reader links present", () => {
+  describe("book access status", () => {
+    test("should prompt users to read on the Palace App when a book has a redirect links", () => {
       const book = mergeBook<FulfillableBook>({
         status: "fulfillable",
         revokeUrl: "/revoke",
@@ -661,7 +661,7 @@ describe("FulfillableBook", () => {
           {
             url: "/epub",
             contentType: "application/epub+zip",
-            supportLevel: "redirect-and-show"
+            supportLevel: "redirect"
           }
         ]
       });
@@ -671,7 +671,25 @@ describe("FulfillableBook", () => {
       ).toBeInTheDocument();
     });
 
-    test("should prompt users to read online or in the Palace App when a book can be read in an external web reader or downloaded", () => {
+    test("should alert user that book is also available in companion app if book has a single redirect-and-show link", () => {
+      const book = mergeBook<FulfillableBook>({
+        status: "fulfillable",
+        revokeUrl: "/revoke",
+        fulfillmentLinks: [
+          {
+            url: "/overdrive-read-online",
+            contentType: `text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"`,
+            supportLevel: "redirect-and-show"
+          }
+        ]
+      });
+      setup(<FulfillmentCard book={book} />);
+      expect(
+        screen.getByText("Also available to read in the Palace App.")
+      ).toBeInTheDocument();
+    });
+
+    test("should prompt users to read online or in the Palace App when a book has multiple redirect/redirect-and-show links", () => {
       const book = mergeBook<FulfillableBook>({
         status: "fulfillable",
         revokeUrl: "/revoke",
@@ -684,7 +702,7 @@ describe("FulfillableBook", () => {
           {
             url: "/overdrive-read-online",
             contentType: `text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"`,
-            supportLevel: "show"
+            supportLevel: "redirect-and-show"
           }
         ]
       });
@@ -694,24 +712,45 @@ describe("FulfillableBook", () => {
       ).toBeInTheDocument();
     });
 
-    test("should also render text from BookStatus component if only an external web reader link is provided", () => {
+    test("should alert user that that book is available to read when only a show link", () => {
       const book = mergeBook<FulfillableBook>({
         status: "fulfillable",
         revokeUrl: "/revoke",
         fulfillmentLinks: [
           {
-            url: "/overdrive-read-online",
-            contentType: `text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"`,
+            url: "/epub",
+            contentType: "application/epub+zip",
             supportLevel: "show"
           }
         ]
       });
       setup(<FulfillmentCard book={book} />);
-      expect(screen.getByText("Ready to Read!")).toBeInTheDocument();
-      expect(
-        screen.getByText("Also available to read in the Palace App.")
-      ).toBeInTheDocument();
+      expect(screen.getByText("Available to read.")).toBeInTheDocument();
     });
+  });
+
+  test("should prompt users to listen if format is Audiobook", () => {
+    const book = mergeBook<FulfillableBook>({
+      status: "fulfillable",
+      revokeUrl: "/revoke",
+      format: "Audiobook",
+      fulfillmentLinks: [
+        {
+          url: "/epub",
+          contentType: "application/epub+zip",
+          supportLevel: "redirect"
+        },
+        {
+          url: "/overdrive-read-online",
+          contentType: `text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"`,
+          supportLevel: "redirect-and-show"
+        }
+      ]
+    });
+    setup(<FulfillmentCard book={book} />);
+    expect(
+      screen.getByText("Also available to listen to in the Palace App.")
+    ).toBeInTheDocument();
   });
 });
 

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -22,6 +22,7 @@ import useUser from "components/context/UserContext";
 import useBreadcrumbContext from "components/context/BreadcrumbContext";
 import { useAppConfig } from "components/context/AppConfigContext";
 import { getAuthors, getLanguageLabel } from "utils/book";
+import Stack from "components/Stack";
 
 export const BookDetails: React.FC = () => {
   const { companionApp, showMedium } = useAppConfig();
@@ -72,18 +73,24 @@ export const BookDetails: React.FC = () => {
               flexDirection: "column"
             }}
           >
-            <H1 sx={{ m: 0 }}>
-              <ScreenReaderOnly>Book title: </ScreenReaderOnly>
-              {book.title}
-              {book.subtitle && `: ${book.subtitle}`}
-            </H1>
+            <Stack direction="column">
+              <H1 sx={{ m: 0 }}>
+                <ScreenReaderOnly>Book title: </ScreenReaderOnly>
+                {book.title}
+                {book.subtitle && `: ${book.subtitle}`}
+              </H1>
 
-            <Text variant="text.callouts.regular">
-              by&nbsp;
-              {getAuthors(book)?.join(", ") ?? "Unknown"}
-            </Text>
-            {showMedium && <MediumIndicator book={book} />}
-            <FulfillmentCard book={book} sx={{ mt: 3 }} />
+              <Text variant="text.callouts.regular">
+                by&nbsp;
+                {getAuthors(book)?.join(", ") ?? "Unknown"}
+              </Text>
+              {showMedium && (
+                <div sx={{ my: 2 }}>
+                  <MediumIndicator book={book} />
+                </div>
+              )}
+              <FulfillmentCard book={book} sx={{ mt: 3 }} />
+            </Stack>
             <Summary book={book} />
             <dl
               sx={{

--- a/src/hooks/useBorrow.ts
+++ b/src/hooks/useBorrow.ts
@@ -16,7 +16,7 @@ export default function useBorrow(isBorrow: boolean) {
   const { error, handleError, setErrorString, clearError } = useError();
 
   const loadingText = isBorrow ? "Borrowing..." : "Reserving...";
-  const buttonLabel = isBorrow ? "Borrow this book" : "Reserve this book";
+  const buttonLabel = isBorrow ? "Borrow" : "Reserve";
 
   const borrowOrReserve = async (url: string) => {
     clearError();

--- a/src/icons/Book.tsx
+++ b/src/icons/Book.tsx
@@ -1,15 +1,28 @@
 import * as React from "react";
 
+// const SvgBook = (props: React.SVGProps<SVGSVGElement>) => (
+//   <svg
+//     width="1em"
+//     height="1em"
+//     viewBox="0 0 24 24"
+//     fill="currentColor"
+//     {...props}
+//   >
+//     <path fill="none" d="M0 0h24v24H0V0z" />
+//     <path d="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM6 4h5v8l-2.5-1.5L6 12V4z" />
+//   </svg>
+// );
+
 const SvgBook = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
-    width="1em"
-    height="1em"
-    viewBox="0 0 24 24"
+    width="1rem"
+    height="1rem"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 640 640"
     fill="currentColor"
     {...props}
   >
-    <path fill="none" d="M0 0h24v24H0V0z" />
-    <path d="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM6 4h5v8l-2.5-1.5L6 12V4z" />
+    <path d="M96 128C96 92.7 124.7 64 160 64L480 64C515.3 64 544 92.7 544 128L544 512C544 547.3 515.3 576 480 576L160 576C124.7 576 96 547.3 96 512L96 128zM256 504C256 517.3 266.7 528 280 528L360 528C373.3 528 384 517.3 384 504C384 490.7 373.3 480 360 480L280 480C266.7 480 256 490.7 256 504zM480 128L160 128L160 432L480 432L480 128z" />
   </svg>
 );
 

--- a/src/icons/Book.tsx
+++ b/src/icons/Book.tsx
@@ -1,18 +1,5 @@
 import * as React from "react";
 
-// const SvgBook = (props: React.SVGProps<SVGSVGElement>) => (
-//   <svg
-//     width="1em"
-//     height="1em"
-//     viewBox="0 0 24 24"
-//     fill="currentColor"
-//     {...props}
-//   >
-//     <path fill="none" d="M0 0h24v24H0V0z" />
-//     <path d="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM6 4h5v8l-2.5-1.5L6 12V4z" />
-//   </svg>
-// );
-
 const SvgBook = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
     width="1rem"

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -21,7 +21,11 @@ const ui = {
     extraExtraLight: "#fafafa"
   },
   blue: {
-    focus: "#007AFF"
+    focus: "#007AFF",
+    light: "#43BAE6"
+  },
+  green: {
+    success: "#32855D"
   }
 };
 

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -4,9 +4,9 @@ import typography from "./typography";
 import variants from "./variants";
 import styles from "./styles";
 
-const radii = [0, 2, 4] as Overloadable<number[], number>;
-radii.card = radii[2];
-radii.button = radii[1];
+const radii = [0, 2, 4, 8] as Overloadable<number[], number>;
+radii.card = radii[3];
+radii.button = radii[3];
 
 const borders = {
   solid: `1px solid ${colors.ui.gray.medium}`

--- a/src/theme/variants.ts
+++ b/src/theme/variants.ts
@@ -48,6 +48,12 @@ const variants = {
         fontWeight: "light",
         lineHeight: 3
       },
+      medium: {
+        fontFamily: "body",
+        fontSize: 0,
+        fontWeight: "medium",
+        lineHeight: 3
+      },
       bold: {
         fontFamily: "body",
         fontSize: 0,
@@ -92,6 +98,16 @@ const variants = {
       clip: "rect(0,0,0,0)",
       whiteSpace: "nowrap",
       border: 0
+    }
+  },
+  badges: {
+    primary: {
+      borderRadius: "50%",
+      height: "28px",
+      width: "28px",
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center"
     }
   }
 };

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -129,7 +129,7 @@ export const getFulfillmentFromLink =
             link.url
           ),
           contentType,
-          buttonLabel: `${action} Online`
+          buttonLabel: action
         };
 
       /**


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Buttons that open external web readers are now considered as primary actions and are also surfaced on the "My Books" page. The new styling and visual prominence matches that of the iOS and Android apps, further bringing the CPW into branded parity. All other buttons and select other surfaces have also been updated to mirror the visual styling of the apps.

Before
<img width="313" height="175" alt="image" src="https://github.com/user-attachments/assets/9ac93f88-0cae-4f2e-a09b-d79884135d29" />

After
<img width="300" height="150" alt="image" src="https://github.com/user-attachments/assets/60efe54b-efc2-41e7-9638-988348478e18" />

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Initial testing highlighted a difficult transition from borrowing to reading. Testers noted that the "Read Online" and "Listen Online" buttons had low visual priority on the page and thus were easily missed by users, especially K-12 students.

[Jira PP-4355](https://ebce-lyrasis.atlassian.net/browse/PP-4355)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested in Firefox, Chrome, and Safari
- Unit and integration tests have been added to test the new verbiage

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
