### PR TITLE
Refactor MultiLibraryHome filtering for re-use (PP-3760)

### DIFF
--- a/src/components/HighlightedText.tsx
+++ b/src/components/HighlightedText.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+/** Renders `text` with matched characters wrapped in <mark> for search highlighting. */
+const HighlightedText: React.FC<{ text: string; matchIndices: number[] }> = ({
+  text,
+  matchIndices
+}) => {
+  if (matchIndices.length === 0) return <>{text}</>;
+  const set = new Set(matchIndices);
+  const runs: Array<[string, boolean]> = [];
+  for (let i = 0; i < text.length; ) {
+    const hl = set.has(i);
+    let j = i + 1;
+    while (j < text.length && set.has(j) === hl) j++;
+    runs.push([text.slice(i, j), hl]);
+    i = j;
+  }
+  return (
+    <>
+      {runs.map(([chunk, hl], idx) =>
+        hl ? (
+          <mark key={idx} sx={{ bg: "transparent", fontWeight: "bold" }}>
+            {chunk}
+          </mark>
+        ) : (
+          <React.Fragment key={idx}>{chunk}</React.Fragment>
+        )
+      )}
+    </>
+  );
+};
+
+export default HighlightedText;

--- a/src/components/LibraryFilterList.tsx
+++ b/src/components/LibraryFilterList.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+import TextInput from "components/TextInput";
+import HighlightedText from "components/HighlightedText";
+import { scoreMatch } from "utils/libraryFilter";
+
+const FILTER_DEBOUNCE_MS = 200;
+const NO_MATCH_MESSAGE = "No libraries match.";
+
+export interface LibraryFilterItem {
+  /** Unique identifier, used as the React key for each result. */
+  slug: string;
+  /** Plain text used for scoring, filtering, and display. */
+  label: string;
+}
+
+interface LibraryFilterListProps {
+  heading: React.ReactNode;
+  items: LibraryFilterItem[];
+  /** Renders the content inside each result's <li>. */
+  renderItem: (
+    item: LibraryFilterItem & { highlighted: React.ReactNode }
+  ) => React.ReactNode;
+  resultsListId: string;
+}
+
+const LibraryFilterList: React.FC<LibraryFilterListProps> = ({
+  heading,
+  items,
+  renderItem,
+  resultsListId
+}) => {
+  const [inputValue, setInputValue] = React.useState("");
+  const [filterQuery, setFilterQuery] = React.useState("");
+
+  React.useEffect(() => {
+    const timer = setTimeout(
+      () => setFilterQuery(inputValue),
+      FILTER_DEBOUNCE_MS
+    );
+    return () => clearTimeout(timer);
+  }, [inputValue]);
+
+  const filteredWithScores = items.flatMap(item => {
+    const { score, matchIndices } = filterQuery
+      ? scoreMatch(filterQuery, item.label)
+      : { score: 0, matchIndices: [] };
+    if (filterQuery && score === 0) return [];
+    return [{ item, matchIndices, score }];
+  });
+
+  const displayed = filterQuery
+    ? [...filteredWithScores].sort(
+        (a, b) => b.score - a.score || a.item.label.localeCompare(b.item.label)
+      )
+    : filteredWithScores;
+
+  const resultCount = displayed.length;
+  const statusMessage = filterQuery
+    ? resultCount === 0
+      ? NO_MATCH_MESSAGE
+      : `${resultCount} ${
+          resultCount === 1 ? "library" : "libraries"
+        } shown, best matches first`
+    : "";
+
+  return (
+    <>
+      {heading}
+      <div sx={{ display: "inline-block", width: "44ch", mb: 2 }}>
+        <TextInput
+          type="search"
+          aria-label="Filter libraries"
+          aria-controls={resultsListId}
+          placeholder="Filter libraries..."
+          value={inputValue}
+          onChange={e => setInputValue(e.target.value)}
+        />
+      </div>
+      {/* Always in the DOM so screen readers register the live region before content changes. */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        sx={{ variant: "accessibility.visuallyHidden" }}
+      >
+        {statusMessage}
+      </div>
+      {filterQuery && resultCount === 0 && (
+        <p sx={{ pl: 2 }}>{NO_MATCH_MESSAGE}</p>
+      )}
+      <ul id={resultsListId}>
+        {displayed.map(({ item, matchIndices }) => (
+          <li key={item.slug}>
+            {renderItem({
+              ...item,
+              highlighted: (
+                <HighlightedText
+                  text={item.label}
+                  matchIndices={matchIndices}
+                />
+              )
+            })}
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+export default LibraryFilterList;

--- a/src/components/MultiLibraryHome.tsx
+++ b/src/components/MultiLibraryHome.tsx
@@ -6,115 +6,9 @@ import useSWR from "swr";
 import { useAppConfig } from "components/context/AppConfigContext";
 import theme from "theme/theme";
 import LibraryHomeLink from "./LibraryHomeLink";
-import TextInput from "components/TextInput";
+import LibraryFilterList from "components/LibraryFilterList";
+import { fetchLibraries } from "dataflow/fetchLibraries";
 import type { ClientLibrary, LibrariesResponse } from "pages/api/libraries";
-
-const FILTER_DEBOUNCE_MS = 200;
-const RESULTS_LIST_ID = "library-filter-results";
-
-async function fetchLibraries(url: string): Promise<LibrariesResponse> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error("Failed to fetch libraries");
-  return res.json();
-}
-
-/**
- * Returns the indices of matched characters in `target` (case-insensitive),
- * or null if not all query characters can be matched in order.
- * An empty query matches everything and returns [].
- */
-function fuzzyMatchIndices(query: string, target: string): number[] | null {
-  if (!query) return [];
-  const q = query.toLowerCase();
-  const t = target.toLowerCase();
-  const indices: number[] = [];
-  let qi = 0;
-  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
-    if (t[ti] === q[qi]) {
-      indices.push(ti);
-      qi++;
-    }
-  }
-  return qi === q.length ? indices : null;
-}
-
-export type MatchResult = { score: number; matchIndices: number[] };
-
-/**
- * Scores how well `query` matches `target` and returns the character indices
- * to highlight, anchored to the best match position.
- *
- * Tiers (higher is better):
- *   100 — exact match
- *    80 — target starts with query
- *    60 — any word in target starts with query
- *    40 — target contains query as a substring
- *    20 — fuzzy (all query chars appear in order)
- *     0 — no match
- */
-export function scoreMatch(query: string, target: string): MatchResult {
-  const noMatch: MatchResult = { score: 0, matchIndices: [] };
-  if (!query) return noMatch;
-
-  const q = query.toLowerCase();
-  const t = target.toLowerCase();
-  const contiguous = (start: number) =>
-    Array.from({ length: q.length }, (_, i) => start + i);
-
-  if (t.startsWith(q)) {
-    return { score: t === q ? 100 : 80, matchIndices: contiguous(0) };
-  }
-
-  let offset = 0;
-  while (offset < t.length) {
-    while (offset < t.length && /\W/.test(t[offset])) offset++;
-    const wordStart = offset;
-    while (offset < t.length && /\w/.test(t[offset])) offset++;
-    if (offset > wordStart && t.slice(wordStart, offset).startsWith(q)) {
-      return { score: 60, matchIndices: contiguous(wordStart) };
-    }
-  }
-
-  const substringIdx = t.indexOf(q);
-  if (substringIdx !== -1) {
-    return { score: 40, matchIndices: contiguous(substringIdx) };
-  }
-
-  const fuzzyIndices = fuzzyMatchIndices(query, target);
-  return fuzzyIndices !== null
-    ? { score: 20, matchIndices: fuzzyIndices }
-    : noMatch;
-}
-
-/** Renders `text` with matched characters wrapped in <mark> for search highlighting. */
-const HighlightedText: React.FC<{ text: string; matchIndices: number[] }> = ({
-  text,
-  matchIndices
-}) => {
-  if (matchIndices.length === 0) return <>{text}</>;
-  const set = new Set(matchIndices);
-  const runs: Array<[string, boolean]> = [];
-  for (let i = 0; i < text.length; ) {
-    const hl = set.has(i);
-    let j = i + 1;
-    while (j < text.length && set.has(j) === hl) j++;
-    runs.push([text.slice(i, j), hl]);
-    i = j;
-  }
-  return (
-    <>
-      {runs.map(([chunk, hl], idx) =>
-        hl ? (
-          <mark key={idx} sx={{ bg: "transparent", fontWeight: "bold" }}>
-            {chunk}
-          </mark>
-        ) : (
-          <React.Fragment key={idx}>{chunk}</React.Fragment>
-        )
-      )}
-    </>
-  );
-};
 
 const MultiLibraryHome: React.FC = () => {
   const { instanceName } = useAppConfig();
@@ -122,17 +16,6 @@ const MultiLibraryHome: React.FC = () => {
     "/api/libraries",
     fetchLibraries
   );
-
-  const [inputValue, setInputValue] = React.useState("");
-  const [filterQuery, setFilterQuery] = React.useState("");
-
-  React.useEffect(() => {
-    const timer = setTimeout(
-      () => setFilterQuery(inputValue),
-      FILTER_DEBOUNCE_MS
-    );
-    return () => clearTimeout(timer);
-  }, [inputValue]);
 
   if (error)
     return <p>Unable to load static libraries from configuration file.</p>;
@@ -148,31 +31,6 @@ const MultiLibraryHome: React.FC = () => {
 
   if (sorted.length === 0) return null;
 
-  const filteredWithScores = sorted.flatMap(lib => {
-    const displayText = lib.title || lib.slug;
-    const { score, matchIndices } = filterQuery
-      ? scoreMatch(filterQuery, displayText)
-      : { score: 0, matchIndices: [] };
-    if (filterQuery && score === 0) return [];
-    return [{ lib, displayText, matchIndices, score }];
-  });
-
-  const displayed = filterQuery
-    ? [...filteredWithScores].sort(
-        (a, b) =>
-          b.score - a.score || a.displayText.localeCompare(b.displayText)
-      )
-    : filteredWithScores;
-
-  const resultCount = displayed.length;
-  const statusMessage = filterQuery
-    ? resultCount === 0
-      ? "No libraries match."
-      : `${resultCount} ${
-          resultCount === 1 ? "library" : "libraries"
-        } shown, best matches first`
-    : "";
-
   return (
     <ThemeUIProvider theme={theme}>
       <Themed.root
@@ -184,41 +42,17 @@ const MultiLibraryHome: React.FC = () => {
         }}
       >
         <h1>{instanceName} Home</h1>
-        <h2>Choose a library:</h2>
-        <div sx={{ display: "inline-block", width: "44ch", mb: 2 }}>
-          <TextInput
-            type="search"
-            aria-label="Filter libraries"
-            aria-controls={RESULTS_LIST_ID}
-            placeholder="Filter libraries..."
-            value={inputValue}
-            onChange={e => setInputValue(e.target.value)}
-          />
-        </div>
-        {/* Always in the DOM so screen readers register the live region before content changes. */}
-        <div
-          role="status"
-          aria-live="polite"
-          aria-atomic="true"
-          sx={{ variant: "accessibility.visuallyHidden" }}
-        >
-          {statusMessage}
-        </div>
-        {filterQuery && resultCount === 0 && (
-          <p sx={{ pl: 2 }}>No libraries match.</p>
-        )}
-        <ul id={RESULTS_LIST_ID}>
-          {displayed.map(({ lib, displayText, matchIndices }) => (
-            <li key={lib.slug}>
-              <LibraryHomeLink slug={lib.slug} title={lib.title}>
-                <HighlightedText
-                  text={displayText}
-                  matchIndices={matchIndices}
-                />
-              </LibraryHomeLink>
-            </li>
-          ))}
-        </ul>
+        <LibraryFilterList
+          heading={<h2>Choose a library:</h2>}
+          items={sorted.map(lib => ({
+            slug: lib.slug,
+            label: lib.title || lib.slug
+          }))}
+          resultsListId="library-filter-results"
+          renderItem={({ slug, highlighted }) => (
+            <LibraryHomeLink slug={slug}>{highlighted}</LibraryHomeLink>
+          )}
+        />
       </Themed.root>
     </ThemeUIProvider>
   );

--- a/src/components/__tests__/MultiLibraryHome.test.tsx
+++ b/src/components/__tests__/MultiLibraryHome.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { render, screen, fireEvent, act } from "test-utils";
-import MultiLibraryHome, { scoreMatch } from "../MultiLibraryHome";
+import MultiLibraryHome from "../MultiLibraryHome";
 import useSWR from "swr";
 import { makeSwrResponse } from "test-utils/mockSwr";
 import type { LibrariesResponse } from "pages/api/libraries";
@@ -21,74 +21,6 @@ function lib(slug: string, title?: string) {
     authDocUrl: `https://example.com/${slug}/auth`
   };
 }
-
-describe("scoreMatch", () => {
-  it("returns score 0 and no indices for an empty query", () => {
-    expect(scoreMatch("", "Illinois State Library")).toEqual({
-      score: 0,
-      matchIndices: []
-    });
-  });
-
-  it("returns score 100 and full indices for an exact match", () => {
-    expect(scoreMatch("illinois", "Illinois")).toEqual({
-      score: 100,
-      matchIndices: [0, 1, 2, 3, 4, 5, 6, 7]
-    });
-  });
-
-  it("returns score 80 and leading indices when target starts with query", () => {
-    expect(scoreMatch("ill", "Illinois State Library")).toEqual({
-      score: 80,
-      matchIndices: [0, 1, 2]
-    });
-  });
-
-  it("returns score 60 and indices at the matching word when a word starts with query", () => {
-    // "Illinois" starts at index 14 in "Northern Illinois University"
-    //  N o r t h e r n   I  l  l  i  n  o  i  s
-    //  0 1 2 3 4 5 6 7 8 9 10 11 ...
-    const { score, matchIndices } = scoreMatch(
-      "ill",
-      "Northern Illinois University"
-    );
-    expect(score).toBe(60);
-    expect(matchIndices).toEqual([9, 10, 11]);
-  });
-
-  it("anchors indices to the matching word, not an earlier fuzzy opportunity", () => {
-    // "RAILS" contains 'i' and 'l' before "Illinois", but the word match wins.
-    const { score, matchIndices } = scoreMatch(
-      "ill",
-      "RAILS eRead Illinois Library"
-    );
-    expect(score).toBe(60);
-    // "Illinois" starts at index 12 in the lowercased string
-    expect(matchIndices).toEqual([12, 13, 14]);
-  });
-
-  it("returns score 40 and substring indices when query appears as a substring", () => {
-    // "ill" appears inside "Millbrook" at index 1
-    expect(scoreMatch("ill", "Millbrook Library")).toEqual({
-      score: 40,
-      matchIndices: [1, 2, 3]
-    });
-  });
-
-  it("returns score 20 and fuzzy indices for a non-contiguous match", () => {
-    // "ill" in "Tidal Library": i→1, l→4, l→6 (T-i-d-a-l- -L-i...)
-    const { score, matchIndices } = scoreMatch("ill", "Tidal Library");
-    expect(score).toBe(20);
-    expect(matchIndices).toEqual([1, 4, 6]);
-  });
-
-  it("returns score 0 and no indices when there is no match", () => {
-    expect(scoreMatch("zzz", "Alpha Library")).toEqual({
-      score: 0,
-      matchIndices: []
-    });
-  });
-});
 
 describe("MultiLibraryHome", () => {
   afterEach(() => {

--- a/src/dataflow/fetchLibraries.ts
+++ b/src/dataflow/fetchLibraries.ts
@@ -1,0 +1,7 @@
+import type { LibrariesResponse } from "pages/api/libraries";
+
+export async function fetchLibraries(url: string): Promise<LibrariesResponse> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error("Failed to fetch libraries");
+  return res.json();
+}

--- a/src/utils/__tests__/libraryFilter.test.ts
+++ b/src/utils/__tests__/libraryFilter.test.ts
@@ -1,0 +1,69 @@
+import { scoreMatch } from "utils/libraryFilter";
+
+describe("scoreMatch", () => {
+  it("returns score 0 and no indices for an empty query", () => {
+    expect(scoreMatch("", "Illinois State Library")).toEqual({
+      score: 0,
+      matchIndices: []
+    });
+  });
+
+  it("returns score 100 and full indices for an exact match", () => {
+    expect(scoreMatch("illinois", "Illinois")).toEqual({
+      score: 100,
+      matchIndices: [0, 1, 2, 3, 4, 5, 6, 7]
+    });
+  });
+
+  it("returns score 80 and leading indices when target starts with query", () => {
+    expect(scoreMatch("ill", "Illinois State Library")).toEqual({
+      score: 80,
+      matchIndices: [0, 1, 2]
+    });
+  });
+
+  it("returns score 60 and indices at the matching word when a word starts with query", () => {
+    // "Illinois" starts at index 14 in "Northern Illinois University"
+    //  N o r t h e r n   I  l  l  i  n  o  i  s
+    //  0 1 2 3 4 5 6 7 8 9 10 11 ...
+    const { score, matchIndices } = scoreMatch(
+      "ill",
+      "Northern Illinois University"
+    );
+    expect(score).toBe(60);
+    expect(matchIndices).toEqual([9, 10, 11]);
+  });
+
+  it("anchors indices to the matching word, not an earlier fuzzy opportunity", () => {
+    // "RAILS" contains 'i' and 'l' before "Illinois", but the word match wins.
+    const { score, matchIndices } = scoreMatch(
+      "ill",
+      "RAILS eRead Illinois Library"
+    );
+    expect(score).toBe(60);
+    // "Illinois" starts at index 12 in the lowercased string
+    expect(matchIndices).toEqual([12, 13, 14]);
+  });
+
+  it("returns score 40 and substring indices when query appears as a substring", () => {
+    // "ill" appears inside "Millbrook" at index 1
+    expect(scoreMatch("ill", "Millbrook Library")).toEqual({
+      score: 40,
+      matchIndices: [1, 2, 3]
+    });
+  });
+
+  it("returns score 20 and fuzzy indices for a non-contiguous match", () => {
+    // "ill" in "Tidal Library": i→1, l→4, l→6 (T-i-d-a-l- -L-i...)
+    const { score, matchIndices } = scoreMatch("ill", "Tidal Library");
+    expect(score).toBe(20);
+    expect(matchIndices).toEqual([1, 4, 6]);
+  });
+
+  it("returns score 0 and no indices when there is no match", () => {
+    expect(scoreMatch("zzz", "Alpha Library")).toEqual({
+      score: 0,
+      matchIndices: []
+    });
+  });
+});

--- a/src/utils/libraryFilter.ts
+++ b/src/utils/libraryFilter.ts
@@ -1,0 +1,70 @@
+export type MatchResult = { score: number; matchIndices: number[] };
+
+/**
+ * Returns the indices of matched characters in `target` (case-insensitive),
+ * or null if not all query characters can be matched in order.
+ * An empty query matches everything and returns [].
+ */
+export function fuzzyMatchIndices(
+  query: string,
+  target: string
+): number[] | null {
+  if (!query) return [];
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  const indices: number[] = [];
+  let qi = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      indices.push(ti);
+      qi++;
+    }
+  }
+  return qi === q.length ? indices : null;
+}
+
+/**
+ * Scores how well `query` matches `target` and returns the character indices
+ * to highlight, anchored to the best match position.
+ *
+ * Tiers (higher is better):
+ *   100 — exact match
+ *    80 — target starts with query
+ *    60 — any word in target starts with query
+ *    40 — target contains query as a substring
+ *    20 — fuzzy (all query chars appear in order)
+ *     0 — no match
+ */
+export function scoreMatch(query: string, target: string): MatchResult {
+  const noMatch: MatchResult = { score: 0, matchIndices: [] };
+  if (!query) return noMatch;
+
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+  const contiguous = (start: number) =>
+    Array.from({ length: q.length }, (_, i) => start + i);
+
+  if (t.startsWith(q)) {
+    return { score: t === q ? 100 : 80, matchIndices: contiguous(0) };
+  }
+
+  let offset = 0;
+  while (offset < t.length) {
+    while (offset < t.length && /\W/.test(t[offset])) offset++;
+    const wordStart = offset;
+    while (offset < t.length && /\w/.test(t[offset])) offset++;
+    if (offset > wordStart && t.slice(wordStart, offset).startsWith(q)) {
+      return { score: 60, matchIndices: contiguous(wordStart) };
+    }
+  }
+
+  const substringIdx = t.indexOf(q);
+  if (substringIdx !== -1) {
+    return { score: 40, matchIndices: contiguous(substringIdx) };
+  }
+
+  const fuzzyIndices = fuzzyMatchIndices(query, target);
+  return fuzzyIndices !== null
+    ? { score: 20, matchIndices: fuzzyIndices }
+    : noMatch;
+}


### PR DESCRIPTION
## Description

- Refactors the multi-library home page by extracting its filtering functionality into standalone, reusable modules, with no changes in behavior.
- Reorganizes the code a little.

The home page now composes these pieces instead of implementing them inline.

## Motivation and Context

The filtering logic was embedded in the multi-library home page component, so it was not easy to use elsewhere. And location of some of the functionality did not match the organizational model of the project. 

Extracting this into reusable pieces supports future work (e.g., on PP-3760).

[Jira PP-3760]

## How Has This Been Tested?

- Manual testing in local development environment.
- All checks continue to pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/29512003945) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
