### PR TITLE
Display title "Series" metadata with link to series collection search (PP-4649)

### DIFF
--- a/src/components/BookMetaDetail.tsx
+++ b/src/components/BookMetaDetail.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 const DetailField: React.FC<{
   heading: string;
-  details?: string;
+  details?: React.ReactNode;
 }> = ({ heading, details }) =>
   details ? (
     <>

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -2,13 +2,14 @@ import * as React from "react";
 import { fixtures, render, setup, screen, waitFor } from "test-utils";
 import merge from "deepmerge";
 import { BookDetails } from "../index";
-import { AnyBook } from "interfaces";
+import { AnyBook, Book } from "interfaces";
 import * as complaintActions from "hooks/useComplaints/actions";
 import ReportProblem from "../ReportProblem";
 import { ServerError } from "errors";
 import useSWR from "swr";
 import mockConfig from "test-utils/mockConfig";
 import { BreadcrumbContext } from "components/context/BreadcrumbContext";
+import { mockPush } from "test-utils/mockNextRouter";
 
 jest.mock("swr");
 
@@ -104,6 +105,10 @@ describe("book details page", () => {
     // 9. Distributor
     expect(terms[8]).toHaveTextContent("Distributor:");
     expect(defintions[8]).toHaveTextContent("Palace Marketplace");
+
+    // 10. Series
+    expect(terms[9]).toHaveTextContent("Series:");
+    expect(defintions[9]).toHaveTextContent("A Disorganized Series");
   });
 
   test("shows categories", () => {
@@ -167,6 +172,64 @@ describe("book details page", () => {
     setup(<BookDetails />);
     expect(screen.getByText("Format:")).toBeInTheDocument();
     expect(screen.getByText("ePub")).toBeInTheDocument();
+  });
+
+  test("shows series as a link to the series collection", () => {
+    const bookWithSeries = merge<Book>(fixtures.book, {
+      series: {
+        name: "Kat, Incorrigible",
+        position: 3,
+        url: "http://series-url/Kat%2C%20Incorrigible"
+      }
+    });
+    mockSwr({ data: bookWithSeries });
+    setup(<BookDetails />);
+    expect(screen.getByText("Series:")).toBeInTheDocument();
+    const seriesLink = screen.getByRole("link", { name: "Kat, Incorrigible" });
+    expect(seriesLink).toHaveAttribute(
+      "href",
+      `/testlib/collection/${encodeURIComponent("http://series-url/Kat%2C%20Incorrigible")}`
+    );
+    expect(seriesLink).toHaveTextContent(/^Kat, Incorrigible$/);
+  });
+
+  test("clicking the series link navigates to the series collection page", async () => {
+    const bookWithSeries = merge<Book>(fixtures.book, {
+      series: {
+        name: "Kat, Incorrigible",
+        position: 3,
+        url: "http://series-url/Kat%2C%20Incorrigible"
+      }
+    });
+    mockSwr({ data: bookWithSeries });
+    const { user } = setup(<BookDetails />);
+
+    await user.click(screen.getByRole("link", { name: "Kat, Incorrigible" }));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush.mock.calls[0][0]).toBe(
+      `/testlib/collection/${encodeURIComponent(
+        "http://series-url/Kat%2C%20Incorrigible"
+      )}`
+    );
+  });
+
+  test("doesn't show series when the book has none", () => {
+    mockSwr({ data: fixtures.book });
+    setup(<BookDetails />);
+    expect(screen.queryByText("Series:")).toBeFalsy();
+  });
+
+  test("doesn't show series when series has no url", () => {
+    const bookWithUrllessSeries = merge<Book>(fixtures.book, {
+      series: {
+        name: "Kat, Incorrigible"
+      }
+    });
+    mockSwr({ data: bookWithUrllessSeries });
+    setup(<BookDetails />);
+    expect(screen.queryByText("Series:")).toBeFalsy();
+    expect(screen.queryByText("Kat, Incorrigible")).toBeFalsy();
   });
 
   test("does not show simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'openebooks'", () => {

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -23,6 +23,7 @@ import useBreadcrumbContext from "components/context/BreadcrumbContext";
 import { useAppConfig } from "components/context/AppConfigContext";
 import { getAuthors, getLanguageLabel } from "utils/book";
 import Stack from "components/Stack";
+import Link from "components/Link";
 
 export const BookDetails: React.FC = () => {
   const { companionApp, showMedium } = useAppConfig();
@@ -118,6 +119,19 @@ export const BookDetails: React.FC = () => {
               <DetailField heading="Published" details={book.published} />
               <DetailField heading="Publisher" details={book.publisher} />
               <DetailField heading="Distributor" details={book.providerName} />
+              {book.series?.name && book.series?.url && (
+                <DetailField
+                  heading="Series"
+                  details={
+                    <Link
+                      collectionUrl={book.series.url}
+                      sx={{ textDecoration: "underline" }}
+                    >
+                      {book.series.name}
+                    </Link>
+                  }
+                />
+              )}
             </dl>
             <ReportProblem book={book} />
           </div>

--- a/src/dataflow/opds1/__tests__/parse.test.ts
+++ b/src/dataflow/opds1/__tests__/parse.test.ts
@@ -113,6 +113,29 @@ test("extracts basic book info", () => {
     },
     language: "en",
     unparsed: {
+      "schema:Series": [
+        {
+          $: {
+            name: {
+              name: "name",
+              value: "Fake Series",
+              local: "name"
+            }
+          },
+          $ns: {
+            uri: "http://schema.org/",
+            local: "Series"
+          },
+          link: [
+            {
+              $: {
+                rel: { value: "series" },
+                href: { value: "/works/series/fake" }
+              }
+            }
+          ]
+        }
+      ],
       "bibframe:distribution": [
         {
           $: {
@@ -220,6 +243,7 @@ test("extracts basic book info", () => {
   expect(book.contributors?.[0]).toBe(entry.contributors[0].name);
   expect(book.series?.name).toBe(entry.series.name);
   expect(book.series?.position).toBe(entry.series.position);
+  expect(book.series?.url).toBe("http://test-url.com/works/series/fake");
   expect(book.subtitle).toBe(entry.subtitle);
   expect(book.summary).toBe(sanitizeHtml(entry.summary.content));
   expect(book.summary).toMatch(
@@ -336,6 +360,224 @@ test("chooses the first supported borrow link", () => {
   expect(bookIsBorrowable(book)).toBeTruthy();
   expect((book as any).borrowUrl).toBe("/borrow-axisnow");
   expect(book.status).toBe("borrowable");
+});
+
+describe("series", () => {
+  function seriesBook(props: {
+    series?: { name: string; position?: number };
+    unparsed?: any;
+  }) {
+    mockConfig();
+    const entry = factory.entry({
+      ...basicInfo,
+      ...props,
+      links: [detailLink]
+    });
+    return entryToBook(entry, "http://test-url.com");
+  }
+
+  test("parses series from lowercase schema:series tag", () => {
+    // the current CM does not use a capitalized tag, so opds-feed-parser
+    // leaves entry.series undefined and everything comes from unparsed
+    const book = seriesBook({
+      unparsed: {
+        "schema:series": [
+          {
+            $: { name: { value: "A Series" } },
+            $ns: { uri: "http://schema.org/", local: "series" },
+            position: [{ _: "6" }],
+            link: [
+              {
+                $: {
+                  rel: { value: "series" },
+                  href: {
+                    value: "https://cm.example.com/works/series/A%20Series"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    });
+    expect(book.series).toEqual({
+      name: "A Series",
+      position: 6,
+      url: "https://cm.example.com/works/series/A%20Series"
+    });
+  });
+
+  test("parses series from capitalized schema:Series tag", () => {
+    const book = seriesBook({
+      series: { name: "Fake Series", position: 2 },
+      unparsed: {
+        "schema:Series": [
+          {
+            $: { name: { value: "Fake Series" } },
+            $ns: { uri: "http://schema.org/", local: "Series" },
+            link: [
+              {
+                $: {
+                  rel: { value: "series" },
+                  href: { value: "https://cm.example.com/series/Fake%20Series" }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    });
+    expect(book.series).toEqual({
+      name: "Fake Series",
+      position: 2,
+      url: "https://cm.example.com/series/Fake%20Series"
+    });
+  });
+
+  test("resolves a relative series href against the feed url", () => {
+    const book = seriesBook({
+      unparsed: {
+        "schema:series": [
+          {
+            $: { name: { value: "Fake Series" } },
+            $ns: { uri: "http://schema.org/", local: "series" },
+            link: [
+              {
+                $: {
+                  rel: { value: "series" },
+                  href: { value: "/works/series/Fake%20Series" }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    });
+    expect(book.series?.url).toBe(
+      "http://test-url.com/works/series/Fake%20Series"
+    );
+  });
+
+  test("uses the first link with rel series and ignores other rels", () => {
+    const book = seriesBook({
+      unparsed: {
+        "schema:series": [
+          {
+            $: { name: { value: "Fake Series" } },
+            $ns: { uri: "http://schema.org/", local: "series" },
+            link: [
+              { $: { rel: { value: "contributor" }, href: { value: "/no" } } },
+              {
+                $: {
+                  rel: { value: "series" },
+                  href: { value: "/Fake%20Series" }
+                }
+              },
+              { $: { rel: { value: "series" }, href: { value: "/second" } } }
+            ]
+          }
+        ]
+      }
+    });
+    expect(book.series?.url).toBe("http://test-url.com/Fake%20Series");
+  });
+
+  test("falls back to the series when unparsed has no tag", () => {
+    const book = seriesBook({
+      series: { name: "Fake Series", position: 2 }
+    });
+    expect(book.series).toEqual({
+      name: "Fake Series",
+      position: 2,
+      url: undefined
+    });
+  });
+
+  test("is undefined when the entry has no series", () => {
+    const book = seriesBook({});
+    expect(book.series).toBeUndefined();
+  });
+
+  test("does not throw on malformed series XML", () => {
+    const ns = { uri: "http://schema.org/", local: "series" };
+
+    // empty tag / no $ns
+    expect(
+      seriesBook({ unparsed: { "schema:series": [{}] } }).series
+    ).toBeUndefined();
+
+    // tag without a name
+    expect(
+      seriesBook({ unparsed: { "schema:series": [{ $ns: ns }] } }).series
+    ).toBeUndefined();
+
+    // tag without links
+    expect(
+      seriesBook({
+        unparsed: {
+          "schema:series": [{ $ns: ns, $: { name: { value: "X" } } }]
+        }
+      }).series
+    ).toEqual({ name: "X", position: undefined, url: undefined });
+
+    // empty link element
+    expect(
+      seriesBook({
+        unparsed: {
+          "schema:series": [
+            { $ns: ns, $: { name: { value: "X" } }, link: [{}] }
+          ]
+        }
+      }).series?.url
+    ).toBeUndefined();
+
+    // link with rel but no href
+    expect(
+      seriesBook({
+        unparsed: {
+          "schema:series": [
+            {
+              $ns: ns,
+              $: { name: { value: "X" } },
+              link: [{ $: { rel: { value: "series" } } }]
+            }
+          ]
+        }
+      }).series?.url
+    ).toBeUndefined();
+
+    // unparsable href
+    expect(
+      seriesBook({
+        unparsed: {
+          "schema:series": [
+            {
+              $ns: ns,
+              $: { name: { value: "X" } },
+              link: [
+                { $: { rel: { value: "series" }, href: { value: "http://" } } }
+              ]
+            }
+          ]
+        }
+      }).series?.url
+    ).toBeUndefined();
+
+    // non-numeric position
+    expect(
+      seriesBook({
+        unparsed: {
+          "schema:series": [
+            {
+              $ns: ns,
+              $: { name: { value: "X" } },
+              position: [{ _: "not-a-number" }]
+            }
+          ]
+        }
+      }).series
+    ).toEqual({ name: "X", position: undefined, url: undefined });
+  });
 });
 
 describe("FulfillableBook", () => {

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -252,7 +252,7 @@ function getSeries(entry: OPDSEntry, feedUrl: string): Book["series"] {
     : undefined;
   const positionNum = Number(entry.series?.position ?? positionText);
   const position = Number.isFinite(positionNum) ? positionNum : undefined;
-  console.log(tag);
+
   let url: string | undefined;
   const links = tag?.["link"];
   if (Array.isArray(links)) {

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -213,6 +213,66 @@ function getDuration(entry: OPDSEntry): string | undefined {
 }
 
 /**
+ * Finds the schema.org series tag in the raw entry XML regardless of
+ * namespace prefix and element-name casing.
+ * The current Palace CM emits <schema:series>, older CMs emit <schema:Series>.
+ * opds-feed-parser only matches the capitalized form, so entry.series cannot be relied on.
+ */
+function findSeriesTag(unparsed: any): any {
+  if (!unparsed || typeof unparsed !== "object") return undefined;
+  for (const value of Object.values(unparsed)) {
+    if (Array.isArray(value)) {
+      const tag = value[0];
+      const ns = tag?.["$ns"];
+      if (
+        ns?.uri === "http://schema.org/" &&
+        typeof ns?.local === "string" &&
+        ns.local.toLowerCase() === "series"
+      ) {
+        return tag;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Builds the series from entry.unparsed, because opds-feed-parser drops
+ * the nested <link rel="series"> that holds the series feed url.
+ */
+function getSeries(entry: OPDSEntry, feedUrl: string): Book["series"] {
+  const tag = findSeriesTag(entry.unparsed);
+  const name = tag?.["$"]?.["name"]?.value ?? entry.series?.name;
+  if (typeof name !== "string" || name.length === 0) return undefined;
+
+  // Older CMs put the position in a schema:position attribute (which
+  // opds-feed-parser reads); the current CM emits a <position> child.
+  const positionText = Array.isArray(tag?.["position"])
+    ? tag["position"][0]?._
+    : undefined;
+  const positionNum = Number(entry.series?.position ?? positionText);
+  const position = Number.isFinite(positionNum) ? positionNum : undefined;
+  console.log(tag);
+  let url: string | undefined;
+  const links = tag?.["link"];
+  if (Array.isArray(links)) {
+    const seriesLink = links.find(
+      link => link?.["$"]?.["rel"]?.value === "series"
+    );
+    const href = seriesLink?.["$"]?.["href"]?.value;
+    if (typeof href === "string" && href.length > 0) {
+      try {
+        url = resolve(feedUrl, href);
+      } catch {
+        // ignore a malformed series href
+      }
+    }
+  }
+
+  return { name, position, url };
+}
+
+/**
  * Converters
  */
 
@@ -304,11 +364,11 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
   const bibframeTags = entryToBibframeData(entry);
   const providerName = getProviderName(bibframeTags);
   const duration = getDuration(entry);
+  const series = getSeries(entry, feedUrl);
 
   const book: Book = {
     id: entry.id,
     title: entry.title,
-    series: entry.series,
     authors: authors,
     contributors: contributors,
     subtitle: entry.subtitle,
@@ -335,6 +395,7 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
     trackOpenBookUrl: trackOpenBookLink?.href ?? null,
     previewUrl: previewUrl,
     format: format,
+    series: series,
     raw: entry.unparsed
   };
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -188,6 +188,7 @@ export type Book<Status = EmptyObject> = Readonly<
     series?: {
       name: string;
       position?: number;
+      url?: string;
     } | null;
     authors?: string[];
     contributors?: string[];

--- a/src/test-utils/fixtures/book.ts
+++ b/src/test-utils/fixtures/book.ts
@@ -206,6 +206,11 @@ export const audiobook: Book = {
   narrators: ["Simon Brett"],
   audience: "Adult",
   language: "en",
+  series: {
+    name: "A Disorganized Series",
+    position: 2,
+    url: "http://series-url"
+  },
   raw: {
     $: { "schema:additionalType": { value: "http://schema.org/Audiobook" } },
     category: [


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
<img width="472" height="289" alt="image" src="https://github.com/user-attachments/assets/574221fc-09cf-48ba-bb43-0679039c6e94" />

If a title belongs as a part of a series, the name of the series is now listed on the book details page as a link. The link will place users on a collection search page listing all titles within that series.

`opds-feed-parser` expects to find capital-S `schema:Series` which aligns with the legacy NYPL circulation manager. The current Palace Circulation Manager outputs a lowercase-S `schema:series`. The newly added `getSeries` first checks for `schema:series` then `schema:Series` as a fallback.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Listing the series title on the book details page helps users find other titles within that series more easily. The Palace iOS ([PP-4463](https://ebce-lyrasis.atlassian.net/browse/PP-4463)) and Android ([PP-4464](https://ebce-lyrasis.atlassian.net/browse/PP-4464)) apps add a SERIES row to the Book Details Information block, rendering the series name as a link that opens a search for other titles in that series. These changes bring the CPW into further parity with the mobile apps.

[Jira PP-4649](https://ebce-lyrasis.atlassian.net/browse/PP-4649)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested in Firefox, Chrome, and Safari
- Unit tests added that ensure OPDS feed entries are parsed for series metadata and link surfaces on book details page when present

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.


[PP-4463]: https://ebce-lyrasis.atlassian.net/browse/PP-4463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PP-4464]: https://ebce-lyrasis.atlassian.net/browse/PP-4464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ