### PR TITLE
Multi-library home page live library filtering (PP-4693)

### DIFF
--- a/src/components/LibraryHomeLink.tsx
+++ b/src/components/LibraryHomeLink.tsx
@@ -11,10 +11,10 @@ export interface LibraryHomeLinkProps {
  * A link to a library's home page from the multi-library selection page.
  * Displays the library's title, if available. Otherwise, falls back to its slug.
  */
-const LibraryHomeLink: React.FC<LibraryHomeLinkProps> = ({ slug, title }) => {
-  const displayText = title || slug;
-
-  return <Link href={`/${slug}`}>{displayText}</Link>;
+const LibraryHomeLink: React.FC<
+  React.PropsWithChildren<LibraryHomeLinkProps>
+> = ({ slug, title, children }) => {
+  return <Link href={`/${slug}`}>{children ?? (title || slug)}</Link>;
 };
 
 export default LibraryHomeLink;

--- a/src/components/MultiLibraryHome.tsx
+++ b/src/components/MultiLibraryHome.tsx
@@ -6,7 +6,11 @@ import useSWR from "swr";
 import { useAppConfig } from "components/context/AppConfigContext";
 import theme from "theme/theme";
 import LibraryHomeLink from "./LibraryHomeLink";
+import TextInput from "components/TextInput";
 import type { ClientLibrary, LibrariesResponse } from "pages/api/libraries";
+
+const FILTER_DEBOUNCE_MS = 200;
+const RESULTS_LIST_ID = "library-filter-results";
 
 async function fetchLibraries(url: string): Promise<LibrariesResponse> {
   const res = await fetch(url);
@@ -14,12 +18,73 @@ async function fetchLibraries(url: string): Promise<LibrariesResponse> {
   return res.json();
 }
 
+/**
+ * Returns the indices of matched characters in `target` (case-insensitive),
+ * or null if not all query characters can be matched in order.
+ * An empty query matches everything and returns [].
+ */
+function fuzzyMatchIndices(query: string, target: string): number[] | null {
+  if (!query) return [];
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  const indices: number[] = [];
+  let qi = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      indices.push(ti);
+      qi++;
+    }
+  }
+  return qi === q.length ? indices : null;
+}
+
+/** Renders `text` with matched characters wrapped in <mark> for search highlighting. */
+const HighlightedText: React.FC<{ text: string; matchIndices: number[] }> = ({
+  text,
+  matchIndices
+}) => {
+  if (matchIndices.length === 0) return <>{text}</>;
+  const set = new Set(matchIndices);
+  const runs: Array<[string, boolean]> = [];
+  for (let i = 0; i < text.length; ) {
+    const hl = set.has(i);
+    let j = i + 1;
+    while (j < text.length && set.has(j) === hl) j++;
+    runs.push([text.slice(i, j), hl]);
+    i = j;
+  }
+  return (
+    <>
+      {runs.map(([chunk, hl], idx) =>
+        hl ? (
+          <mark key={idx} sx={{ bg: "transparent", fontWeight: "bold" }}>
+            {chunk}
+          </mark>
+        ) : (
+          <React.Fragment key={idx}>{chunk}</React.Fragment>
+        )
+      )}
+    </>
+  );
+};
+
 const MultiLibraryHome: React.FC = () => {
   const { instanceName } = useAppConfig();
   const { data, error } = useSWR<LibrariesResponse>(
     "/api/libraries",
     fetchLibraries
   );
+
+  const [inputValue, setInputValue] = React.useState("");
+  const [filterQuery, setFilterQuery] = React.useState("");
+
+  React.useEffect(() => {
+    const timer = setTimeout(
+      () => setFilterQuery(inputValue),
+      FILTER_DEBOUNCE_MS
+    );
+    return () => clearTimeout(timer);
+  }, [inputValue]);
 
   if (error)
     return <p>Unable to load static libraries from configuration file.</p>;
@@ -35,6 +100,19 @@ const MultiLibraryHome: React.FC = () => {
 
   if (sorted.length === 0) return null;
 
+  const filteredWithIndices = sorted.flatMap(lib => {
+    const displayText = lib.title || lib.slug;
+    const matchIndices = fuzzyMatchIndices(filterQuery, displayText);
+    return matchIndices !== null ? [{ lib, displayText, matchIndices }] : [];
+  });
+
+  const resultCount = filteredWithIndices.length;
+  const statusMessage = filterQuery
+    ? resultCount === 0
+      ? "No libraries match."
+      : `${resultCount} ${resultCount === 1 ? "library" : "libraries"} shown`
+    : "";
+
   return (
     <ThemeUIProvider theme={theme}>
       <Themed.root
@@ -46,11 +124,45 @@ const MultiLibraryHome: React.FC = () => {
         }}
       >
         <h1>{instanceName} Home</h1>
-        <h3>Choose a library:</h3>
-        <ul>
-          {sorted.map(lib => (
+        <h2>Choose a library:</h2>
+        <div sx={{ display: "inline-block", width: "44ch", mb: 2 }}>
+          <TextInput
+            type="search"
+            aria-label="Filter libraries"
+            aria-controls={RESULTS_LIST_ID}
+            placeholder="Filter libraries..."
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+          />
+        </div>
+        {/* Always in the DOM so screen readers register the live region before content changes. */}
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          sx={{
+            position: "absolute",
+            width: "1px",
+            height: "1px",
+            overflow: "hidden",
+            clip: "rect(0,0,0,0)",
+            whiteSpace: "nowrap"
+          }}
+        >
+          {statusMessage}
+        </div>
+        {filterQuery && resultCount === 0 && (
+          <p sx={{ pl: 2 }}>No libraries match.</p>
+        )}
+        <ul id={RESULTS_LIST_ID}>
+          {filteredWithIndices.map(({ lib, displayText, matchIndices }) => (
             <li key={lib.slug}>
-              <LibraryHomeLink slug={lib.slug} title={lib.title} />
+              <LibraryHomeLink slug={lib.slug} title={lib.title}>
+                <HighlightedText
+                  text={displayText}
+                  matchIndices={matchIndices}
+                />
+              </LibraryHomeLink>
             </li>
           ))}
         </ul>

--- a/src/components/MultiLibraryHome.tsx
+++ b/src/components/MultiLibraryHome.tsx
@@ -38,6 +38,54 @@ function fuzzyMatchIndices(query: string, target: string): number[] | null {
   return qi === q.length ? indices : null;
 }
 
+export type MatchResult = { score: number; matchIndices: number[] };
+
+/**
+ * Scores how well `query` matches `target` and returns the character indices
+ * to highlight, anchored to the best match position.
+ *
+ * Tiers (higher is better):
+ *   100 — exact match
+ *    80 — target starts with query
+ *    60 — any word in target starts with query
+ *    40 — target contains query as a substring
+ *    20 — fuzzy (all query chars appear in order)
+ *     0 — no match
+ */
+export function scoreMatch(query: string, target: string): MatchResult {
+  const noMatch: MatchResult = { score: 0, matchIndices: [] };
+  if (!query) return noMatch;
+
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  const contiguous = (start: number) =>
+    Array.from({ length: q.length }, (_, i) => start + i);
+
+  if (t.startsWith(q)) {
+    return { score: t === q ? 100 : 80, matchIndices: contiguous(0) };
+  }
+
+  let offset = 0;
+  while (offset < t.length) {
+    while (offset < t.length && /\W/.test(t[offset])) offset++;
+    const wordStart = offset;
+    while (offset < t.length && /\w/.test(t[offset])) offset++;
+    if (offset > wordStart && t.slice(wordStart, offset).startsWith(q)) {
+      return { score: 60, matchIndices: contiguous(wordStart) };
+    }
+  }
+
+  const substringIdx = t.indexOf(q);
+  if (substringIdx !== -1) {
+    return { score: 40, matchIndices: contiguous(substringIdx) };
+  }
+
+  const fuzzyIndices = fuzzyMatchIndices(query, target);
+  return fuzzyIndices !== null
+    ? { score: 20, matchIndices: fuzzyIndices }
+    : noMatch;
+}
+
 /** Renders `text` with matched characters wrapped in <mark> for search highlighting. */
 const HighlightedText: React.FC<{ text: string; matchIndices: number[] }> = ({
   text,
@@ -100,17 +148,29 @@ const MultiLibraryHome: React.FC = () => {
 
   if (sorted.length === 0) return null;
 
-  const filteredWithIndices = sorted.flatMap(lib => {
+  const filteredWithScores = sorted.flatMap(lib => {
     const displayText = lib.title || lib.slug;
-    const matchIndices = fuzzyMatchIndices(filterQuery, displayText);
-    return matchIndices !== null ? [{ lib, displayText, matchIndices }] : [];
+    const { score, matchIndices } = filterQuery
+      ? scoreMatch(filterQuery, displayText)
+      : { score: 0, matchIndices: [] };
+    if (filterQuery && score === 0) return [];
+    return [{ lib, displayText, matchIndices, score }];
   });
 
-  const resultCount = filteredWithIndices.length;
+  const displayed = filterQuery
+    ? [...filteredWithScores].sort(
+        (a, b) =>
+          b.score - a.score || a.displayText.localeCompare(b.displayText)
+      )
+    : filteredWithScores;
+
+  const resultCount = displayed.length;
   const statusMessage = filterQuery
     ? resultCount === 0
       ? "No libraries match."
-      : `${resultCount} ${resultCount === 1 ? "library" : "libraries"} shown`
+      : `${resultCount} ${
+          resultCount === 1 ? "library" : "libraries"
+        } shown, best matches first`
     : "";
 
   return (
@@ -155,7 +215,7 @@ const MultiLibraryHome: React.FC = () => {
           <p sx={{ pl: 2 }}>No libraries match.</p>
         )}
         <ul id={RESULTS_LIST_ID}>
-          {filteredWithIndices.map(({ lib, displayText, matchIndices }) => (
+          {displayed.map(({ lib, displayText, matchIndices }) => (
             <li key={lib.slug}>
               <LibraryHomeLink slug={lib.slug} title={lib.title}>
                 <HighlightedText

--- a/src/components/__tests__/MultiLibraryHome.test.tsx
+++ b/src/components/__tests__/MultiLibraryHome.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "test-utils";
+import { render, screen, fireEvent, act } from "test-utils";
 import MultiLibraryHome from "../MultiLibraryHome";
 import useSWR from "swr";
 import { makeSwrResponse } from "test-utils/mockSwr";
@@ -122,5 +122,245 @@ describe("MultiLibraryHome", () => {
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
       "My Custom Instance Home"
     );
+  });
+
+  it("uses h2 for the sub-heading to maintain heading hierarchy", () => {
+    mockLibraries([lib("test", "Test Library")]);
+    render(<MultiLibraryHome />);
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Choose a library:"
+    );
+  });
+
+  describe("library filter input", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
+
+    it("renders a filter input", () => {
+      mockLibraries([lib("alpha", "Alpha Library")]);
+      render(<MultiLibraryHome />);
+      expect(
+        screen.getByRole("searchbox", { name: /filter libraries/i })
+      ).toBeInTheDocument();
+    });
+
+    it("filter input has aria-controls pointing to the results list", () => {
+      mockLibraries([lib("alpha", "Alpha Library")]);
+      render(<MultiLibraryHome />);
+      const input = screen.getByRole("searchbox", {
+        name: /filter libraries/i
+      });
+      const listId = input.getAttribute("aria-controls");
+      expect(listId).toBeTruthy();
+      expect(document.getElementById(listId!)).toBe(screen.getByRole("list"));
+    });
+
+    it("shows all libraries when filter is empty", () => {
+      mockLibraries([
+        lib("alpha", "Alpha Library"),
+        lib("beta", "Beta Library")
+      ]);
+      render(<MultiLibraryHome />);
+      expect(screen.getAllByRole("link")).toHaveLength(2);
+    });
+
+    it("narrows the list after the debounce delay", () => {
+      mockLibraries([
+        lib("alpha", "Alpha Library"),
+        lib("beta", "Beta Library"),
+        lib("gamma", "Gamma Library")
+      ]);
+      render(<MultiLibraryHome />);
+
+      fireEvent.change(
+        screen.getByRole("searchbox", { name: /filter libraries/i }),
+        {
+          target: { value: "alp" }
+        }
+      );
+
+      // Before debounce fires the list should be unfiltered.
+      expect(screen.getAllByRole("link")).toHaveLength(3);
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(screen.getAllByRole("link")).toHaveLength(1);
+      expect(screen.getByRole("link")).toHaveTextContent("Alpha Library");
+    });
+
+    it("uses fuzzy matching (non-contiguous characters)", () => {
+      mockLibraries([
+        lib("alpha", "Alpha Library"),
+        lib("beta", "Beta Library"),
+        lib("gamma", "Gamma Library")
+      ]);
+      render(<MultiLibraryHome />);
+
+      // "py" matches "al[p]ha librar[y]" but not Beta/Gamma (no 'p').
+      fireEvent.change(
+        screen.getByRole("searchbox", { name: /filter libraries/i }),
+        {
+          target: { value: "py" }
+        }
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(screen.getAllByRole("link")).toHaveLength(1);
+      expect(screen.getByRole("link")).toHaveTextContent("Alpha Library");
+    });
+
+    it("shows no results when filter matches nothing", () => {
+      mockLibraries([
+        lib("alpha", "Alpha Library"),
+        lib("beta", "Beta Library")
+      ]);
+      render(<MultiLibraryHome />);
+
+      fireEvent.change(
+        screen.getByRole("searchbox", { name: /filter libraries/i }),
+        {
+          target: { value: "zzz" }
+        }
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(screen.queryAllByRole("link")).toHaveLength(0);
+      // Message appears in both the visible <p> and the visually-hidden live region.
+      expect(screen.getAllByText("No libraries match.")).toHaveLength(2);
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "No libraries match."
+      );
+    });
+
+    it("restores the full list when filter is cleared", () => {
+      mockLibraries([
+        lib("alpha", "Alpha Library"),
+        lib("beta", "Beta Library")
+      ]);
+      render(<MultiLibraryHome />);
+
+      const input = screen.getByRole("searchbox", {
+        name: /filter libraries/i
+      });
+
+      fireEvent.change(input, { target: { value: "alp" } });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(screen.getAllByRole("link")).toHaveLength(1);
+
+      fireEvent.change(input, { target: { value: "" } });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(screen.getAllByRole("link")).toHaveLength(2);
+    });
+
+    it("announces result count in a live region after debounce", () => {
+      mockLibraries([
+        lib("alpha", "Alpha Library"),
+        lib("beta", "Beta Library"),
+        lib("gamma", "Gamma Library")
+      ]);
+      render(<MultiLibraryHome />);
+
+      // No announcement when filter is empty.
+      const status = screen.getByRole("status");
+      expect(status).toHaveTextContent("");
+
+      fireEvent.change(
+        screen.getByRole("searchbox", { name: /filter libraries/i }),
+        {
+          target: { value: "alp" }
+        }
+      );
+
+      // No announcement yet — debounce hasn't fired.
+      expect(status).toHaveTextContent("");
+
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(status).toHaveTextContent("1 library shown");
+    });
+
+    it("announces plural form when multiple results remain", () => {
+      mockLibraries([
+        lib("alpha", "Alpha Library"),
+        lib("albany", "Albany Library")
+      ]);
+      render(<MultiLibraryHome />);
+
+      fireEvent.change(
+        screen.getByRole("searchbox", { name: /filter libraries/i }),
+        {
+          target: { value: "al" }
+        }
+      );
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      expect(screen.getByRole("status")).toHaveTextContent("2 libraries shown");
+    });
+
+    it("clears the status message when the filter is emptied", () => {
+      mockLibraries([lib("alpha", "Alpha Library")]);
+      render(<MultiLibraryHome />);
+
+      const input = screen.getByRole("searchbox", {
+        name: /filter libraries/i
+      });
+
+      fireEvent.change(input, { target: { value: "alp" } });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(screen.getByRole("status")).toHaveTextContent("1 library shown");
+
+      fireEvent.change(input, { target: { value: "" } });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+      expect(screen.getByRole("status")).toHaveTextContent("");
+    });
+
+    it("highlights matched characters using <mark> elements", async () => {
+      mockLibraries([lib("alpha", "Alpha Library")]);
+      render(<MultiLibraryHome />);
+
+      // No filter active — no <mark> elements.
+      expect(screen.getByRole("link").querySelectorAll("mark")).toHaveLength(0);
+
+      fireEvent.change(
+        screen.getByRole("searchbox", { name: /filter libraries/i }),
+        {
+          target: { value: "alp" }
+        }
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(200);
+      });
+
+      const link = screen.getByRole("link");
+      expect(link.querySelectorAll("mark").length).toBeGreaterThan(0);
+      expect(link.textContent).toBe("Alpha Library");
+    });
   });
 });

--- a/src/components/__tests__/MultiLibraryHome.test.tsx
+++ b/src/components/__tests__/MultiLibraryHome.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { render, screen, fireEvent, act } from "test-utils";
-import MultiLibraryHome from "../MultiLibraryHome";
+import MultiLibraryHome, { scoreMatch } from "../MultiLibraryHome";
 import useSWR from "swr";
 import { makeSwrResponse } from "test-utils/mockSwr";
 import type { LibrariesResponse } from "pages/api/libraries";
@@ -21,6 +21,74 @@ function lib(slug: string, title?: string) {
     authDocUrl: `https://example.com/${slug}/auth`
   };
 }
+
+describe("scoreMatch", () => {
+  it("returns score 0 and no indices for an empty query", () => {
+    expect(scoreMatch("", "Illinois State Library")).toEqual({
+      score: 0,
+      matchIndices: []
+    });
+  });
+
+  it("returns score 100 and full indices for an exact match", () => {
+    expect(scoreMatch("illinois", "Illinois")).toEqual({
+      score: 100,
+      matchIndices: [0, 1, 2, 3, 4, 5, 6, 7]
+    });
+  });
+
+  it("returns score 80 and leading indices when target starts with query", () => {
+    expect(scoreMatch("ill", "Illinois State Library")).toEqual({
+      score: 80,
+      matchIndices: [0, 1, 2]
+    });
+  });
+
+  it("returns score 60 and indices at the matching word when a word starts with query", () => {
+    // "Illinois" starts at index 14 in "Northern Illinois University"
+    //  N o r t h e r n   I  l  l  i  n  o  i  s
+    //  0 1 2 3 4 5 6 7 8 9 10 11 ...
+    const { score, matchIndices } = scoreMatch(
+      "ill",
+      "Northern Illinois University"
+    );
+    expect(score).toBe(60);
+    expect(matchIndices).toEqual([9, 10, 11]);
+  });
+
+  it("anchors indices to the matching word, not an earlier fuzzy opportunity", () => {
+    // "RAILS" contains 'i' and 'l' before "Illinois", but the word match wins.
+    const { score, matchIndices } = scoreMatch(
+      "ill",
+      "RAILS eRead Illinois Library"
+    );
+    expect(score).toBe(60);
+    // "Illinois" starts at index 12 in the lowercased string
+    expect(matchIndices).toEqual([12, 13, 14]);
+  });
+
+  it("returns score 40 and substring indices when query appears as a substring", () => {
+    // "ill" appears inside "Millbrook" at index 1
+    expect(scoreMatch("ill", "Millbrook Library")).toEqual({
+      score: 40,
+      matchIndices: [1, 2, 3]
+    });
+  });
+
+  it("returns score 20 and fuzzy indices for a non-contiguous match", () => {
+    // "ill" in "Tidal Library": i→1, l→4, l→6 (T-i-d-a-l- -L-i...)
+    const { score, matchIndices } = scoreMatch("ill", "Tidal Library");
+    expect(score).toBe(20);
+    expect(matchIndices).toEqual([1, 4, 6]);
+  });
+
+  it("returns score 0 and no indices when there is no match", () => {
+    expect(scoreMatch("zzz", "Alpha Library")).toEqual({
+      score: 0,
+      matchIndices: []
+    });
+  });
+});
 
 describe("MultiLibraryHome", () => {
   afterEach(() => {
@@ -246,6 +314,54 @@ describe("MultiLibraryHome", () => {
       );
     });
 
+    it("sorts alphabetically within the same relevance tier", () => {
+      // Both start with "ill" (tier 80), so alpha order should apply within the tier.
+      mockLibraries([
+        lib("illinois-state", "Illinois State Library"),
+        lib("illinois-central", "Illinois Central Library")
+      ]);
+      render(<MultiLibraryHome />);
+
+      fireEvent.change(
+        screen.getByRole("searchbox", { name: /filter libraries/i }),
+        { target: { value: "ill" } }
+      );
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      const links = screen.getAllByRole("link");
+      expect(links[0]).toHaveTextContent("Illinois Central Library");
+      expect(links[1]).toHaveTextContent("Illinois State Library");
+    });
+
+    it("orders filtered results by relevance (highest first), overriding alpha order", () => {
+      // Alphabetical order: East Illinois, Illinois State, Millbrook, Tidal
+      // Relevance order for "ill": Illinois State (starts-with, 80), East Illinois
+      //   (word-starts-with, 60), Millbrook (contains, 40), Tidal (fuzzy, 20)
+      mockLibraries([
+        lib("tidal", "Tidal Library"),
+        lib("millbrook", "Millbrook Library"),
+        lib("east-illinois", "East Illinois Library"),
+        lib("illinois-state", "Illinois State Library")
+      ]);
+      render(<MultiLibraryHome />);
+
+      fireEvent.change(
+        screen.getByRole("searchbox", { name: /filter libraries/i }),
+        { target: { value: "ill" } }
+      );
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      const links = screen.getAllByRole("link");
+      expect(links[0]).toHaveTextContent("Illinois State Library");
+      expect(links[1]).toHaveTextContent("East Illinois Library");
+      expect(links[2]).toHaveTextContent("Millbrook Library");
+      expect(links[3]).toHaveTextContent("Tidal Library");
+    });
+
     it("restores the full list when filter is cleared", () => {
       mockLibraries([
         lib("alpha", "Alpha Library"),
@@ -296,7 +412,7 @@ describe("MultiLibraryHome", () => {
         jest.advanceTimersByTime(200);
       });
 
-      expect(status).toHaveTextContent("1 library shown");
+      expect(status).toHaveTextContent("1 library shown, best matches first");
     });
 
     it("announces plural form when multiple results remain", () => {
@@ -316,7 +432,9 @@ describe("MultiLibraryHome", () => {
         jest.advanceTimersByTime(200);
       });
 
-      expect(screen.getByRole("status")).toHaveTextContent("2 libraries shown");
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "2 libraries shown, best matches first"
+      );
     });
 
     it("clears the status message when the filter is emptied", () => {
@@ -331,7 +449,9 @@ describe("MultiLibraryHome", () => {
       act(() => {
         jest.advanceTimersByTime(200);
       });
-      expect(screen.getByRole("status")).toHaveTextContent("1 library shown");
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "1 library shown, best matches first"
+      );
 
       fireEvent.change(input, { target: { value: "" } });
       act(() => {
@@ -361,6 +481,31 @@ describe("MultiLibraryHome", () => {
       const link = screen.getByRole("link");
       expect(link.querySelectorAll("mark").length).toBeGreaterThan(0);
       expect(link.textContent).toBe("Alpha Library");
+    });
+
+    it("highlights the best-match word, not the first fuzzy opportunity", async () => {
+      // Searching "ill" in "RAILS eRead Illinois Library":
+      // A greedy fuzzy scan would highlight 'il' from "RAILS" and 'l' from "Illinois".
+      // bestMatchIndices should instead highlight 'ill' from "Illinois".
+      mockLibraries([lib("rails-illinois", "RAILS eRead Illinois Library")]);
+      render(<MultiLibraryHome />);
+
+      fireEvent.change(
+        screen.getByRole("searchbox", { name: /filter libraries/i }),
+        { target: { value: "ill" } }
+      );
+      await act(async () => {
+        jest.advanceTimersByTime(200);
+      });
+
+      const link = screen.getByRole("link");
+      const marks = link.querySelectorAll("mark");
+      // All highlighted characters should come from a single contiguous run in "Illinois".
+      expect(
+        Array.from(marks)
+          .map(m => m.textContent)
+          .join("")
+      ).toBe("Ill");
     });
   });
 });


### PR DESCRIPTION
## Description

- Adds a live-filter input to the multi-library home page. As the patron types, the library is narrowed and sorted by relevance tier and library name using fuzzy character matching with a 200 ms debounce. Matched characters are bolded in each result. When no libraries match the query, a "No libraries match." message replaces the list. 
- For accessibility:
  - A visually-hidden ARIA live region announces the result count (and "best matches first") to screen readers after each debounce cycle.
  - Also fixes a heading hierarchy issue: the "Choose a library:" subheading was `<h3>` and is now `<h2>`.

## Motivation and Context

On deployments with many libraries, the home page presents a long, undifferentiated list that patrons must scroll through manually. Filtering makes it faster and easier to find a specific library by shortening the list.

[Jira PP-4693]

## How Has This Been Tested?

- Manually verified in browser in local dev environment: progressive narrowing, bold highlighting, "No libraries match." message, and native search-input clear button.
- New and updated tests to cover the new functionality.
- All tests and checks pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/28474573760) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
