### PR TITLE
Clean up test output for expected errors/warnings (PP-4714)

### DIFF
--- a/src/auth/__tests__/BasicTokenAuthHandler.test.tsx
+++ b/src/auth/__tests__/BasicTokenAuthHandler.test.tsx
@@ -14,16 +14,24 @@ import mockAuthenticated, {
   tokenCreds1
 } from "test-utils/mockAuthState";
 import { generateCredentials } from "utils/auth";
+import { expectAndSuppressConsole } from "test-utils/suppressConsole";
 
 beforeEach(() => {
   jest.useFakeTimers();
   const mockedDate = expirationDate;
   jest.spyOn(Date, "now").mockImplementation(() => mockedDate.getTime());
+  expectAndSuppressConsole(
+    "warn",
+    "Failed to fetch patron profile:",
+    "Server Error: Access token expired:",
+    "The patron authentication access token has expired."
+  );
   fetchMock.resetMocks();
 });
 
 afterEach(() => {
   jest.useRealTimers();
+  jest.restoreAllMocks();
 });
 
 test("displays form", async () => {

--- a/src/components/__tests__/AccountMenu.test.tsx
+++ b/src/components/__tests__/AccountMenu.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { render, waitFor, fireEvent } from "../../test-utils";
 import { AccountMenu } from "../AccountMenu";
+import { expectAndSuppressConsole } from "../../test-utils/suppressConsole";
 
 function setup(overrideOptions: any = {}) {
   const userEvent = require("@testing-library/user-event").default;
@@ -160,6 +161,11 @@ describe("AccountMenu", () => {
     );
     // Also mock legacy fallback to fail
     document.execCommand = jest.fn(() => false);
+    const errorSpy = expectAndSuppressConsole(
+      "error",
+      "Clipboard API failed:",
+      "Error: Clipboard API not available"
+    );
 
     const { user, getByRole, getByTestId, findByText } = setup({
       user: { isAuthenticated: true, patronId: "test-patron-12345" },
@@ -173,6 +179,7 @@ describe("AccountMenu", () => {
     fireEvent.click(patronIdButton);
 
     expect(await findByText("Failed")).toBeInTheDocument();
+    errorSpy.mockRestore();
   });
 
   it("clears copy status after 2 seconds on success", async () => {
@@ -211,6 +218,11 @@ describe("AccountMenu", () => {
       new Error("Clipboard API not available")
     );
     document.execCommand = jest.fn(() => false);
+    const errorSpy = expectAndSuppressConsole(
+      "error",
+      "Clipboard API failed:",
+      "Error: Clipboard API not available"
+    );
 
     const { user, getByRole, getByTestId, queryByText } = setup({
       user: { isAuthenticated: true, patronId: "test-patron-12345" },
@@ -234,6 +246,7 @@ describe("AccountMenu", () => {
     // "Failed" should be gone
     expect(queryByText("Failed")).not.toBeInTheDocument();
 
+    errorSpy.mockRestore();
     jest.useRealTimers();
   });
 });

--- a/src/dataflow/__tests__/download.test.ts
+++ b/src/dataflow/__tests__/download.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, test } from "@jest/globals";
 import fetchMock from "jest-fetch-mock";
 import downloadFile from "../download";
+import { expectAndSuppressConsole } from "test-utils/suppressConsole";
 
 describe("downloadFile", () => {
+  beforeEach(() => {
+    expectAndSuppressConsole(
+      "warn",
+      "only proceeded after retry without X-Requested-With header. " +
+        "Distributor may not allow X-Requested-With for CORS."
+    );
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
   test("should fetch the url with the supplied token", async () => {
     fetchMock.mockResponseOnce("nice job");
 

--- a/src/server/__tests__/appConfig.test.ts
+++ b/src/server/__tests__/appConfig.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../appConfig";
 import { AppSetupError } from "errors";
 import { DEFAULT_REGISTRY_FETCH_TIMEOUT } from "constants/registry";
+import { expectAndSuppressConsole } from "test-utils/suppressConsole";
 
 jest.mock("fs", () => ({ readFileSync: jest.fn() }));
 
@@ -515,6 +516,17 @@ describe("config parsing", () => {
   // --- deprecated string libraries field ---
 
   describe("deprecated libraries field", () => {
+    let warnSpy: jest.SpyInstance;
+    beforeEach(() => {
+      warnSpy = expectAndSuppressConsole(
+        "warn",
+        "WARNING: Using a string for 'libraries' in config is deprecated. " +
+          "Please migrate to the 'registries' array format. " +
+          "See the 'Libraries and Registries Configuration Settings' section in README.md."
+      );
+    });
+    afterEach(() => warnSpy.mockRestore());
+
     it("adds a string libraries value as a registry entry", async () => {
       const config = await load(`libraries: https://old.example.com/libs`);
       expect(config.registries).toEqual([
@@ -527,14 +539,10 @@ describe("config parsing", () => {
     });
 
     it("emits a deprecation warning when string libraries is used", async () => {
-      const warnSpy = jest
-        .spyOn(console, "warn")
-        .mockImplementation(() => undefined);
       await load(`libraries: https://old.example.com/libs`);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("deprecated")
       );
-      warnSpy.mockRestore();
     });
 
     it("appends the string libraries entry after explicit registries", async () => {
@@ -596,6 +604,20 @@ describe("config parsing", () => {
   // --- libraries ---
 
   describe("libraries", () => {
+    let warnSpy: jest.SpyInstance;
+    beforeEach(() => {
+      warnSpy = expectAndSuppressConsole(
+        "warn",
+        "WARNING: Using a string for 'libraries' in config is deprecated. " +
+          "Please migrate to the 'registries' array format. " +
+          "See the 'Libraries and Registries Configuration Settings' section in README.md.",
+        "WARNING: Using an object for 'libraries' to define static libraries is deprecated. " +
+          "Please rename it to 'static_libraries'. " +
+          "See the 'Libraries and Registries Configuration Settings' section in README.md."
+      );
+    });
+    afterEach(() => warnSpy.mockRestore());
+
     it.each([
       ["absent", MINIMAL_YAML],
       [
@@ -707,14 +729,10 @@ describe("config parsing", () => {
     });
 
     it("emits a deprecation warning when an object is used", async () => {
-      const warnSpy = jest
-        .spyOn(console, "warn")
-        .mockImplementation(() => undefined);
       await load("libraries:\n  my-lib: https://example.com/auth");
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining("deprecated")
       );
-      warnSpy.mockRestore();
     });
 
     it("throws AppSetupError when both libraries object and staticLibraries are set", async () => {

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL,
   DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL
 } from "constants/registry";
+import { expectAndSuppressConsole } from "test-utils/suppressConsole";
 
 // ---------------------------------------------------------------------------
 // Test infrastructure
@@ -249,7 +250,18 @@ describe("shouldRefresh", () => {
 // ---------------------------------------------------------------------------
 
 describe("fetchRegistryLibraries", () => {
-  beforeEach(() => resetRegistryCaches());
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetRegistryCaches();
+    warnSpy = expectAndSuppressConsole(
+      "warn",
+      "Skipping library missing auth document link:",
+      "Skipping library with invalid slug"
+    );
+  });
+
+  afterEach(() => warnSpy.mockRestore());
 
   it("returns a LibrariesConfig from a valid single-page feed", async () => {
     const feed = makePagedFeed([
@@ -384,9 +396,6 @@ describe("fetchRegistryLibraries", () => {
       { id: "", title: "Empty Slug", authDocUrl: "https://b.example.com/" }
     ]);
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
-    const warnSpy = jest
-      .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
 
     const result = await fetchRegistryLibraries(REGISTRY_URL);
 
@@ -406,9 +415,22 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
   const OLD_TIMESTAMP = new Date((NOW_SECONDS - 1000) * 1000).toISOString();
   const NEW_TIMESTAMP = new Date((NOW_SECONDS + 1000) * 1000).toISOString();
 
+  let warnSpy: jest.SpyInstance;
+
   beforeEach(() => {
     resetRegistryCaches();
     jest.spyOn(Date, "now").mockReturnValue(NOW_SECONDS * 1000);
+    warnSpy = expectAndSuppressConsole(
+      "warn",
+      "has no order=modified facet; incremental fetching is not supported. " +
+        "Full crawls will run every refresh."
+    );
+    expectAndSuppressConsole(
+      "error",
+      "Failed to refresh registry",
+      "Registry fetch failed for",
+      "500 Internal Server Error"
+    );
   });
 
   afterEach(() => jest.restoreAllMocks());
@@ -661,9 +683,6 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
       // no incrementalFacetHref
     );
     global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
-    const warnSpy = jest
-      .spyOn(console, "warn")
-      .mockImplementation(() => undefined);
 
     await getLibraries(makeConfig({ registries: [makeIncrementalConfig()] }));
 
@@ -779,9 +798,18 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 // ---------------------------------------------------------------------------
 
 describe("getLibraries", () => {
+  let warnSpy: jest.SpyInstance;
+
   beforeEach(() => {
     resetRegistryCaches();
+    warnSpy = expectAndSuppressConsole(
+      "warn",
+      "has no order=modified facet; incremental fetching is not supported. " +
+        "Full crawls will run every refresh."
+    );
   });
+
+  afterEach(() => warnSpy.mockRestore());
 
   it("returns static libraries when no registries are configured", async () => {
     const staticLibraries = {
@@ -904,7 +932,20 @@ describe("getLibraries", () => {
 describe("concurrent first-fetch coalescing", () => {
   beforeEach(() => {
     resetRegistryCaches();
+    expectAndSuppressConsole(
+      "warn",
+      "has no order=modified facet; incremental fetching is not supported. " +
+        "Full crawls will run every refresh."
+    );
+    expectAndSuppressConsole(
+      "error",
+      "Failed to refresh registry",
+      "Registry fetch failed for",
+      "503 Service Unavailable"
+    );
   });
+
+  afterEach(() => jest.restoreAllMocks());
 
   it("concurrent getLibraries calls both receive the fetched libraries, not an empty list", async () => {
     /*
@@ -989,7 +1030,14 @@ describe("concurrent first-fetch coalescing", () => {
 // ---------------------------------------------------------------------------
 
 describe("fetch timeout", () => {
-  beforeEach(() => resetRegistryCaches());
+  beforeEach(() => {
+    resetRegistryCaches();
+    expectAndSuppressConsole(
+      "error",
+      "Failed to refresh registry",
+      "The operation was aborted."
+    );
+  });
 
   afterEach(() => {
     jest.useRealTimers();

--- a/src/test-utils/suppressConsole.ts
+++ b/src/test-utils/suppressConsole.ts
@@ -1,0 +1,26 @@
+/**
+ * Spy on console[method], silently dropping messages that match any of the
+ * given patterns. Everything else passes through to the real implementation so
+ * unexpected output remains visible during the test run.
+ *
+ * Returns the spy so callers can assert on `.toHaveBeenCalledWith` when
+ * verifying that an expected message was actually produced.
+ *
+ * Restore with `spy.mockRestore()` or `jest.restoreAllMocks()` in afterEach.
+ */
+export function expectAndSuppressConsole(
+  method: "warn" | "error",
+  ...patterns: Array<string | RegExp>
+): jest.SpyInstance {
+  const original = console[method].bind(console);
+  return jest.spyOn(console, method).mockImplementation((...args) => {
+    const text = args.map(a => String(a)).join(" ");
+    if (
+      patterns.some(p =>
+        p instanceof RegExp ? p.test(text) : text.includes(p)
+      )
+    )
+      return;
+    original(...args);
+  });
+}

--- a/src/utils/__tests__/clipboard.test.ts
+++ b/src/utils/__tests__/clipboard.test.ts
@@ -1,4 +1,5 @@
 import { copyToClipboard } from "../clipboard";
+import { expectAndSuppressConsole } from "test-utils/suppressConsole";
 
 describe("clipboard utility", () => {
   let originalNavigator: Navigator;
@@ -13,6 +14,15 @@ describe("clipboard utility", () => {
       value: true,
       configurable: true
     });
+
+    expectAndSuppressConsole(
+      "error",
+      "Clipboard API failed:",
+      "Legacy clipboard copy failed:",
+      "Error: Clipboard API failed",
+      "Error: execCommand not supported",
+      "Error: execCommand failed"
+    );
 
     // Clear mocks between tests
     jest.clearAllMocks();

--- a/tests/pages/api/libraries.test.ts
+++ b/tests/pages/api/libraries.test.ts
@@ -23,6 +23,7 @@ jest.mock("server/appConfig", () => ({
 import { getLibraries } from "server/libraryRegistry";
 import { getAppConfig } from "server/appConfig";
 import handler from "pages/api/libraries";
+import { expectAndSuppressConsole } from "test-utils/suppressConsole";
 
 const mockGetLibraries = getLibraries as jest.MockedFunction<
   typeof getLibraries
@@ -59,10 +60,20 @@ function makeRes() {
 // ---------------------------------------------------------------------------
 
 describe("GET /api/libraries", () => {
+  let errorSpy: jest.SpyInstance;
+
   beforeEach(() => {
+    errorSpy = expectAndSuppressConsole(
+      "error",
+      "GET /api/libraries failed:",
+      "Error: CONFIG_FILE not set",
+      "Error: Registry unavailable"
+    );
     mockGetAppConfig.mockResolvedValue(VALID_APP_CONFIG);
     jest.clearAllMocks();
   });
+
+  afterEach(() => errorSpy.mockRestore());
 
   it("returns 200 with an array of client-safe library objects", async () => {
     mockGetLibraries.mockResolvedValue({


### PR DESCRIPTION
## Description

- Adds a shared `expectAndSuppressConsole` test helper that spies on `console.warn`/`console.error`, suppresses messages matching expected patterns, and passes everything else through — so unexpected output (e.g., mismatched error messages or test code errors) remains visible.
- Refactors inline per-test spy setup/teardown into describe-level `beforeEach`/`afterEach` blocks across several test files.
- Patterns at each call site include the full expected message content (including error object strings), serving as inline documentation of what output is expected.

## Motivation and Context

Tests exercising error-handling paths were emitting expected `console.warn`/`console.error` output with multi-line stack traces on every run, making it harder to spot real failures. Blanket suppression was not acceptable because some console output (like React `act()` warnings) reflects genuine test quality issues.

[Jira PP-4714]

## How Has This Been Tested?

Changes are limited to test infrastructure — no production code was modified. The existing test suite validates that affected code paths still produce expected output (spy-call assertions remain where tests verify the warning was actually produced).

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
