### PR TITLE
Fix test quality issues (PP-4714)

### DIFF
--- a/src/components/__tests__/AccountMenu.test.tsx
+++ b/src/components/__tests__/AccountMenu.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, waitFor, fireEvent } from "../../test-utils";
+import { render, waitFor, fireEvent, act } from "../../test-utils";
 import { AccountMenu } from "../AccountMenu";
 
 function setup(overrideOptions: any = {}) {
@@ -170,7 +170,7 @@ describe("AccountMenu", () => {
     const patronIdButton = getByTestId("patron-id-menuitem").querySelector(
       "button"
     ) as HTMLButtonElement;
-    fireEvent.click(patronIdButton);
+    await user.click(patronIdButton);
 
     expect(await findByText("Failed")).toBeInTheDocument();
   });
@@ -187,7 +187,7 @@ describe("AccountMenu", () => {
     const patronIdButton = getByTestId("patron-id-menuitem").querySelector(
       "button"
     ) as HTMLButtonElement;
-    fireEvent.click(patronIdButton);
+    await user.click(patronIdButton);
 
     // Wait for "Copied!" to appear
     await waitFor(() => {
@@ -195,7 +195,7 @@ describe("AccountMenu", () => {
     });
 
     // Fast-forward 2 seconds
-    jest.advanceTimersByTime(2000);
+    await act(async () => jest.advanceTimersByTime(2000));
 
     // "Copied!" should be gone
     expect(queryByText("Copied!")).not.toBeInTheDocument();
@@ -221,7 +221,7 @@ describe("AccountMenu", () => {
     const patronIdButton = getByTestId("patron-id-menuitem").querySelector(
       "button"
     ) as HTMLButtonElement;
-    fireEvent.click(patronIdButton);
+    await user.click(patronIdButton);
 
     // Wait for "Failed" to appear
     await waitFor(() => {
@@ -229,7 +229,7 @@ describe("AccountMenu", () => {
     });
 
     // Fast-forward 2 seconds
-    jest.advanceTimersByTime(2000);
+    await act(async () => jest.advanceTimersByTime(2000));
 
     // "Failed" should be gone
     expect(queryByText("Failed")).not.toBeInTheDocument();


### PR DESCRIPTION
## Description

- Replaces `fireEvent.click` with `await user.click` in three tests where the clipboard operation is asynchronous.
- Wraps `jest.advanceTimersByTime` in `await act(...)` in two fake-timer tests.

## Motivation and Context

Several `AccountMenu` tests were producing React `act()` warnings due to async state updates not being properly wrapped. These are real test quality issues, not noise, indicating that component updates were happening after the test framework had relinquished control.
- `fireEvent.click`: the resulting state update was occurring outside of `act`.
-  Advancing timers fires internal state updates need to be inside `act`.

[Jira PP-4714]

## How Has This Been Tested?

- The fix is in the test file itself. 
- All tests pass locally with no `act()` warnings.
- [CI tests](https://github.com/ThePalaceProject/web-patron/actions/runs/28490464588/job/84445827480) pass with no `act()` warnings. 

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.