### PR TITLE
Schema validation for registry and authentication document responses (PP-4583)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -164,6 +164,7 @@ module.exports = {
     // These run separately with jest.config.node.js (via test:ci)
     "/src/config/__tests__/",
     "/src/server/__tests__/",
+    "/tests/validation/",
     "/tests/pages/"
   ],
 

--- a/jest.config.node.js
+++ b/jest.config.node.js
@@ -16,7 +16,8 @@ module.exports = {
   testMatch: [
     "**/config/**/?(*.)+(spec|test).[tj]s?(x)",
     "**/tests/pages/**/?(*.)+(spec|test).[tj]s?(x)",
-    "**/server/**/?(*.)+(spec|test).[tj]s?(x)"
+    "**/server/**/?(*.)+(spec|test).[tj]s?(x)",
+    "**/tests/validation/**/?(*.)+(spec|test).[tj]s?(x)"
   ],
   testPathIgnorePatterns: ["/node_modules/", "/.next/"],
   // arktype and its ark*/@ark/* dependencies ship as ESM and must be transformed.

--- a/src/auth/__tests__/BasicAuthForm.test.tsx
+++ b/src/auth/__tests__/BasicAuthForm.test.tsx
@@ -23,6 +23,7 @@ const method: ClientBasicMethod = {
 const noPasswordMethod: ClientBasicMethod = {
   ...method,
   inputs: {
+    login: {},
     password: {
       keyboard: Keyboard.NoInput
     }

--- a/src/auth/__tests__/BasicAuthForm.test.tsx
+++ b/src/auth/__tests__/BasicAuthForm.test.tsx
@@ -23,7 +23,6 @@ const method: ClientBasicMethod = {
 const noPasswordMethod: ClientBasicMethod = {
   ...method,
   inputs: {
-    login: {},
     password: {
       keyboard: Keyboard.NoInput
     }

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -22,6 +22,15 @@ const mockGetLibraries = getLibraries as jest.MockedFunction<
   typeof getLibraries
 >;
 
+function validAuthDoc(extra: Record<string, unknown> = {}): OPDS1.AuthDocument {
+  return {
+    id: "test-auth-doc",
+    title: "Test Library",
+    authentication: [],
+    ...extra
+  };
+}
+
 describe("fetching catalog", () => {
   test("calls fetch with catalog url", async () => {
     fetchMock.mockResponseOnce(rawCatalog);
@@ -95,27 +104,23 @@ describe("fetchAuthDocument", () => {
   beforeEach(() => resetAuthDocCache());
 
   test("calls the auth document url and returns json", async () => {
-    fetchMock.mockResponseOnce(
-      JSON.stringify({
-        some: "json"
-      })
-    );
+    const doc = validAuthDoc();
+    fetchMock.mockResponseOnce(JSON.stringify(doc));
 
     const json = await fetchAuthDocument("/auth-doc");
     expect(fetchMock).toHaveBeenCalledWith("/auth-doc");
-    expect(json).toEqual({
-      some: "json"
-    });
+    expect(json).toEqual(doc);
   });
 
   test("returns cached result without fetching on second call", async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({ cached: true }));
+    const doc = validAuthDoc();
+    fetchMock.mockResponseOnce(JSON.stringify(doc));
     await fetchAuthDocument("/auth-doc");
     fetchMock.mockClear();
 
     const result = await fetchAuthDocument("/auth-doc");
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(result).toEqual({ cached: true });
+    expect(result).toEqual(doc);
   });
 
   describe("refresh intervals", () => {
@@ -124,27 +129,32 @@ describe("fetchAuthDocument", () => {
     afterEach(() => jest.restoreAllMocks());
 
     test("re-fetches when refreshMaxInterval has elapsed", async () => {
+      const doc1 = validAuthDoc({ v: 1 });
+      const doc2 = validAuthDoc({ v: 2 });
+
       jest.spyOn(Date, "now").mockReturnValue(T0);
-      fetchMock.mockResponseOnce(JSON.stringify({ v: 1 }));
+      fetchMock.mockResponseOnce(JSON.stringify(doc1));
       await fetchAuthDocument("/auth-doc", {
         refreshMinInterval: 5,
         refreshMaxInterval: 10
       });
 
       jest.spyOn(Date, "now").mockReturnValue(T0 + 11_000);
-      fetchMock.mockResponseOnce(JSON.stringify({ v: 2 }));
+      fetchMock.mockResponseOnce(JSON.stringify(doc2));
       const result = await fetchAuthDocument("/auth-doc", {
         refreshMinInterval: 5,
         refreshMaxInterval: 10
       });
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
-      expect(result).toEqual({ v: 2 });
+      expect(result).toEqual(doc2);
     });
 
     test("does not re-fetch within refreshMinInterval", async () => {
+      const doc = validAuthDoc({ v: 1 });
+
       jest.spyOn(Date, "now").mockReturnValue(T0);
-      fetchMock.mockResponseOnce(JSON.stringify({ v: 1 }));
+      fetchMock.mockResponseOnce(JSON.stringify(doc));
       await fetchAuthDocument("/auth-doc", {
         refreshMinInterval: 30,
         refreshMaxInterval: 10
@@ -158,10 +168,12 @@ describe("fetchAuthDocument", () => {
       });
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({ v: 1 });
+      expect(result).toEqual(doc);
     });
 
     test("retries a failed first fetch even within refreshMinInterval", async () => {
+      const doc = validAuthDoc();
+
       jest.spyOn(Date, "now").mockReturnValue(T0);
       fetchMock.mockRejectOnce(new Error("down"));
       await fetchAuthDocument("/auth-doc", { refreshMinInterval: 30 }).catch(
@@ -170,27 +182,38 @@ describe("fetchAuthDocument", () => {
 
       // Still within minInterval but no cached doc — should retry.
       jest.spyOn(Date, "now").mockReturnValue(T0 + 5_000);
-      fetchMock.mockResponseOnce(JSON.stringify({ recovered: true }));
+      fetchMock.mockResponseOnce(JSON.stringify(doc));
       const result = await fetchAuthDocument("/auth-doc", {
         refreshMinInterval: 30
       });
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
-      expect(result).toEqual({ recovered: true });
+      expect(result).toEqual(doc);
     });
   });
 
   test("coalesces concurrent requests for the same url", async () => {
-    fetchMock.mockResponseOnce(JSON.stringify({ coalesced: true }));
+    const doc = validAuthDoc();
+    fetchMock.mockResponseOnce(JSON.stringify(doc));
     const [r1, r2, r3] = await Promise.all([
       fetchAuthDocument("/concurrent-doc"),
       fetchAuthDocument("/concurrent-doc"),
       fetchAuthDocument("/concurrent-doc")
     ]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(r1).toEqual({ coalesced: true });
+    expect(r1).toEqual(doc);
     expect(r2).toEqual(r1);
     expect(r3).toEqual(r1);
+  });
+
+  test("throws ApplicationError when response is not a valid auth document", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify({ wrong: "shape" }));
+
+    const promise = fetchAuthDocument("/bad-doc");
+    await expect(promise).rejects.toThrow(ApplicationError);
+    await expect(promise).rejects.toThrow(
+      "not a valid authentication document"
+    );
   });
 
   test("passes fetch errors through", async () => {

--- a/src/dataflow/getLibraryData.ts
+++ b/src/dataflow/getLibraryData.ts
@@ -154,8 +154,7 @@ export async function fetchAuthDocument(
         const details = await response.json();
         throw new ServerError(url, response.status, details);
       }
-      const json = await response.json();
-      const validated = AuthDocumentSchema(json);
+      const validated = AuthDocumentSchema(await response.json());
       if (validated instanceof type.errors) {
         throw new ApplicationError({
           title: "Invalid Authentication Document",
@@ -164,7 +163,7 @@ export async function fetchAuthDocument(
             validated.summary
         });
       }
-      const doc: OPDS1.AuthDocument = json;
+      const doc = validated as OPDS1.AuthDocument;
       authDocCache.set(url, {
         doc,
         lastSuccessfulFetch: now,

--- a/src/dataflow/getLibraryData.ts
+++ b/src/dataflow/getLibraryData.ts
@@ -1,3 +1,4 @@
+import { type } from "arktype";
 import {
   AppConfig,
   AuthDocConfig,
@@ -13,6 +14,7 @@ import {
   DEFAULT_AUTH_DOC_REFRESH_MIN_INTERVAL,
   DEFAULT_AUTH_DOC_REFRESH_MAX_INTERVAL
 } from "constants/registry";
+import { AuthDocumentSchema } from "validation/authDocument";
 
 // ---------------------------------------------------------------------------
 // Auth document cache
@@ -152,7 +154,17 @@ export async function fetchAuthDocument(
         const details = await response.json();
         throw new ServerError(url, response.status, details);
       }
-      const doc: OPDS1.AuthDocument = await response.json();
+      const json = await response.json();
+      const validated = AuthDocumentSchema(json);
+      if (validated instanceof type.errors) {
+        throw new ApplicationError({
+          title: "Invalid Authentication Document",
+          detail:
+            `Response from ${url} is not a valid authentication document: ` +
+            validated.summary
+        });
+      }
+      const doc: OPDS1.AuthDocument = json;
       authDocCache.set(url, {
         doc,
         lastSuccessfulFetch: now,

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -331,6 +331,15 @@ describe("fetchRegistryLibraries", () => {
     expect(result).toEqual({});
   });
 
+  it("throws when the response body is not a valid OPDS2 feed", async () => {
+    global.fetch = mockFetchSuccess({
+      wrong: "shape"
+    }) as unknown as typeof fetch;
+    await expect(fetchRegistryLibraries(REGISTRY_URL)).rejects.toThrow(
+      "not a valid OPDS2 feed"
+    );
+  });
+
   it("throws when the response is not ok", async () => {
     global.fetch = mockFetchError(
       503,

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -94,7 +94,13 @@ function makePagedFeed(
     links,
     facets,
     catalogs: catalogs.map(({ id, title, authDocUrl, updated }) => ({
-      metadata: { id, title, updated: updated ?? "", description: "" },
+      metadata: {
+        id,
+        title,
+        updated: updated ?? "",
+        modified: updated ?? "",
+        description: ""
+      },
       links: authDocUrl
         ? [
             {

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -1,3 +1,4 @@
+import { type } from "arktype";
 import type { AppConfig, LibrariesConfig, RegistryConfig } from "interfaces";
 import { OPDS2 } from "interfaces";
 import {
@@ -7,6 +8,7 @@ import {
   DEFAULT_REGISTRY_FETCH_TIMEOUT
 } from "constants/registry";
 import { computeSlug, validateSlug } from "utils/librarySlug";
+import { RegistryFeedSchema } from "validation/registryFeed";
 
 // ---------------------------------------------------------------------------
 // Internal state types
@@ -149,7 +151,15 @@ async function crawlRegistryFeed(
       );
     }
 
-    const feed = (await response.json()) as OPDS2.LibraryRegistryFeed;
+    const json = await response.json();
+    const validated = RegistryFeedSchema(json);
+    if (validated instanceof type.errors) {
+      throw new Error(
+        `Registry response from ${currentUrl} is not a valid OPDS2 feed: ` +
+          validated.summary
+      );
+    }
+    const feed = json as OPDS2.LibraryRegistryFeed;
 
     // Read facets from the first page only.
     if (isFirstPage) {

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -151,15 +151,15 @@ async function crawlRegistryFeed(
       );
     }
 
-    const json = await response.json();
-    const validated = RegistryFeedSchema(json);
+    const validated = RegistryFeedSchema(await response.json());
+    // Plain Error here, since it should never propagate to the client.
     if (validated instanceof type.errors) {
       throw new Error(
         `Registry response from ${currentUrl} is not a valid OPDS2 feed: ` +
           validated.summary
       );
     }
-    const feed = json as OPDS2.LibraryRegistryFeed;
+    const feed = validated as OPDS2.LibraryRegistryFeed;
 
     // Read facets from the first page only.
     if (isFirstPage) {

--- a/src/test-utils/fixtures/opds2.ts
+++ b/src/test-utils/fixtures/opds2.ts
@@ -29,6 +29,7 @@ const catalogRootFeedLink: OPDS2.CatalogRootFeedLink = {
 export const catalogEntry: OPDS2.CatalogEntry = {
   metadata: {
     updated: "catalog updated",
+    modified: "catalog updated",
     description: "catalog entry description",
     id: "catalog entry id",
     title: "catalog entry title"

--- a/src/types/opds1.ts
+++ b/src/types/opds1.ts
@@ -163,7 +163,36 @@ export interface Link {
 
 /**
  * Auth Document
+ *
+ * Simple leaf types are derived from the ArkType schemas in
+ * validation/authDocument.ts (aligned with Palace Manager Pydantic models).
+ * Compound types that use CPW-specific narrowing (discriminated auth method
+ * union, AuthDocument itself) remain hand-written interfaces here.
  */
+
+// Schema-derived types — single source of truth for these shapes.
+export type {
+  AuthenticateLink,
+  Authentication,
+  AuthenticationInput,
+  AuthenticationInputs,
+  AuthenticationLabels,
+  Features,
+  LocalizedValue,
+  PublicKey,
+  WebColorScheme
+} from "validation/authDocument";
+
+// Local import so the interfaces below can reference the derived types.
+import type {
+  AuthenticationInputs,
+  AuthenticationLabels,
+  Features,
+  LocalizedValue,
+  PublicKey,
+  WebColorScheme
+} from "validation/authDocument";
+
 export const CatalogRootRel = "start";
 export const ShelfLinkRel = "http://opds-spec.org/shelf";
 export const UserProfileLinkRel =
@@ -211,6 +240,15 @@ export type AnyAuthType =
   | typeof ImplicitGrantAuthType
   | typeof PasswordCredentialsAuthType;
 
+/**
+ * CPW-specific narrowing of auth methods by their type discriminant.
+ *
+ * The schema-derived Authentication type matches what the Palace Manager
+ * sends: a single shape with optional fields. These interfaces narrow the
+ * type field to a specific literal so downstream code can discriminate on
+ * auth method kind.
+ */
+
 // https://drafts.opds.io/authentication-for-opds-1.0
 export interface AuthMethod<T extends AnyAuthType, L extends Link = Link> {
   type: T;
@@ -231,15 +269,8 @@ export interface ServerOidcMethod extends AuthMethod<
 export interface CleverAuthMethod extends AuthMethod<typeof CleverAuthType> {}
 
 export interface BasicAuthMethod extends AuthMethod<typeof BasicAuthType> {
-  inputs?: {
-    login?: AuthInput;
-    password?: AuthInput;
-  };
-
-  labels: {
-    login: string;
-    password: string;
-  };
+  inputs?: AuthenticationInputs;
+  labels: AuthenticationLabels;
 }
 
 // TODO: This may need adjustment when we actually implement BasicTokenAuth.
@@ -248,10 +279,6 @@ export interface BasicTokenAuthMethod
   extends
     Omit<BasicAuthMethod, "type">,
     AuthMethod<typeof BasicTokenAuthType> {}
-
-export interface AuthInput {
-  keyboard?: Keyboard;
-}
 
 export enum Keyboard {
   Default = "Default",
@@ -272,18 +299,24 @@ export interface Announcement {
   content: string;
 }
 
+/**
+ * Aligned with PM's PalaceAuthenticationDocument. Fields marked "Palace
+ * extension" are emitted by Palace Manager but not part of the base
+ * Authentication for OPDS 1.0 spec.
+ */
 export interface AuthDocument {
   id: string;
   title: string;
-  // used to display text prompt to authenticating user
   description?: string;
   links?: AuthDocumentLink[];
   authentication: ServerAuthMethod[];
+  // Palace extensions
   announcements?: Announcement[];
-  web_color_scheme?: {
-    primary?: string;
-    secondary?: string;
-  };
+  color_scheme?: string;
+  web_color_scheme?: WebColorScheme;
+  service_description?: string;
+  public_key?: PublicKey;
+  features?: Features;
 }
 
 /**
@@ -299,44 +332,31 @@ export interface BearerTokenDocument {
 }
 
 /**
- * SAML is an extension on the OPDS1 spec which only
- * works when backed by a Circulation Manager
+ * SAML/OIDC authenticate links.
+ *
+ * Narrow the schema-derived AuthenticateLink with the specific rel values
+ * used by SAML and OIDC providers. The localized-value arrays match PM's
+ * AuthenticateLink model (palace.opds.authentication.document).
  */
 export type SamlIdp = {
   href: string;
   rel: "authenticate" | "logout";
-  display_names?: Array<{ language: string; value: string }>;
-  descriptions?: Array<{ language: string; value: string }>;
-  privacy_statement_urls?: [];
-  logo_urls?: [];
-  information_urls?: [];
+  display_names?: LocalizedValue[];
+  descriptions?: LocalizedValue[];
+  privacy_statement_urls?: LocalizedValue[];
+  logo_urls?: LocalizedValue[];
+  information_urls?: LocalizedValue[];
   templated?: boolean;
 };
 
-/**
- * OIDC is an extension on the OPDS1 spec which only
- * works when backed by a Circulation Manager
- */
-// TODO: Currently OidcLink is identical to SamlIdp (above). We should
-//  factor out the common properties, if that remains the case.
 export type OidcLink = {
-  privacy_statement_urls: [];
-  logo_urls: [];
-  display_names: [
-    {
-      language: string;
-      value: string;
-    }
-  ];
   href: string;
-  descriptions: [
-    {
-      language: string;
-      value: string;
-    }
-  ];
   rel: "authenticate" | "logout";
-  information_urls: [];
+  display_names?: LocalizedValue[];
+  descriptions?: LocalizedValue[];
+  privacy_statement_urls?: LocalizedValue[];
+  logo_urls?: LocalizedValue[];
+  information_urls?: LocalizedValue[];
   templated?: boolean;
   /** Structurally equivalent to OPDS2.UriTemplateProperties (see types/opds2.ts). */
   properties?: {

--- a/src/types/opds2.ts
+++ b/src/types/opds2.ts
@@ -1,24 +1,31 @@
 /* eslint-disable camelcase */
 import { OPDS1 } from "interfaces";
+
 /**
  * OPDS 2.0 DATA TYPES
- * Currently only used for support of a Library Regristry, which is
- * an OPDS 2 Feed of OPDS 2 Catalogs from which we extract the catalog root url
  *
- * This is a working document that still has more to fill in.
+ * Library Registry types are derived from the ArkType schemas in
+ * validation/registryFeed.ts (aligned with what the Palace Library Registry
+ * actually produces). Generic OPDS 2 structural types (Collection, Feed, etc.)
+ * remain hand-written.
  */
 
+// Schema-derived types for registry feed validation.
+export type {
+  CatalogEntry,
+  CatalogEntryMetadata,
+  FacetGroup,
+  FacetGroupMetadata,
+  FeedMetadata,
+  RegistryFeed as LibraryRegistryFeed
+} from "validation/registryFeed";
+
 export interface Collection<M extends AnyObject = AnyObject> {
-  /**
-   * Must comply with "application/opds+json", but that is
-   * not necessarily marked as the type
-   */
   metadata: M;
   links: Link[];
 }
-// a feed is a collection since it has metadata, links and sub collections.
+
 export interface Feed<M extends AnyObject = AnyObject> extends Collection<M> {
-  // sub collections of with roles "navigation", "publication", "group"
   navigation?: NavigationLink[];
   publications?: Publication[];
   groups?: Group[];
@@ -29,84 +36,35 @@ export interface NavigationLink extends Link {
 
 type GroupMetadata = { title: string };
 export interface Group extends Collection<GroupMetadata> {
-  /**
-   * For when a catalog has more than one collection of
-   * navigation or publications. It contains an array of
-   * Feeds
-   *
-   */
   groups: Feed<GroupMetadata>[];
 }
 
 /** URI identifying the sort facet group in a Library Registry feed. */
 export const SortFacetType = "http://palaceproject.io/terms/rel/sort";
 
+/** URI identifying the availability facet group in a Library Registry feed. */
+export const AvailabilityFacetType =
+  "http://palaceproject.io/terms/rel/availability";
+
 /** Property key marking a facet link as the default option for its group. */
 export const FacetDefaultProperty =
-  "http://palaceproject.io/terms/facet/default";
+  "http://palaceproject.io/terms/properties/default";
 
-export interface FacetGroupMetadata {
-  title: string;
-  "@type"?: string; // e.g. SortFacetType
-}
+/** Facet link property: the query parameter value for this facet. */
+export const FacetValueProperty = "http://palaceproject.io/terms/facet/value";
 
-export interface FacetGroup {
-  metadata: FacetGroupMetadata;
-  links: Link[]; // the active facet link has rel === "self"
-}
+/** Facet group property: the query parameter name this group controls. */
+export const FacetParamProperty = "http://palaceproject.io/terms/facet/param";
 
-type LibraryRegistryFeedMetadata = {
-  adobe_vendor_id: string;
-  title: string;
-  numberOfItems?: number;
-};
+/** Facet link property: logical group linking related sort variants. */
+export const FacetGroupProperty = "http://palaceproject.io/terms/facet/group";
 
-export interface LibraryRegistryFeed extends Feed<LibraryRegistryFeedMetadata> {
-  links: Link[];
-  /**
-   * When you fetch a templated url from a LibraryRegistryFeed, you
-   * get back another LibraryRegistryFeed, but with a single catalog
-   * in an array. A generic LibraryRegistryFeed has a list of all catalogs
-   */
-  catalogs?: CatalogEntry[];
-  facets?: FacetGroup[];
-}
-
-type CatalogEntryMetadata = {
-  updated: string;
-  description: string;
-  id: string;
-  title: string;
-};
-export interface CatalogEntry extends Feed<CatalogEntryMetadata> {
-  /**
-   * The CatalogEntry is a Feed which describes an OPDS Catalog (v1 or v2).
-   * It contains a link to an AuthDocument, thus marking it the top level descriptor
-   * for a library with an authentication boundary. The AuthDocument and CatalogRootLink
-   * are nested within Links.
-   *
-   * Since there is no way in typescript to describe an array that must contain
-   * certain elements, this just extends Feed.
-   */
-}
-
-/**
- * Publications must either be:
- * a Readium Web Publication with no restrictions in terms of access
- * (no payment, no credentials required, no limitations whatsoever),
- * or an OPDS Publication
- */
 export type Publication = ReadiumWebPub | OPDSPublication;
 
 export interface ReadiumWebPub extends Collection {
   readingOrder: any[];
 }
-export interface OPDSPublication extends Collection {
-  /**
-   * An OPDS Publication is basically a ReadiumWebPub without
-   * the requirement that it contain a readingOrder collection
-   */
-}
+export interface OPDSPublication extends Collection {}
 
 /**
  * Links

--- a/src/utils/__tests__/librarySlug.test.ts
+++ b/src/utils/__tests__/librarySlug.test.ts
@@ -10,7 +10,13 @@ function makeCatalog(
   links: OPDS2.CatalogEntry["links"] = []
 ): OPDS2.CatalogEntry {
   return {
-    metadata: { id, title: "Test Library", updated: "", description: "" },
+    metadata: {
+      id,
+      title: "Test Library",
+      updated: "",
+      modified: "",
+      description: ""
+    },
     links
   };
 }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -90,7 +90,7 @@ function serverToClientOidcMethod(
 }
 
 export const getEnglishValue = (
-  arr: Array<{ language: string; value: string }> | undefined
+  arr: Array<{ language?: string; value: string }> | undefined
 ) => arr?.find(item => item.language === "en")?.value;
 
 export function generateCredentials(username: string, password = "") {

--- a/src/validation/authDocument.ts
+++ b/src/validation/authDocument.ts
@@ -1,27 +1,160 @@
+/* eslint-disable camelcase */
+
+/**
+ * ArkType runtime schemas for the Palace Manager authentication document.
+ *
+ * These schemas mirror the Pydantic models in the Palace Manager
+ * (`palace-opds` package, `palace.opds.authentication` module):
+ *
+ *   PalaceAuthenticationDocument  →  AuthDocumentSchema
+ *   PalaceAuthentication          →  AuthenticationSchema
+ *   AuthenticationLabels          →  AuthenticationLabelsSchema
+ *   AuthenticationInput           →  AuthenticationInputSchema
+ *   AuthenticationInputs          →  AuthenticationInputsSchema
+ *   AuthenticateLink / BaseLink   →  LinkSchema / AuthenticateLinkSchema
+ *   LocalizedValue                →  LocalizedValueSchema
+ *   AnnouncementDocument          →  AnnouncementSchema
+ *   WebColorScheme                →  WebColorSchemeSchema
+ *   Features                      →  FeaturesSchema
+ *   PublicKey                     →  PublicKeySchema
+ *
+ * The derived TypeScript types are re-exported from types/opds1.ts so the
+ * rest of the codebase can continue to import them from the OPDS1 namespace.
+ */
+
 import { type } from "arktype";
 
-const AuthDocLinkSchema = type({
+// -- Links ------------------------------------------------------------------
+
+// Matches PM's BaseLink.
+// TODO: PM allows `rel` to be `string | string[]`. CPW currently
+//  uses `rel` with strict equality, so accepting arrays here would
+//  pass validation but silently break downstream matching.
+//  Update all `rel` uses to handle both forms before widening this.
+export const LinkSchema = type({
   href: "string",
   "rel?": "string",
-  "title?": "string",
+  "templated?": "boolean",
   "type?": "string",
+  "title?": "string",
   "role?": "string"
 });
 
-const AuthMethodSchema = type({
-  type: "string",
-  "description?": "string"
+// Matches PM's palace.LocalizedValue.
+export const LocalizedValueSchema = type({
+  value: "string",
+  "language?": "string",
+  "height?": "number",
+  "width?": "number"
 });
 
+// Matches PM's AuthenticateLink (Link + Palace localized extensions).
+// Used for SAML IdP and OIDC authenticate/logout links.
+export const AuthenticateLinkSchema = type({
+  href: "string",
+  "rel?": "string",
+  "templated?": "boolean",
+  "type?": "string",
+  "title?": "string",
+  "display_names?": LocalizedValueSchema.array(),
+  "descriptions?": LocalizedValueSchema.array(),
+  "information_urls?": LocalizedValueSchema.array(),
+  "privacy_statement_urls?": LocalizedValueSchema.array(),
+  "logo_urls?": LocalizedValueSchema.array(),
+  "properties?": type({
+    "uri_template_variables?": type({
+      '"@type"?': "string",
+      map: "Record<string, unknown>"
+    })
+  })
+});
+
+// -- Authentication methods -------------------------------------------------
+
+// Matches PM's AuthenticationLabels.
+export const AuthenticationLabelsSchema = type({
+  login: "string",
+  password: "string"
+});
+
+// Matches PM's AuthenticationInput.
+export const AuthenticationInputSchema = type({
+  "keyboard?": "string",
+  "maximum_length?": "number",
+  "barcode_format?": "string"
+});
+
+// Matches PM's AuthenticationInputs.
+export const AuthenticationInputsSchema = type({
+  login: AuthenticationInputSchema,
+  password: AuthenticationInputSchema
+});
+
+// Matches PM's PalaceAuthentication (Authentication + AuthenticationExtension).
+export const AuthenticationSchema = type({
+  type: "string",
+  "description?": "string",
+  "labels?": AuthenticationLabelsSchema,
+  "inputs?": AuthenticationInputsSchema,
+  "links?": LinkSchema.array()
+});
+
+// -- Document-level fields --------------------------------------------------
+
+// Matches PM's AnnouncementDocument.
+export const AnnouncementSchema = type({
+  id: "string",
+  content: "string"
+});
+
+// Matches PM's WebColorScheme.
+export const WebColorSchemeSchema = type({
+  "primary?": "string",
+  "secondary?": "string",
+  "background?": "string",
+  "foreground?": "string"
+});
+
+// Matches PM's Features.
+export const FeaturesSchema = type({
+  "enabled?": "string[]",
+  "disabled?": "string[]"
+});
+
+// Matches PM's PublicKey.
+export const PublicKeySchema = type({
+  "type?": "string",
+  value: "string"
+});
+
+// -- Authentication document ------------------------------------------------
+
+// Matches PM's PalaceAuthenticationDocument.
 export const AuthDocumentSchema = type({
   id: "string",
   title: "string",
   "description?": "string",
-  "links?": AuthDocLinkSchema.array(),
-  authentication: AuthMethodSchema.array(),
-  "announcements?": type({ id: "string", content: "string" }).array(),
-  "web_color_scheme?": type({
-    "primary?": "string",
-    "secondary?": "string"
-  })
+  "links?": LinkSchema.array(),
+  authentication: AuthenticationSchema.array(),
+  "color_scheme?": "string",
+  "web_color_scheme?": WebColorSchemeSchema,
+  "service_description?": "string",
+  "public_key?": PublicKeySchema,
+  "features?": FeaturesSchema,
+  "announcements?": AnnouncementSchema.array()
 });
+
+// -- Derived types ----------------------------------------------------------
+
+export type AuthDocumentLink = typeof LinkSchema.infer;
+export type AuthenticateLink = typeof AuthenticateLinkSchema.infer;
+export type LocalizedValue = typeof LocalizedValueSchema.infer;
+export type AuthenticationLabels = typeof AuthenticationLabelsSchema.infer;
+export type AuthenticationInput = typeof AuthenticationInputSchema.infer;
+export type AuthenticationInputs = typeof AuthenticationInputsSchema.infer;
+export type Authentication = typeof AuthenticationSchema.infer;
+export type Announcement = typeof AnnouncementSchema.infer;
+export type WebColorScheme = typeof WebColorSchemeSchema.infer;
+export type Features = typeof FeaturesSchema.infer;
+export type PublicKey = typeof PublicKeySchema.infer;
+export type AuthDocument = typeof AuthDocumentSchema.infer;

--- a/src/validation/authDocument.ts
+++ b/src/validation/authDocument.ts
@@ -1,0 +1,27 @@
+import { type } from "arktype";
+
+const AuthDocLinkSchema = type({
+  href: "string",
+  "rel?": "string",
+  "title?": "string",
+  "type?": "string",
+  "role?": "string"
+});
+
+const AuthMethodSchema = type({
+  type: "string",
+  "description?": "string"
+});
+
+export const AuthDocumentSchema = type({
+  id: "string",
+  title: "string",
+  "description?": "string",
+  "links?": AuthDocLinkSchema.array(),
+  authentication: AuthMethodSchema.array(),
+  "announcements?": type({ id: "string", content: "string" }).array(),
+  "web_color_scheme?": type({
+    "primary?": "string",
+    "secondary?": "string"
+  })
+});

--- a/src/validation/authDocument.ts
+++ b/src/validation/authDocument.ts
@@ -84,19 +84,24 @@ export const AuthenticationInputSchema = type({
   "barcode_format?": "string"
 });
 
-// Matches PM's AuthenticationInputs.
+// PM's AuthenticationInputs requires both login and password, but
+// third-party CMs may omit one. Keep both optional to avoid rejecting
+// an entire auth document over a missing sub-field.
 export const AuthenticationInputsSchema = type({
-  login: AuthenticationInputSchema,
-  password: AuthenticationInputSchema
+  "login?": AuthenticationInputSchema,
+  "password?": AuthenticationInputSchema
 });
 
 // Matches PM's PalaceAuthentication (Authentication + AuthenticationExtension).
+// Auth method links use AuthenticateLinkSchema because SAML/OIDC authenticate
+// links carry localized extensions (display_names, descriptions, etc.).
+// Plain links (e.g. logout) still pass since those fields are optional.
 export const AuthenticationSchema = type({
   type: "string",
   "description?": "string",
   "labels?": AuthenticationLabelsSchema,
   "inputs?": AuthenticationInputsSchema,
-  "links?": LinkSchema.array()
+  "links?": AuthenticateLinkSchema.array()
 });
 
 // -- Document-level fields --------------------------------------------------
@@ -146,7 +151,6 @@ export const AuthDocumentSchema = type({
 
 // -- Derived types ----------------------------------------------------------
 
-export type AuthDocumentLink = typeof LinkSchema.infer;
 export type AuthenticateLink = typeof AuthenticateLinkSchema.infer;
 export type LocalizedValue = typeof LocalizedValueSchema.infer;
 export type AuthenticationLabels = typeof AuthenticationLabelsSchema.infer;

--- a/src/validation/registryFeed.ts
+++ b/src/validation/registryFeed.ts
@@ -1,31 +1,93 @@
+/* eslint-disable camelcase */
+
+/**
+ * ArkType runtime schemas for Library Registry OPDS 2.0 feed responses.
+ *
+ * These schemas are aligned with what the Palace Library Registry
+ * (`library-registry` repo, `palace.registry.opds.OPDSCatalog`) produces.
+ * Both the full feed and crawlable (paginated) feed share the same shape;
+ * the single-library endpoint (`/libraries/<uuid>`) also uses it (with
+ * a single catalog entry).
+ *
+ * The derived TypeScript types are re-exported from types/opds2.ts so
+ * the rest of the codebase can continue to import from the OPDS2 namespace.
+ */
+
 import { type } from "arktype";
 
-const LinkSchema = type({
+// -- Links ------------------------------------------------------------------
+
+// Matches the dict-style links emitted by OPDSCatalog.add_link_to_catalog.
+// Links may carry a `properties` dict (used for facet metadata and hyperlink
+// validation status).
+export const LinkSchema = type({
   href: "string",
   "type?": "string",
-  "rel?": "string"
+  "rel?": "string",
+  "title?": "string",
+  "properties?": "Record<string, unknown>"
 });
 
-const CatalogEntryMetadataSchema = type({
+// -- Catalog entries --------------------------------------------------------
+
+// Matches OPDSCatalog.library_catalog metadata output.
+// The registry emits both `modified` and `updated` (identical values) for
+// backwards compatibility.
+export const CatalogEntryMetadataSchema = type({
   id: "string",
   title: "string",
   updated: "string",
+  modified: "string",
   "description?": "string"
 });
 
-const CatalogEntrySchema = type({
+export const CatalogEntrySchema = type({
   metadata: CatalogEntryMetadataSchema,
+  links: LinkSchema.array(),
+  "images?": LinkSchema.array()
+});
+
+// -- Facets -----------------------------------------------------------------
+
+// Matches the facet groups emitted by OPDSCatalog._add_facets.
+// Metadata carries `title` and an optional `@type` URI identifying the
+// facet dimension (sort, availability, etc.).
+export const FacetGroupMetadataSchema = type({
+  title: "string",
+  '"@type"?': "string"
+});
+
+export const FacetGroupSchema = type({
+  metadata: FacetGroupMetadataSchema,
   links: LinkSchema.array()
 });
 
-const FacetGroupSchema = type({
-  metadata: type({ title: "string" }),
-  links: LinkSchema.array()
+// -- Feed -------------------------------------------------------------------
+
+// Matches the top-level OPDSCatalog output.
+// Paginated feeds add `numberOfItems` to metadata.
+// `adobe_vendor_id` is a sitewide setting from the registry's
+// ExternalIntegration table, always present but null when no Adobe
+// Vendor ID integration is configured.
+export const FeedMetadataSchema = type({
+  title: "string",
+  "adobe_vendor_id?": "string | null",
+  "numberOfItems?": "number"
 });
 
 export const RegistryFeedSchema = type({
-  metadata: type({ title: "string" }),
+  metadata: FeedMetadataSchema,
   links: LinkSchema.array(),
   "catalogs?": CatalogEntrySchema.array(),
   "facets?": FacetGroupSchema.array()
 });
+
+// -- Derived types ----------------------------------------------------------
+
+export type RegistryLink = typeof LinkSchema.infer;
+export type CatalogEntryMetadata = typeof CatalogEntryMetadataSchema.infer;
+export type CatalogEntry = typeof CatalogEntrySchema.infer;
+export type FacetGroupMetadata = typeof FacetGroupMetadataSchema.infer;
+export type FacetGroup = typeof FacetGroupSchema.infer;
+export type FeedMetadata = typeof FeedMetadataSchema.infer;
+export type RegistryFeed = typeof RegistryFeedSchema.infer;

--- a/src/validation/registryFeed.ts
+++ b/src/validation/registryFeed.ts
@@ -1,0 +1,31 @@
+import { type } from "arktype";
+
+const LinkSchema = type({
+  href: "string",
+  "type?": "string",
+  "rel?": "string"
+});
+
+const CatalogEntryMetadataSchema = type({
+  id: "string",
+  title: "string",
+  updated: "string",
+  "description?": "string"
+});
+
+const CatalogEntrySchema = type({
+  metadata: CatalogEntryMetadataSchema,
+  links: LinkSchema.array()
+});
+
+const FacetGroupSchema = type({
+  metadata: type({ title: "string" }),
+  links: LinkSchema.array()
+});
+
+export const RegistryFeedSchema = type({
+  metadata: type({ title: "string" }),
+  links: LinkSchema.array(),
+  "catalogs?": CatalogEntrySchema.array(),
+  "facets?": FacetGroupSchema.array()
+});

--- a/tests/validation/authDocument.test.ts
+++ b/tests/validation/authDocument.test.ts
@@ -41,7 +41,7 @@ describe("AuthDocumentSchema", () => {
           type: "http://opds-spec.org/auth/basic",
           description: "Basic Auth",
           labels: { login: "Barcode", password: "PIN" },
-          inputs: { login: { keyboard: "Default" }, password: {} }
+          inputs: { login: { keyboard: "Default" } }
         },
         {
           type: "http://librarysimplified.org/authtype/SAML-2.0",

--- a/tests/validation/authDocument.test.ts
+++ b/tests/validation/authDocument.test.ts
@@ -41,7 +41,7 @@ describe("AuthDocumentSchema", () => {
           type: "http://opds-spec.org/auth/basic",
           description: "Basic Auth",
           labels: { login: "Barcode", password: "PIN" },
-          inputs: { login: { keyboard: "Default" } }
+          inputs: { login: { keyboard: "Default" }, password: {} }
         },
         {
           type: "http://librarysimplified.org/authtype/SAML-2.0",

--- a/tests/validation/authDocument.test.ts
+++ b/tests/validation/authDocument.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for AuthDocumentSchema runtime validation.
+ * Run under jest.config.node.js.
+ */
+
+import { type } from "arktype";
+import { AuthDocumentSchema } from "validation/authDocument";
+
+function minimal() {
+  return { id: "urn:uuid:abc", title: "Test Library", authentication: [] };
+}
+
+describe("AuthDocumentSchema", () => {
+  it("accepts a minimal valid auth document", () => {
+    const result = AuthDocumentSchema(minimal());
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  it("accepts an auth document with all optional fields", () => {
+    const doc = {
+      ...minimal(),
+      description: "A test library",
+      links: [
+        { href: "/catalog", rel: "start" },
+        { href: "/shelf", rel: "http://opds-spec.org/shelf" }
+      ],
+      announcements: [{ id: "ann-1", content: "Welcome!" }],
+      web_color_scheme: { primary: "#000", secondary: "#fff" } // eslint-disable-line camelcase -- from external API
+    };
+    const result = AuthDocumentSchema(doc);
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  it("accepts auth methods with extra fields (labels, inputs, etc.)", () => {
+    const doc = {
+      ...minimal(),
+      authentication: [
+        {
+          type: "http://opds-spec.org/auth/basic",
+          description: "Basic Auth",
+          labels: { login: "Barcode", password: "PIN" },
+          inputs: { login: { keyboard: "Default" } }
+        },
+        {
+          type: "http://librarysimplified.org/authtype/SAML-2.0",
+          links: [{ href: "https://idp.example.com/", rel: "authenticate" }]
+        }
+      ]
+    };
+    const result = AuthDocumentSchema(doc);
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  it("preserves extra fields on the validated output", () => {
+    const doc = {
+      ...minimal(),
+      authentication: [
+        {
+          type: "http://opds-spec.org/auth/basic",
+          labels: { login: "Barcode", password: "PIN" }
+        }
+      ]
+    };
+    const result = AuthDocumentSchema(doc);
+    expect(result instanceof type.errors).toBe(false);
+    expect((result as any).authentication[0].labels).toEqual({
+      login: "Barcode",
+      password: "PIN"
+    });
+  });
+
+  it("rejects when id is missing", () => {
+    const result = AuthDocumentSchema({ title: "X", authentication: [] });
+    expect(result instanceof type.errors).toBe(true);
+    expect((result as any).summary).toContain("id");
+  });
+
+  it("rejects when title is missing", () => {
+    const result = AuthDocumentSchema({ id: "x", authentication: [] });
+    expect(result instanceof type.errors).toBe(true);
+    expect((result as any).summary).toContain("title");
+  });
+
+  it("rejects when authentication is missing", () => {
+    const result = AuthDocumentSchema({ id: "x", title: "X" });
+    expect(result instanceof type.errors).toBe(true);
+    expect((result as any).summary).toContain("authentication");
+  });
+
+  it("rejects when authentication is not an array", () => {
+    const result = AuthDocumentSchema({
+      id: "x",
+      title: "X",
+      authentication: "not-array"
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  it("rejects when an auth method is missing its type field", () => {
+    const result = AuthDocumentSchema({
+      ...minimal(),
+      authentication: [{ description: "no type" }]
+    });
+    expect(result instanceof type.errors).toBe(true);
+    expect((result as any).summary).toContain("type");
+  });
+
+  it("rejects when a link is missing its href", () => {
+    const result = AuthDocumentSchema({
+      ...minimal(),
+      links: [{ rel: "start" }]
+    });
+    expect(result instanceof type.errors).toBe(true);
+    expect((result as any).summary).toContain("href");
+  });
+
+  it("rejects a completely wrong response (e.g. HTML parsed as JSON)", () => {
+    const result = AuthDocumentSchema("not an object");
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  it("rejects null", () => {
+    const result = AuthDocumentSchema(null);
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  it("rejects an empty object", () => {
+    const result = AuthDocumentSchema({});
+    expect(result instanceof type.errors).toBe(true);
+  });
+});

--- a/tests/validation/registryFeed.test.ts
+++ b/tests/validation/registryFeed.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * @jest-environment node
  *
@@ -10,14 +11,20 @@ import { RegistryFeedSchema } from "validation/registryFeed";
 
 function minimal() {
   return {
-    metadata: { title: "Test Registry" },
+    metadata: { title: "Test Registry", adobe_vendor_id: null }, // eslint-disable-line camelcase -- from external API
     links: []
   };
 }
 
 function catalogEntry(id: string, title: string) {
   return {
-    metadata: { id, title, updated: new Date().toISOString(), description: "" },
+    metadata: {
+      id,
+      title,
+      updated: new Date().toISOString(),
+      modified: new Date().toISOString(), // from external API
+      description: ""
+    },
     links: [
       {
         href: `https://${id}.example.com/auth`,
@@ -45,13 +52,29 @@ describe("RegistryFeedSchema", () => {
     expect(result instanceof type.errors).toBe(false);
   });
 
-  it("accepts a feed with facets", () => {
+  it("accepts a feed with facets including @type and properties", () => {
     const feed = {
       ...minimal(),
       facets: [
         {
-          metadata: { title: "Sort" },
-          links: [{ href: "/sort?order=modified", rel: "self" }]
+          metadata: {
+            title: "Sort by",
+            "@type": "http://palaceproject.io/terms/rel/sort",
+            "http://palaceproject.io/terms/facet/param": "order"
+          },
+          links: [
+            {
+              href: "/libraries?order=modified",
+              title: "Most recently modified first",
+              type: "application/opds+json",
+              rel: "self",
+              properties: {
+                "http://palaceproject.io/terms/facet/value": "modified",
+                "http://palaceproject.io/terms/properties/default": true,
+                "http://palaceproject.io/terms/facet/group": "modified"
+              }
+            }
+          ]
         }
       ]
     };
@@ -59,11 +82,71 @@ describe("RegistryFeedSchema", () => {
     expect(result instanceof type.errors).toBe(false);
   });
 
-  it("accepts a feed with pagination links", () => {
+  it("accepts a paginated feed with numberOfItems", () => {
     const feed = {
-      metadata: { title: "Registry", adobe_vendor_id: "vendor" }, // eslint-disable-line camelcase -- from external API
-      links: [{ href: "/page2", rel: "next", type: "application/opds+json" }],
+      metadata: {
+        title: "Libraries",
+        adobe_vendor_id: "VENDORID",
+        numberOfItems: 42
+      }, // eslint-disable-line camelcase -- from external API
+      links: [
+        { href: "/page1", rel: "first", type: "application/opds+json" },
+        { href: "/page2", rel: "next", type: "application/opds+json" }
+      ],
       catalogs: [catalogEntry("urn:uuid:a", "A")]
+    };
+    const result = RegistryFeedSchema(feed);
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  it("accepts catalog entries with images", () => {
+    const feed = {
+      ...minimal(),
+      catalogs: [
+        {
+          ...catalogEntry("urn:uuid:x", "X"),
+          images: [
+            {
+              href: "https://example.com/logo.png",
+              rel: "http://opds-spec.org/image/thumbnail",
+              type: "image/png"
+            }
+          ]
+        }
+      ]
+    };
+    const result = RegistryFeedSchema(feed);
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  it("accepts links with properties (hyperlink validation status)", () => {
+    const feed = {
+      ...minimal(),
+      catalogs: [
+        {
+          metadata: {
+            id: "urn:uuid:a",
+            title: "A",
+            updated: "2024-01-01T00:00:00Z",
+            modified: "2024-01-01T00:00:00Z"
+          },
+          links: [
+            {
+              href: "https://example.com/auth",
+              type: "application/vnd.opds.authentication.v1.0+json",
+              rel: "http://opds-spec.org/auth/document"
+            },
+            {
+              href: "mailto:help@example.com",
+              rel: "help",
+              properties: {
+                "http://librarysimplified.org/rel/registry/validation-status":
+                  "confirmed"
+              }
+            }
+          ]
+        }
+      ]
     };
     const result = RegistryFeedSchema(feed);
     expect(result instanceof type.errors).toBe(false);

--- a/tests/validation/registryFeed.test.ts
+++ b/tests/validation/registryFeed.test.ts
@@ -209,7 +209,8 @@ describe("RegistryFeedSchema", () => {
           metadata: {
             id: "x",
             title: "X",
-            updated: "2024-01-01T00:00:00Z"
+            updated: "2024-01-01T00:00:00Z",
+            modified: "2024-01-01T00:00:00Z"
           }
         }
       ]

--- a/tests/validation/registryFeed.test.ts
+++ b/tests/validation/registryFeed.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for RegistryFeedSchema runtime validation.
+ * Run under jest.config.node.js.
+ */
+
+import { type } from "arktype";
+import { RegistryFeedSchema } from "validation/registryFeed";
+
+function minimal() {
+  return {
+    metadata: { title: "Test Registry" },
+    links: []
+  };
+}
+
+function catalogEntry(id: string, title: string) {
+  return {
+    metadata: { id, title, updated: new Date().toISOString(), description: "" },
+    links: [
+      {
+        href: `https://${id}.example.com/auth`,
+        type: "application/vnd.opds.authentication.v1.0+json"
+      }
+    ]
+  };
+}
+
+describe("RegistryFeedSchema", () => {
+  it("accepts a minimal valid registry feed", () => {
+    const result = RegistryFeedSchema(minimal());
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  it("accepts a feed with catalogs", () => {
+    const feed = {
+      ...minimal(),
+      catalogs: [
+        catalogEntry("urn:uuid:abc", "Library A"),
+        catalogEntry("urn:uuid:def", "Library B")
+      ]
+    };
+    const result = RegistryFeedSchema(feed);
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  it("accepts a feed with facets", () => {
+    const feed = {
+      ...minimal(),
+      facets: [
+        {
+          metadata: { title: "Sort" },
+          links: [{ href: "/sort?order=modified", rel: "self" }]
+        }
+      ]
+    };
+    const result = RegistryFeedSchema(feed);
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  it("accepts a feed with pagination links", () => {
+    const feed = {
+      metadata: { title: "Registry", adobe_vendor_id: "vendor" }, // eslint-disable-line camelcase -- from external API
+      links: [{ href: "/page2", rel: "next", type: "application/opds+json" }],
+      catalogs: [catalogEntry("urn:uuid:a", "A")]
+    };
+    const result = RegistryFeedSchema(feed);
+    expect(result instanceof type.errors).toBe(false);
+  });
+
+  it("preserves extra fields on catalog entries", () => {
+    const feed = {
+      ...minimal(),
+      catalogs: [
+        {
+          ...catalogEntry("urn:uuid:x", "X"),
+          navigation: [{ title: "Nav", href: "/nav" }]
+        }
+      ]
+    };
+    const result = RegistryFeedSchema(feed);
+    expect(result instanceof type.errors).toBe(false);
+    expect((result as any).catalogs[0].navigation).toBeDefined();
+  });
+
+  it("rejects when metadata is missing", () => {
+    const result = RegistryFeedSchema({ links: [] });
+    expect(result instanceof type.errors).toBe(true);
+    expect((result as any).summary).toContain("metadata");
+  });
+
+  it("rejects when metadata.title is missing", () => {
+    const result = RegistryFeedSchema({ metadata: {}, links: [] });
+    expect(result instanceof type.errors).toBe(true);
+    expect((result as any).summary).toContain("title");
+  });
+
+  it("rejects when links is missing", () => {
+    const result = RegistryFeedSchema({ metadata: { title: "X" } });
+    expect(result instanceof type.errors).toBe(true);
+    expect((result as any).summary).toContain("links");
+  });
+
+  it("rejects when a catalog entry is missing metadata", () => {
+    const result = RegistryFeedSchema({
+      ...minimal(),
+      catalogs: [{ links: [] }]
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  it("rejects when a catalog entry metadata is missing required fields", () => {
+    const result = RegistryFeedSchema({
+      ...minimal(),
+      catalogs: [{ metadata: { title: "X" }, links: [] }]
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  it("rejects when a catalog entry is missing links", () => {
+    const result = RegistryFeedSchema({
+      ...minimal(),
+      catalogs: [
+        {
+          metadata: {
+            id: "x",
+            title: "X",
+            updated: "2024-01-01T00:00:00Z"
+          }
+        }
+      ]
+    });
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  it("rejects a completely wrong response", () => {
+    const result = RegistryFeedSchema("not an object");
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  it("rejects null", () => {
+    const result = RegistryFeedSchema(null);
+    expect(result instanceof type.errors).toBe(true);
+  });
+
+  it("rejects an empty object", () => {
+    const result = RegistryFeedSchema({});
+    expect(result instanceof type.errors).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Add runtime validation for library registry feed and authentication document responses using ArkType schemas, complementing the existing compile-time TypeScript types.

- New ArkType schemas in `src/validation/` validate auth document and registry feed responses at the point they are fetched, catching malformed upstream data before it enters the application.
- Schema-derived types for leaf shapes (labels, inputs, localized values, color scheme, features, etc.) replace hand-written interfaces, making the ArkType schemas the single source of truth for those types. Compound types that use CPW-specific narrowing (discriminated auth method union, `AuthDocument` itself) remain hand-written.
- Auth document schema aligned with Palace Manager's `PalaceAuthenticationDocument` Pydantic model, including Palace extension fields (e.g., `features`, `public_key`, `service_description`).
- Registry feed schema aligned with the Library Registry's `OPDSCatalog` output, including `modified` alongside `updated`, nullable `adobe_vendor_id`, `numberOfItems` for paginated feeds, `images` on catalog entries, `properties` on links, and `@type` on facet group metadata.

## Motivation and Context

CPW has TypeScript types enforcing structure at compile time, but no runtime validation of responses from the Circulation Manager (auth documents) or Library Registry (OPDS 2 feeds). A malformed upstream response would silently propagate through the app, potentially causing confusing errors far from the source. Runtime validation catches these at the API boundary and produces clear error messages.

ArkType is already used for config file validation, so this extends the same approach to external API responses. This is foundational work toward making ArkType schemas the single source of truth for related types — deriving TypeScript types directly from the schemas so runtime validation and compile-time type checking stay aligned by default, without the need for manual synchronization.

[Jira PP-4583]

## How Has This Been Tested?

- New test suites in `tests/validation/` cover both schemas: valid documents with all field combinations, rejection of missing required fields, rejection of malformed data (wrong types, null, non-objects).
- Existing tests for `fetchAuthDocument` and `crawlRegistryFeed` updated to use valid response shapes and to verify that invalid responses are rejected with appropriate errors.
- All 803 tests pass across both Jest configurations (JSDOM and Node).
- TypeScript strict-mode typecheck passes.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
