### PR TITLE
Show library card sign up link when configured for library (PP-4611)

### DIFF
--- a/src/auth/LoginWrapper.tsx
+++ b/src/auth/LoginWrapper.tsx
@@ -82,9 +82,7 @@ const LoginWrapper = ({ children }: LoginWrapperProps) => {
           ) : (
             <>
               {children}
-              <div sx={{ textAlign: "center" }}>
-                <SignUpLink />
-              </div>
+              <SignUpLink />
             </>
           )}
         </Stack>

--- a/src/auth/LoginWrapper.tsx
+++ b/src/auth/LoginWrapper.tsx
@@ -8,6 +8,7 @@ import Head from "next/head";
 import BreadcrumbBar from "components/BreadcrumbBar";
 import useLoginRedirectUrl from "auth/useLoginRedirect";
 import { H1, Text } from "components/Text";
+import SignUpLink from "auth/SignUpLink";
 
 /**
  * Redirects on success
@@ -79,7 +80,12 @@ const LoginWrapper = ({ children }: LoginWrapperProps) => {
               Logging in...
             </Stack>
           ) : (
-            children
+            <>
+              {children}
+              <div sx={{ textAlign: "center" }}>
+                <SignUpLink />
+              </div>
+            </>
           )}
         </Stack>
       </div>

--- a/src/auth/SignUpLink.tsx
+++ b/src/auth/SignUpLink.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import useLibraryContext from "components/context/LibraryContext";
+import ExternalLink from "components/ExternalLink";
+
+const SignUpLink: React.FC = () => {
+  const {
+    libraryLinks: { registration }
+  } = useLibraryContext();
+
+  if (!registration?.href) return null;
+
+  return (
+    <ExternalLink href={registration.href}>
+      Sign up for a library card
+    </ExternalLink>
+  );
+};
+
+export default SignUpLink;

--- a/src/auth/SignUpLink.tsx
+++ b/src/auth/SignUpLink.tsx
@@ -10,9 +10,11 @@ const SignUpLink: React.FC = () => {
   if (!registration?.href) return null;
 
   return (
-    <ExternalLink href={registration.href}>
-      Sign up for a library card
-    </ExternalLink>
+    <div sx={{ textAlign: "center" }}>
+      <ExternalLink href={registration.href}>
+        Sign up for a library card
+      </ExternalLink>
+    </div>
   );
 };
 

--- a/src/auth/__tests__/LoginWrapper.test.tsx
+++ b/src/auth/__tests__/LoginWrapper.test.tsx
@@ -32,6 +32,36 @@ test("shows children when not loading", () => {
   expect(utils.getByText("child")).toBeInTheDocument();
 });
 
+describe("sign up for a library card link", () => {
+  test("renders when a registration link is configured", () => {
+    const utils = render(<LoginWrapper>child</LoginWrapper>, {
+      library: {
+        libraryLinks: {
+          registration: {
+            rel: "register",
+            href: "https://example.com/register"
+          }
+        }
+      }
+    });
+    const link = utils.getByRole("link", {
+      name: "Sign up for a library card (Opens in a new tab)"
+    });
+    expect(link).toHaveAttribute("href", "https://example.com/register");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  test("does not render when no registration link is configured", () => {
+    const utils = render(<LoginWrapper>child</LoginWrapper>);
+    expect(
+      utils.queryByRole("link", {
+        name: "Sign up for a library card (Opens in a new tab)"
+      })
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe("redirects when user becomes authenticated", () => {
   test("uses nextUrl when present", async () => {
     render(<LoginWrapper />, {

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -412,6 +412,10 @@ describe("buildLibraryData", () => {
       resetPassword: {
         rel: OPDS1.PasswordResetLinkRel,
         href: "/reset-password"
+      },
+      registration: {
+        rel: "register",
+        href: "/register"
       }
     });
 

--- a/src/dataflow/getLibraryData.ts
+++ b/src/dataflow/getLibraryData.ts
@@ -278,6 +278,7 @@ function parseLinks(links: OPDS1.AuthDocumentLink[] | undefined): LibraryLinks {
       case OPDS1.PasswordResetLinkRel:
         return { ...links, resetPassword: link };
       case "register":
+        return { ...links, registration: link };
       case "logo":
       case "navigation":
         return links;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
<img width="346" height="358" alt="image" src="https://github.com/user-attachments/assets/315748ed-610d-47a8-a2f2-e0d5e2204d72" />

An online registration link now displays on the sign-in page when offered by a library. When clicked, it opens the user in a new tab at the URL that has been configured for that library in the Palace Manager.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Palace iOS and Android apps display a "Sign up for a library card" link on a library's sign-in screen whenever a Patron Registration URL has been configured for that library in the Palace Manager (i.e. when a link with `rel="register"` is found within a library's authentication document). This change brings CPW further into parity with the mobile apps.

At present, the Virtual Library Card (VLC) application is the most common -- and currently the only -- registration system behind this URL. The presence of this link should purely be driven by whether a Patron Registration URL is configured for the library, not by the registration system in use. In other words, the authentication method should not determine whether the link renders or not, so the new `SignUpLink` component has been added to the base `LoginWrapper`. 

[Jira PP-4611](https://ebce-lyrasis.atlassian.net/browse/PP-4611)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit tests ensure link only appears when present in a library's authentication document
- Manually tested in Firefox, Chrome, and Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
