### PR TITLE
Reduce server-side caching (PP-4753)

### DIFF
--- a/src/dataflow/__mocks__/withAppProps.ts
+++ b/src/dataflow/__mocks__/withAppProps.ts
@@ -1,8 +1,15 @@
-import { GetStaticProps } from "next";
+import { GetServerSideProps, GetStaticProps } from "next";
 
 export default function withAppProps(pageGetStaticProps?: GetStaticProps) {
   return async (ctx: any) => {
     // Call the inner page getStaticProps directly
     return pageGetStaticProps ? pageGetStaticProps(ctx) : { props: {} };
+  };
+}
+
+export function withAppPropsSSR(pageGetServerSideProps?: GetServerSideProps) {
+  return async (ctx: any) => {
+    // Call the inner page getServerSideProps directly
+    return pageGetServerSideProps ? pageGetServerSideProps(ctx) : { props: {} };
   };
 }

--- a/src/dataflow/__tests__/withAppProps.test.ts
+++ b/src/dataflow/__tests__/withAppProps.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test, beforeEach } from "@jest/globals";
+import { GetServerSidePropsContext, GetStaticPropsContext } from "next";
+import fetchMock from "jest-fetch-mock";
+import withAppProps, { withAppPropsSSR } from "../withAppProps";
+import { resetAuthDocCache } from "../getLibraryData";
+import { getLibraries } from "server/libraryRegistry";
+import { getAppConfig } from "server/appConfig";
+import track from "analytics/track";
+import { config } from "test-utils/fixtures/config";
+import { authDoc } from "test-utils/fixtures/auth-document";
+
+jest.mock("server/libraryRegistry", () => ({
+  getLibraries: jest.fn()
+}));
+
+jest.mock("server/appConfig", () => ({
+  getAppConfig: jest.fn()
+}));
+
+jest.mock("analytics/track", () => ({
+  __esModule: true,
+  default: { error: jest.fn() }
+}));
+
+const mockGetLibraries = getLibraries as jest.MockedFunction<
+  typeof getLibraries
+>;
+const mockGetAppConfig = getAppConfig as jest.MockedFunction<
+  typeof getAppConfig
+>;
+const mockTrackError = track.error as jest.MockedFunction<typeof track.error>;
+
+function staticCtx(params?: Record<string, string>): GetStaticPropsContext {
+  return { params };
+}
+
+function ssrCtx(params?: Record<string, string>): GetServerSidePropsContext {
+  return {
+    params,
+    res: { statusCode: 200 }
+  } as unknown as GetServerSidePropsContext;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchMock.resetMocks();
+  resetAuthDocCache();
+  mockGetAppConfig.mockResolvedValue(config);
+  mockGetLibraries.mockResolvedValue({
+    testlib: { title: "Test Library", authDocUrl: "http://auth.doc/document" }
+  });
+  fetchMock.mockResponse(JSON.stringify(authDoc));
+});
+
+describe("withAppProps (static)", () => {
+  test("merges library and appConfig into page props with hourly revalidation", async () => {
+    const gsp = withAppProps(async () => ({ props: { foo: "bar" } }));
+    const result = await gsp(staticCtx({ library: "testlib" }));
+
+    expect(result).toMatchObject({
+      revalidate: 3600,
+      props: {
+        foo: "bar",
+        appConfig: config,
+        library: { slug: "testlib", catalogName: authDoc.title }
+      }
+    });
+  });
+
+  test("uses the default library slug when provided", async () => {
+    const gsp = withAppProps(undefined, "testlib");
+    const result = await gsp(staticCtx());
+
+    expect(result).toMatchObject({
+      props: { library: { slug: "testlib" } }
+    });
+  });
+
+  test("returns notFound for an unknown library slug", async () => {
+    mockGetLibraries.mockResolvedValue({});
+    const gsp = withAppProps();
+    const result = await gsp(staticCtx({ library: "not-there" }));
+
+    expect(result).toEqual({ notFound: true, revalidate: 1 });
+    expect(mockTrackError).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns error props for a non-404 failure", async () => {
+    fetchMock.mockReject(new Error("connection refused"));
+    const gsp = withAppProps();
+    const result = await gsp(staticCtx({ library: "testlib" }));
+
+    expect(result).toMatchObject({
+      revalidate: 1,
+      props: { error: { status: 500 } }
+    });
+    expect(mockTrackError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withAppPropsSSR", () => {
+  test("merges library and appConfig into page props", async () => {
+    const gssp = withAppPropsSSR(async () => ({ props: { foo: "bar" } }));
+    const result = await gssp(ssrCtx({ library: "testlib" }));
+
+    expect(result).toEqual({
+      props: {
+        foo: "bar",
+        appConfig: config,
+        library: expect.objectContaining({ slug: "testlib" })
+      }
+    });
+  });
+
+  test("awaits page props supplied as a promise", async () => {
+    const gssp = withAppPropsSSR(async () => ({
+      props: Promise.resolve({ foo: "bar" })
+    }));
+    const result = await gssp(ssrCtx({ library: "testlib" }));
+
+    expect(result).toMatchObject({ props: { foo: "bar" } });
+  });
+
+  test("passes through a page redirect untouched", async () => {
+    const redirect = { destination: "/elsewhere", permanent: false };
+    const gssp = withAppPropsSSR(async () => ({ redirect }));
+    const result = await gssp(ssrCtx({ library: "testlib" }));
+
+    expect(result).toEqual({ redirect });
+  });
+
+  test("passes through a page notFound untouched", async () => {
+    const gssp = withAppPropsSSR(async () => ({ notFound: true }));
+    const result = await gssp(ssrCtx({ library: "testlib" }));
+
+    expect(result).toEqual({ notFound: true });
+  });
+
+  test("uses the default library slug when provided", async () => {
+    const gssp = withAppPropsSSR(undefined, "testlib");
+    const result = await gssp(ssrCtx());
+
+    expect(result).toMatchObject({
+      props: { library: { slug: "testlib" } }
+    });
+  });
+
+  test("returns notFound for an unknown library slug", async () => {
+    mockGetLibraries.mockResolvedValue({});
+    const gssp = withAppPropsSSR();
+    const result = await gssp(ssrCtx({ library: "not-there" }));
+
+    expect(result).toEqual({ notFound: true });
+    expect(mockTrackError).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns error props and a 500 status for other failures", async () => {
+    fetchMock.mockReject(new Error("connection refused"));
+    const gssp = withAppPropsSSR();
+    const ctx = ssrCtx({ library: "testlib" });
+    const result = await gssp(ctx);
+
+    expect(result).toMatchObject({ props: { error: { status: 500 } } });
+    expect(ctx.res.statusCode).toBe(500);
+    expect(mockTrackError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/dataflow/getLibraryData.ts
+++ b/src/dataflow/getLibraryData.ts
@@ -21,10 +21,10 @@ import { AuthDocumentSchema } from "validation/authDocument";
 // ---------------------------------------------------------------------------
 
 /*
- * Caches fetched auth documents by URL. Multiple ISR route rebuilds for the
- * same library (index, loans, book, etc.) all resolve to the same auth document
- * URL; without caching they each issue an independent upstream fetch in quick
- * succession.
+ * Caches fetched auth documents by URL. Page renders for the same library —
+ * ISR route rebuilds (index, loans, etc.) and per-request SSR renders (book,
+ * collection) — all resolve to the same auth document URL; without caching
+ * each render issues an independent upstream fetch.
  *
  * The cache is keyed by URL and stores the last successful fetch time alongside
  * the last attempt time (whether successful or not). refreshMinInterval prevents

--- a/src/dataflow/withAppProps.ts
+++ b/src/dataflow/withAppProps.ts
@@ -1,5 +1,10 @@
 import { AppConfig, LibraryData, OPDS1 } from "../interfaces";
-import { GetStaticProps, GetStaticPropsContext } from "next";
+import {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  GetStaticProps,
+  GetStaticPropsContext
+} from "next";
 import {
   getAuthDocUrl,
   fetchAuthDocument,
@@ -17,28 +22,67 @@ export type AppProps = {
   error?: OPDS1.ProblemDocument;
 };
 
+/*
+ * Resolves the library slug from the route params (or the provided default)
+ * and builds the props every page needs: the app config and the library data
+ * derived from the library's authentication document.
+ */
+async function getLibraryProps(
+  params: ParsedUrlQuery | undefined,
+  defaultLibSlug?: string
+): Promise<{ library: LibraryData; appConfig: AppConfig }> {
+  const librarySlug = defaultLibSlug
+    ? defaultLibSlug
+    : extractParam(params, "library");
+
+  if (!librarySlug)
+    throw new PageNotFoundError(
+      "A library slug is required to be provided in the URL. Eg: https://domain.com/:library"
+    );
+
+  const appConfig = await getAppConfig();
+  const authDocUrl = await getAuthDocUrl(librarySlug, appConfig);
+  const authDocument = await fetchAuthDocument(
+    authDocUrl,
+    appConfig.authenticationDocuments ?? undefined
+  );
+  const library = buildLibraryData(authDocument, librarySlug);
+  return { library, appConfig };
+}
+
+/*
+ * Wraps an unknown thrown value in an ApplicationError if necessary, reports
+ * it, and returns the problem document to render as an error page.
+ */
+function trackError(e: any): OPDS1.ProblemDocument {
+  const error =
+    e instanceof ApplicationError
+      ? e
+      : new ApplicationError(
+          {
+            title: "App Startup Failure",
+            detail:
+              e instanceof Error
+                ? `${e.name}: ${e.message}`
+                : "Unknown error occurred fetching page props",
+            status: 500
+          },
+          e
+        );
+  track.error(error, { severity: "error" });
+  return error.info;
+}
+
 export default function withAppProps(
   pageGetStaticProps?: GetStaticProps,
   defaultLibSlug?: string
 ): GetStaticProps<AppProps> {
   return async (ctx: GetStaticPropsContext<ParsedUrlQuery>) => {
     try {
-      const librarySlug = defaultLibSlug
-        ? defaultLibSlug
-        : extractParam(ctx.params, "library");
-
-      if (!librarySlug)
-        throw new PageNotFoundError(
-          "A library slug is required to be provided in the URL. Eg: https://domain.com/:library"
-        );
-
-      const appConfig = await getAppConfig();
-      const authDocUrl = await getAuthDocUrl(librarySlug, appConfig);
-      const authDocument = await fetchAuthDocument(
-        authDocUrl,
-        appConfig.authenticationDocuments ?? undefined
+      const { library, appConfig } = await getLibraryProps(
+        ctx.params,
+        defaultLibSlug
       );
-      const library = buildLibraryData(authDocument, librarySlug);
       // fetch the static props for the page
       const pageResult = (await pageGetStaticProps?.(ctx)) ?? { props: {} };
       const pageProps = "props" in pageResult ? pageResult.props : {};
@@ -54,28 +98,75 @@ export default function withAppProps(
         revalidate: 60 * 60
       };
     } catch (e) {
-      // if it is not already an application error, wrap it in one
-      const error =
-        e instanceof ApplicationError
-          ? e
-          : new ApplicationError(
-              {
-                title: "App Startup Failure",
-                detail:
-                  e instanceof Error
-                    ? `${e.name}: ${e.message}`
-                    : "Unknown error occurred fetching static props",
-                status: 500
-              },
-              e
-            );
-      track.error(error, { severity: "error" });
+      const error = trackError(e);
+      /*
+       * Unknown library slugs return notFound so Next.js serves its 404 page
+       * without persisting a cache entry on disk for the junk path. Combined
+       * with fallback: "blocking" on the pages using this wrapper, this keeps
+       * arbitrary request paths from growing the incremental cache.
+       */
+      if (error.status === 404) {
+        return { notFound: true, revalidate: 1 };
+      }
       return {
         props: {
-          error: error.info
+          error
         },
         // library data will be revalidated often for error pages.
         revalidate: 1
+      };
+    }
+  };
+}
+
+/*
+ * Per-request variant of withAppProps for pages whose dynamic param space is
+ * unbounded (the route param embeds a backend feed or entry URL). These pages
+ * must use getServerSideProps: statically generating them would persist a
+ * cached page on disk for every unique URL visited.
+ *
+ * Responses keep Next's default no-store Cache-Control (no s-maxage), so
+ * these pages are deliberately never cached — on disk or by a shared cache.
+ */
+export function withAppPropsSSR(
+  pageGetServerSideProps?: GetServerSideProps,
+  defaultLibSlug?: string
+): GetServerSideProps<AppProps> {
+  return async (ctx: GetServerSidePropsContext<ParsedUrlQuery>) => {
+    try {
+      const { library, appConfig } = await getLibraryProps(
+        ctx.params,
+        defaultLibSlug
+      );
+      const pageResult = (await pageGetServerSideProps?.(ctx)) ?? {
+        props: {}
+      };
+      if ("redirect" in pageResult || "notFound" in pageResult) {
+        return pageResult;
+      }
+      const pageProps = await pageResult.props;
+
+      return {
+        props: {
+          ...pageProps,
+          library,
+          appConfig
+        }
+      };
+    } catch (e) {
+      const error = trackError(e);
+      /*
+       * Unknown library slugs render the custom 404 page, matching the static
+       * wrapper's behavior. Next.js sets the 404 status automatically.
+       */
+      if (error.status === 404) {
+        return { notFound: true };
+      }
+      ctx.res.statusCode = error.status ?? 500;
+      return {
+        props: {
+          error
+        }
       };
     }
   };

--- a/src/pages/[library]/book/[bookUrl].tsx
+++ b/src/pages/[library]/book/[bookUrl].tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import BookDetails from "../../../components/bookDetails";
-import withAppProps, { AppProps } from "dataflow/withAppProps";
+import { withAppPropsSSR, AppProps } from "dataflow/withAppProps";
 import LayoutPage from "components/LayoutPage";
-import { NextPage, GetStaticProps, GetStaticPaths } from "next";
+import { NextPage, GetServerSideProps } from "next";
 
 const BookPage: NextPage<AppProps> = ({ library, error }) => {
   return (
@@ -12,13 +12,6 @@ const BookPage: NextPage<AppProps> = ({ library, error }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = withAppProps();
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  return {
-    paths: [],
-    fallback: true
-  };
-};
+export const getServerSideProps: GetServerSideProps = withAppPropsSSR();
 
 export default BookPage;

--- a/src/pages/[library]/collection/[collectionUrl].tsx
+++ b/src/pages/[library]/collection/[collectionUrl].tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import Collection from "components/Collection";
-import { NextPage, GetStaticPaths, GetStaticProps } from "next";
+import { NextPage, GetServerSideProps } from "next";
 import LayoutPage from "components/LayoutPage";
-import withAppProps, { AppProps } from "dataflow/withAppProps";
+import { withAppPropsSSR, AppProps } from "dataflow/withAppProps";
 
 const CollectionPage: NextPage<AppProps> = ({ library, error }) => {
   return (
@@ -12,13 +12,6 @@ const CollectionPage: NextPage<AppProps> = ({ library, error }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = withAppProps();
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  return {
-    paths: [],
-    fallback: true
-  };
-};
+export const getServerSideProps: GetServerSideProps = withAppPropsSSR();
 
 export default CollectionPage;

--- a/src/pages/[library]/index.tsx
+++ b/src/pages/[library]/index.tsx
@@ -17,7 +17,7 @@ export const getStaticProps: GetStaticProps = withAppProps();
 export const getStaticPaths: GetStaticPaths = async () => {
   return {
     paths: [],
-    fallback: true
+    fallback: "blocking"
   };
 };
 

--- a/src/pages/[library]/loans.tsx
+++ b/src/pages/[library]/loans.tsx
@@ -17,7 +17,7 @@ export const getStaticProps: GetStaticProps = withAppProps();
 export const getStaticPaths: GetStaticPaths = async () => {
   return {
     paths: [],
-    fallback: true
+    fallback: "blocking"
   };
 };
 

--- a/src/pages/[library]/login/[methodId].tsx
+++ b/src/pages/[library]/login/[methodId].tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { NextPage, GetStaticPaths, GetStaticProps } from "next";
+import { NextPage, GetServerSideProps } from "next";
 import LayoutPage from "components/LayoutPage";
-import withAppProps, { AppProps } from "dataflow/withAppProps";
+import { withAppPropsSSR, AppProps } from "dataflow/withAppProps";
 import LoginWrapper from "auth/LoginWrapper";
 import { useRouter } from "next/router";
 import extractParam from "dataflow/utils";
@@ -46,13 +46,10 @@ const LoginComponent = () => {
   return <AuthenticationHandler method={method} />;
 };
 
-export const getStaticProps: GetStaticProps = withAppProps();
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  return {
-    paths: [],
-    fallback: true
-  };
-};
+/*
+ * The methodId param is unvalidated free-form input, so this page uses
+ * getServerSideProps to avoid persisting a cache entry per unique URL.
+ */
+export const getServerSideProps: GetServerSideProps = withAppPropsSSR();
 
 export default LoginHandlerPage;

--- a/src/pages/[library]/login/index.tsx
+++ b/src/pages/[library]/login/index.tsx
@@ -23,7 +23,7 @@ export const getStaticProps: GetStaticProps = withAppProps();
 export const getStaticPaths: GetStaticPaths = async () => {
   return {
     paths: [],
-    fallback: true
+    fallback: "blocking"
   };
 };
 

--- a/src/pages/[library]/signed-out.tsx
+++ b/src/pages/[library]/signed-out.tsx
@@ -102,7 +102,7 @@ export const getStaticProps: GetStaticProps = withAppProps();
 export const getStaticPaths: GetStaticPaths = async () => {
   return {
     paths: [],
-    fallback: true
+    fallback: "blocking"
   };
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { GetServerSideProps, NextPage } from "next";
 import OpenEbooksLandingPage from "components/OpenEbooksLanding";
 import MultiLibraryHome from "components/MultiLibraryHome";
-import withAppProps, { AppProps } from "dataflow/withAppProps";
+import { withAppPropsSSR, AppProps } from "dataflow/withAppProps";
 import { getAppConfig } from "server/appConfig";
 import type { AppConfig } from "interfaces";
 
@@ -18,11 +18,11 @@ const HomePage: NextPage<HomeProps> = ({ appConfig, ...rest }) => {
 export const getServerSideProps: GetServerSideProps<HomeProps> = async ctx => {
   const appConfig = await getAppConfig();
   if (appConfig.openebooks) {
-    const fetchProps = withAppProps(
+    const fetchProps = withAppPropsSSR(
       undefined,
       appConfig.openebooks.defaultLibrary
     );
-    const result = await fetchProps(ctx as never);
+    const result = await fetchProps(ctx);
     if ("redirect" in result || "notFound" in result) return result;
     return { props: { ...(await result.props), appConfig } };
   }


### PR DESCRIPTION
## Description

- Adds a per-request (`getServerSideProps`) variant of the shared page-props wrapper and switches the pages whose dynamic route param is unbounded — book, collection, and the login method page (its param embeds a backend URL or free-form input) — from static generation to server-side rendering, so no cache file is written per unique URL. These responses intentionally keep `Next.js`'s default no-store `Cache-Control` (at least for the time being).
- The remaining statically generated pages now use `fallback: "blocking"` and return `notFound` for unknown library slugs, so junk paths render the custom 404 page without persisting a cache entry on disk.
- The auth document cache keeps repeated renders for the same library from issuing redundant upstream fetches for per-request rendering.

## Motivation and Context

Server-side incremental cache files were using too much storage. Several routes accept arbitrary values in their dynamic params, so any unique URL that was requested (e.g., by crawlers or scanners) persisted a statically generated page to disk, growing the cache without bound.

[Jira PP-4753]

## How Has This Been Tested?

- Manual tested in local dev environment and verified that results for the dynamic routes mentioned above were not cached.
- New and updated tests covering both ISR and SSR wrappers.
- All checks pass locally.
- [CI check](https://github.com/ThePalaceProject/web-patron/actions/runs/28947900932) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
