### PR TITLE
Support alternate OIDC auth flow via "prompt" param (PP-4429)

### DIFF
--- a/src/auth/AuthFeedbackPanel.tsx
+++ b/src/auth/AuthFeedbackPanel.tsx
@@ -6,11 +6,13 @@ import { Text } from "components/Text";
 export const AuthFeedbackPanel = ({
   message,
   isError = false,
-  onTryAgain
+  onTryAgain,
+  secondaryAction
 }: {
   message: string;
   isError?: boolean;
   onTryAgain: () => void;
+  secondaryAction?: { label: string; onClick: () => void };
 }) => (
   <Stack
     direction="column"
@@ -27,5 +29,10 @@ export const AuthFeedbackPanel = ({
       {message}
     </Text>
     <Button onClick={onTryAgain}>Try Again</Button>
+    {secondaryAction && (
+      <Button variant="ghost" onClick={secondaryAction.onClick}>
+        {secondaryAction.label}
+      </Button>
+    )}
   </Stack>
 );

--- a/src/auth/OidcAuthHandler.tsx
+++ b/src/auth/OidcAuthHandler.tsx
@@ -26,7 +26,12 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
   const router = useRouter();
   const loginError = extractParam(router.query, "loginError");
 
-  const authUrl = `${method.href}&redirect_uri=${encodeURIComponent(fullSuccessUrl)}`;
+  const authUrl = appendSearchParam(
+    method.href,
+    "redirect_uri",
+    fullSuccessUrl
+  );
+  const altAuthUrl = appendSearchParam(authUrl, "prompt", "select_account");
 
   const { cancelDetected, handleTryAgain, handleCancel } =
     useRedirectCancelDetection({
@@ -37,12 +42,24 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
       token
     });
 
+  const handleSwitchAccount = React.useCallback(() => {
+    sessionStorage.removeItem(oidcRedirectFlag(method.id));
+    sessionStorage.removeItem(oidcCancelFlag(method.id));
+    window.location.href = altAuthUrl;
+  }, [altAuthUrl, method.id]);
+
+  const switchAccountAction = React.useMemo(
+    () => ({ label: "Use a different account", onClick: handleSwitchAccount }),
+    [handleSwitchAccount]
+  );
+
   if (loginError) {
     return (
       <AuthFeedbackPanel
         message={loginError}
         isError
         onTryAgain={handleTryAgain}
+        secondaryAction={switchAccountAction}
       />
     );
   }
@@ -51,6 +68,7 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
       <AuthFeedbackPanel
         message="Login was cancelled."
         onTryAgain={handleTryAgain}
+        secondaryAction={switchAccountAction}
       />
     );
   }
@@ -64,5 +82,11 @@ const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
     </Stack>
   );
 };
+
+function appendSearchParam(href: string, name: string, value: string): string {
+  const url = new URL(href);
+  url.searchParams.set(name, value);
+  return url.toString();
+}
 
 export default clientOnly(OidcAuthHandler);

--- a/src/auth/__tests__/AuthFeedbackPanel.test.tsx
+++ b/src/auth/__tests__/AuthFeedbackPanel.test.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { render, setup } from "test-utils";
+import { AuthFeedbackPanel } from "../AuthFeedbackPanel";
+
+test("renders message and Try Again button", () => {
+  const onTryAgain = jest.fn();
+  const utils = render(
+    <AuthFeedbackPanel
+      message="Something went wrong."
+      onTryAgain={onTryAgain}
+    />
+  );
+  expect(utils.getByText("Something went wrong.")).toBeInTheDocument();
+  expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+  expect(
+    utils.queryByRole("button", { name: /sign out|different account/i })
+  ).not.toBeInTheDocument();
+});
+
+test("does not render secondary button when secondaryAction is not provided", () => {
+  const utils = render(
+    <AuthFeedbackPanel message="Error." onTryAgain={jest.fn()} />
+  );
+  expect(utils.getAllByRole("button")).toHaveLength(1);
+});
+
+test("renders secondary action button when provided", () => {
+  const onSecondary = jest.fn();
+  const utils = render(
+    <AuthFeedbackPanel
+      message="Error."
+      onTryAgain={jest.fn()}
+      secondaryAction={{
+        label: "Use a different account",
+        onClick: onSecondary
+      }}
+    />
+  );
+  expect(
+    utils.getByRole("button", { name: "Use a different account" })
+  ).toBeInTheDocument();
+});
+
+test("calls secondary action onClick when secondary button is clicked", async () => {
+  const onSecondary = jest.fn();
+  const utils = setup(
+    <AuthFeedbackPanel
+      message="Error."
+      onTryAgain={jest.fn()}
+      secondaryAction={{
+        label: "Use a different account",
+        onClick: onSecondary
+      }}
+    />
+  );
+  await utils.user.click(
+    utils.getByRole("button", { name: "Use a different account" })
+  );
+  expect(onSecondary).toHaveBeenCalledTimes(1);
+});

--- a/src/auth/__tests__/OidcAuthHandler.test.tsx
+++ b/src/auth/__tests__/OidcAuthHandler.test.tsx
@@ -32,7 +32,7 @@ test("redirects to proper auth url", async () => {
   });
   await waitFor(() => {
     expect(window.location.href).toBe(
-      "https://oidc-auth.com/0&redirect_uri=http%3A%2F%2Ftest-domain.com%2Ftestlib"
+      "https://oidc-auth.com/0?redirect_uri=http%3A%2F%2Ftest-domain.com%2Ftestlib"
     );
   });
 });
@@ -204,4 +204,66 @@ test('clicking "Cancel" while redirecting shows cancel UI', async () => {
     expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
   });
   expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+});
+
+test('shows "Use a different account" button on error state', () => {
+  const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+    router: { query: { loginError: "Authentication failed" } },
+    user: { token: undefined }
+  });
+  expect(
+    utils.getByRole("button", { name: "Use a different account" })
+  ).toBeInTheDocument();
+});
+
+test('shows "Use a different account" button on cancel state', async () => {
+  sessionStorage.setItem(oidcRedirectKey, "1");
+
+  const utils = render(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(
+    utils.getByRole("button", { name: "Use a different account" })
+  ).toBeInTheDocument();
+});
+
+test('clicking "Use a different account" from error state redirects with prompt=select_account', async () => {
+  const utils = setup(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+    router: { query: { loginError: "Authentication failed" } },
+    user: { token: undefined }
+  });
+
+  await utils.user.click(
+    utils.getByRole("button", { name: "Use a different account" })
+  );
+
+  expect(window.location.href).toContain("prompt=select_account");
+  expect(window.location.href).toContain("oidc-auth.com");
+  expect(sessionStorage.getItem(oidcRedirectKey)).toBeNull();
+  expect(sessionStorage.getItem(oidcCancelKey)).toBeNull();
+});
+
+test('clicking "Use a different account" from cancel state redirects with prompt=select_account', async () => {
+  sessionStorage.setItem(oidcRedirectKey, "1");
+
+  const utils = setup(<OidcAuthHandler method={fixtures.clientOidcMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+
+  await utils.user.click(
+    utils.getByRole("button", { name: "Use a different account" })
+  );
+
+  expect(window.location.href).toContain("prompt=select_account");
+  expect(window.location.href).toContain("oidc-auth.com");
+  expect(sessionStorage.getItem(oidcRedirectKey)).toBeNull();
+  expect(sessionStorage.getItem(oidcCancelKey)).toBeNull();
 });


### PR DESCRIPTION
## Description

> [!NOTE]
> The feature described here is basically equivalent to a regular sign in attempt in the absence of [a supporting change in the Palace Manager (PR 3452)](https://github.com/ThePalaceProject/circulation/pull/3452).

This adds a "Use a different account" escape hatch to the OIDC error and cancel screens. Clicking it retries authentication with the `prompt=select_account` query parameter added to the authorization request URL, which instructs the OIDC provider to show its account chooser regardless of any existing session. The normal sign-in flow is unaffected.

<img width="331" height="329" alt="image" src="https://github.com/user-attachments/assets/149bbd70-dbb3-46d8-8157-5fb998fcd24d" />


Also fixes the OIDC redirect URL, now correctly constructing it using `URL`/`searchParams` rather than string concatenation.

## Motivation and Context

When a library uses OIDC for sign-in (e.g. Google SSO), the client auto-redirects to the identity provider. If the user is already signed into a non-permitted account, authentication fails and they land on the error screen with only a "Try Again" button — which retries the same redirect and fails again.

[Jira PP-4429]

## How Has This Been Tested?

- New tests cover the "Use a different account" button appearing in both the error and cancel states, and verify that clicking it navigates to the correct URL with `prompt=select_account`.
- Existing OIDC handler tests updated to reflect the corrected URL format (`?` separator instead of `&`).
- Manual local testing to ensure that the `prompt=select_account` query param makes it through to the Palace Manager.
- All new and existing tests passed.
- CI tests and checks pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
