### PR TITLE
Parse loans feeds with entries with missing acquisition links (PP-4766)

### DIFF
--- a/src/dataflow/opds1/__tests__/parse.test.ts
+++ b/src/dataflow/opds1/__tests__/parse.test.ts
@@ -847,6 +847,46 @@ test("extracts navigation link info", () => {
   expect(link.url).toBe(`http://test-url.com/${navigationLink.href}`);
 });
 
+/**
+ * opds-feed-parser produces a NavigationFeed whenever any entry lacks
+ * acquisition links; books must still be extracted from it, and the
+ * link-less entries dropped.
+ */
+test("extracts books regardless of feed type", () => {
+  mockConfig();
+
+  const fulfillmentLink = factory.acquisitionLink({
+    rel: OPDSAcquisitionLink.GENERIC_REL,
+    type: OPDS1.EpubMediaType,
+    href: "/epub"
+  });
+  const loanEntry = factory.entry({
+    ...basicInfo,
+    id: "loan-entry",
+    links: [fulfillmentLink, detailLink]
+  });
+  const unfulfillableEntry = factory.entry({
+    ...basicInfo,
+    id: "unfulfillable-entry",
+    links: [
+      factory.opdsLink({ rel: OPDS1.RevokeLinkRel, href: "/revoke" }),
+      detailLink
+    ]
+  });
+
+  const navigationFeed = factory.navigationFeed({
+    id: "some id",
+    entries: [loanEntry, unfulfillableEntry],
+    links: []
+  });
+
+  const collection = feedToCollection(navigationFeed, "http://test-url.com");
+
+  expect(collection.books.map(book => book.id)).toEqual(["loan-entry"]);
+  expect(collection.books[0].status).toBe("fulfillable");
+  expect(collection.navigationLinks.length).toBe(0);
+});
+
 test("extracts facet groups", () => {
   const facetLinks = [
     factory.facetLink({

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -3,7 +3,6 @@ import {
   OPDSFeed,
   OPDSEntry,
   OPDSArtworkLink,
-  AcquisitionFeed,
   OPDSCollectionLink,
   OPDSFacetLink,
   OPDSLink,
@@ -614,8 +613,22 @@ export function feedToCollection(
   let shelfUrl: string | undefined = undefined;
   let links: OPDSLink[] = [];
 
+  /**
+   * Classify entries individually rather than by feed type: opds-feed-parser
+   * treats a feed as an AcquisitionFeed only when every entry has an
+   * acquisition link, so one entry without would otherwise drop every book
+   * in the feed. An entry with a complete-entry link is a book; entryToBook
+   * requires that link.
+   */
   feed.entries.forEach(entry => {
-    if (feed instanceof AcquisitionFeed) {
+    const isBookEntry = entry.links.some(
+      link => link instanceof CompleteEntryLink
+    );
+    if (isBookEntry) {
+      // Drop entries with no acquisition links at all (e.g. a loan for a
+      // title removed from the collection): they cannot be fulfilled by any
+      // application.
+      if (!entry.links.some(isAcquisitionLink)) return;
       const book = entryToBook(entry, feedUrl);
       const collectionLink = entry.links.find(isCollectionLink);
       if (collectionLink) {


### PR DESCRIPTION
## Description

- Classify each feed entry on its own instead of relying on `opds-feed-parser`'s feed-level acquisition-vs-navigation classification: an entry with a complete-entry link is parsed as a book; other entries become navigation links, as before.
- Drop book entries that have no acquisition links at all, matching the current behavior of the iOS and Android mobile apps.

## Motivation and Context

`opds-feed-parser` classifies a feed as an `AcquisitionFeed` only when **every** entry has an acquisition link (aligned with OPDS 1.2  section2); otherwise the whole feed becomes a `NavigationFeed`. A loans feed containing even a single title with no acquisition links (e.g., a book borrowed in another system with a format unsupported in Palace) was therefore classified as a navigation feed and every book in it was turned into a navigation link (currently unhandled). So, the patron's My Books page showed the empty-bookshelf message even though the feed looked valid.

[Jira PP-4766]

## How Has This Been Tested?

- Manual testing in my local dev environment verifying that all holds and loans with acquisition links were displayed on the My Books page of the patron who was experiencing this issue.
- New unit test to verify the new behavior.
- All checks pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/29046167591) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
