### PR TITLE
Code review feedback from #153 (PP-4693)

### DIFF
--- a/src/components/MultiLibraryHome.tsx
+++ b/src/components/MultiLibraryHome.tsx
@@ -200,14 +200,7 @@ const MultiLibraryHome: React.FC = () => {
           role="status"
           aria-live="polite"
           aria-atomic="true"
-          sx={{
-            position: "absolute",
-            width: "1px",
-            height: "1px",
-            overflow: "hidden",
-            clip: "rect(0,0,0,0)",
-            whiteSpace: "nowrap"
-          }}
+          sx={{ variant: "accessibility.visuallyHidden" }}
         >
           {statusMessage}
         </div>


### PR DESCRIPTION
## Description

Replaces an inline visually-hidden CSS styles block in `MultiLibraryHome` with a shared theme variant (`accessibility.visuallyHidden`).

## Motivation and Context

Mentioned during code review of #153, but I forgot to incorporate it. The inline styles duplicated an existing theme variant rather than reusing it. Eliminates duplication and avoids drift by keeping the styles centralized.

[Jira PP-4693]

## How Has This Been Tested?

No new tests added; this is a style-only refactor with no behavioral change. Existing tests for `MultiLibraryHome` -- and all other tests -- continue to pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.