### PR TITLE
Standardize breadcrumbs for search results collection (PP-4675)

### DIFF
--- a/src/__tests__/computeBreadcrumbs.test.tsx
+++ b/src/__tests__/computeBreadcrumbs.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "@jest/globals";
 import computeBreadcrumbs from "../computeBreadcrumbs";
+import { CollectionData, LinkData } from "interfaces";
 
 describe("computeBreadcrumbs", () => {
   const collection = {
@@ -74,40 +75,90 @@ describe("computeBreadcrumbs", () => {
       parentLink
     });
 
-    test("drops the lane when the search feed provides simplified:breadcrumbs", () => {
-      const raw = {
-        "simplified:breadcrumbs": [
-          {
-            link: [
-              {
-                $: {
-                  href: { value: catalogRootLink.url },
-                  title: { value: catalogRootLink.text }
-                }
-              },
-              {
-                $: {
-                  href: { value: parentLink.url },
-                  title: { value: parentLink.text }
-                }
-              }
-            ]
-          }
-        ]
-      };
-      const data = Object.assign({}, searchCollection, { raw });
-      expect(computeBreadcrumbs(data)).toEqual([
-        catalogRootLink,
-        { url: searchCollection.url, text: collection.title }
-      ]);
-    });
+    const urlWithTrailingSlash =
+      "http://cm.example/search/1120/?entrypoint=All&q=love";
+    const searchDataUrlWithTrailingSlash =
+      "http://cm.example/search/1120/?entrypoint=All";
 
-    test("drops the lane when the search feed only has hierarchy links", () => {
-      expect(computeBreadcrumbs(searchCollection)).toEqual([
-        catalogRootLink,
-        { url: searchCollection.url, text: collection.title }
-      ]);
-    });
+    const raw = {
+      "simplified:breadcrumbs": [
+        {
+          link: [
+            {
+              $: {
+                href: { value: catalogRootLink.url },
+                title: { value: catalogRootLink.text }
+              }
+            },
+            {
+              $: {
+                href: { value: parentLink.url },
+                title: { value: parentLink.text }
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    const simplifiedBreadcrumbsCases: Array<
+      [string, CollectionData, Array<LinkData>]
+    > = [
+      [
+        "matching pathnames have no trailing slashes",
+        { ...searchCollection, raw },
+        [catalogRootLink, { url: searchCollection.url, text: collection.title }]
+      ],
+      [
+        "one pathname has a trailing slash",
+        { ...searchCollection, url: urlWithTrailingSlash, raw },
+        [catalogRootLink, { url: urlWithTrailingSlash, text: collection.title }]
+      ],
+      [
+        "both matching pathnames have trailing slashes",
+        {
+          ...searchCollection,
+          url: urlWithTrailingSlash,
+          searchDataUrl: searchDataUrlWithTrailingSlash,
+          raw
+        },
+        [catalogRootLink, { url: urlWithTrailingSlash, text: collection.title }]
+      ]
+    ];
+
+    test.each(simplifiedBreadcrumbsCases)(
+      "drops the lane when the search feed provides simplified:breadcrumbs where %s",
+      (_label, collection, expected) =>
+        expect(computeBreadcrumbs(collection)).toEqual(expected)
+    );
+
+    const hierachyCases: Array<[string, CollectionData, Array<LinkData>]> = [
+      [
+        "with matching pathnames that have no trailing slashes",
+        searchCollection,
+        [catalogRootLink, { url: searchCollection.url, text: collection.title }]
+      ],
+      [
+        "where one pathname has a trailing slash",
+        { ...searchCollection, url: urlWithTrailingSlash },
+        [catalogRootLink, { url: urlWithTrailingSlash, text: collection.title }]
+      ],
+      [
+        "that both have matching pathnames with trailing slashes",
+        {
+          ...searchCollection,
+          url: urlWithTrailingSlash,
+          searchDataUrl: searchDataUrlWithTrailingSlash
+        },
+        [catalogRootLink, { url: urlWithTrailingSlash, text: collection.title }]
+      ]
+    ];
+
+    test.each(hierachyCases)(
+      "drops the lane when the search feed only has hierarchy links %s",
+      (_label, collection, expected) =>
+        expect(computeBreadcrumbs(collection)).toEqual(expected)
+    );
 
     test("keeps the lane on a browse feed", () => {
       const data = Object.assign({}, searchCollection, {

--- a/src/__tests__/computeBreadcrumbs.test.tsx
+++ b/src/__tests__/computeBreadcrumbs.test.tsx
@@ -57,4 +57,76 @@ describe("computeBreadcrumbs", () => {
     ];
     expect(computeBreadcrumbs(data)).toEqual(expected);
   });
+
+  describe("search results", () => {
+    const catalogRootLink = {
+      url: "http://cm.example/groups/",
+      text: "All Books"
+    };
+    const parentLink = {
+      url: "http://cm.example/feed/1120",
+      text: "Adventure"
+    };
+    const searchCollection = Object.assign({}, collection, {
+      url: "http://cm.example/search/1120?entrypoint=All&q=love",
+      searchDataUrl: "http://cm.example/search/1120?entrypoint=All",
+      catalogRootLink,
+      parentLink
+    });
+
+    test("drops the lane when the search feed provides simplified:breadcrumbs", () => {
+      const raw = {
+        "simplified:breadcrumbs": [
+          {
+            link: [
+              {
+                $: {
+                  href: { value: catalogRootLink.url },
+                  title: { value: catalogRootLink.text }
+                }
+              },
+              {
+                $: {
+                  href: { value: parentLink.url },
+                  title: { value: parentLink.text }
+                }
+              }
+            ]
+          }
+        ]
+      };
+      const data = Object.assign({}, searchCollection, { raw });
+      expect(computeBreadcrumbs(data)).toEqual([
+        catalogRootLink,
+        { url: searchCollection.url, text: collection.title }
+      ]);
+    });
+
+    test("drops the lane when the search feed only has hierarchy links", () => {
+      expect(computeBreadcrumbs(searchCollection)).toEqual([
+        catalogRootLink,
+        { url: searchCollection.url, text: collection.title }
+      ]);
+    });
+
+    test("keeps the lane on a browse feed", () => {
+      const data = Object.assign({}, searchCollection, {
+        url: "http://cm.example/feed/1120?entrypoint=All"
+      });
+      expect(computeBreadcrumbs(data)).toEqual([
+        catalogRootLink,
+        parentLink,
+        { url: data.url, text: collection.title }
+      ]);
+    });
+
+    test("treats a collection without a searchDataUrl as a browse feed", () => {
+      const data = Object.assign({}, searchCollection, { searchDataUrl: null });
+      expect(computeBreadcrumbs(data)).toEqual([
+        catalogRootLink,
+        parentLink,
+        { url: searchCollection.url, text: collection.title }
+      ]);
+    });
+  });
 });

--- a/src/computeBreadcrumbs.tsx
+++ b/src/computeBreadcrumbs.tsx
@@ -14,8 +14,39 @@ const urlComparator = (
   return !!(url1 && url2) && url1 === url2;
 };
 
+/**
+ * A collection is a search results feed when its own url
+ * shares a pathname with its search description url
+ */
+export function isSearchResultsCollection(
+  collection?: CollectionData
+): boolean {
+  if (!collection?.url || !collection.searchDataUrl) return false;
+  // provide dummy base URL in case collection.url
+  // or collection.searchDataUrl are relative links
+  const base = "http://base";
+  try {
+    return (
+      new URL(collection.url, base).pathname ===
+      new URL(collection.searchDataUrl, base).pathname
+    );
+  } catch {
+    return false;
+  }
+}
+
 const computeBreadcrumbs = (collection?: CollectionData): LinkData[] => {
   let links: LinkData[] = [];
+
+  // Currently, search runs across the entire catalog.
+  // So no matter where search originates (home, lane, my books, etc.),
+  // the breadcrumbs should be uniform: Catalog Root / Search
+  if (collection && isSearchResultsCollection(collection)) {
+    return hierarchyComputeBreadcrumbs(
+      { ...collection, parentLink: undefined },
+      urlComparator
+    );
+  }
 
   if (
     collection &&

--- a/src/computeBreadcrumbs.tsx
+++ b/src/computeBreadcrumbs.tsx
@@ -18,18 +18,15 @@ const urlComparator = (
  * A collection is a search results feed when its own url
  * shares a pathname with its search description url
  */
-export function isSearchResultsCollection(
-  collection?: CollectionData
-): boolean {
-  if (!collection?.url || !collection.searchDataUrl) return false;
-  // provide dummy base URL in case collection.url
-  // or collection.searchDataUrl are relative links
-  const base = "http://base";
+function isSearchResultsCollection(collection?: CollectionData): boolean {
+  if (!collection?.url || !collection?.searchDataUrl) return false;
+  // Palace CM currently always provides absolute collection and search URLs
   try {
-    return (
-      new URL(collection.url, base).pathname ===
-      new URL(collection.searchDataUrl, base).pathname
+    const { pathname: collectionPathname } = new URL(collection.url);
+    const { pathname: searchDataUrlPathname } = new URL(
+      collection.searchDataUrl
     );
+    return urlComparator(collectionPathname, searchDataUrlPathname);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
When computing breadcrumbs, the CPW will now consider whether or not the collection is a search results feed. When that is the case, the breadcrumbs will now only display the name provided for the catalog root and "Search." For example, a search conduced from a "New & Noteworthy" collection lane will have its name dropped:

`All Books / New & Noteworthy / Search` -> `All Books / Search`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When conducting a search from any page, the breadcrumbs previously included the lane from where the search originated. This incorrectly suggested that the search would be scoped to items within that collection. Searches from any page are performed on the entire catalog. Displaying the breadcrumbs as Catalog Root / "Search" provides a more accurate description of the search results to the user.

[Jira PP-4675](https://ebce-lyrasis.atlassian.net/browse/PP-4675)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually tested in Firefox, Chrome, and Safari
- Unit tests check for presence of lane when running `computeBreadcrumbs`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
