### PR TITLE
Experimental canonical resource URL support POC (PP-3760)

### DIFF
--- a/community-config.yml
+++ b/community-config.yml
@@ -118,3 +118,23 @@ static_libraries:
 # authentication_documents:
 #   refresh_min_interval: 60   # Minimum seconds between re-fetch attempts (default: 60)
 #   refresh_max_interval: 300  # Seconds before a cached auth doc is considered stale (default: 300)
+#
+# ITEM LANDING SLUGS
+#
+# The path segments reserved for the cross-library item landing page
+# (/_item_/{workId} by default). The slugs are resolved at runtime, so
+# overriding them here moves the landing page without a rebuild. Every listed
+# slug serves the page, which allows migrating from one slug to another with
+# both active until the migration is complete; an empty list disables the
+# landing page. A library whose slug matches an active value is shadowed by
+# the landing page; such collisions are logged as warnings.
+#
+# Slugs equal to a path segment reserved by Next.js ("api", "_next") can never
+# serve the landing page; such entries are disabled and an error is logged.
+#
+# A single value or a list is accepted:
+#
+# item_landing_slugs: _item_
+# item_landing_slugs:
+#   - _item_
+#   - item

--- a/src/components/ItemLandingPage.tsx
+++ b/src/components/ItemLandingPage.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { ThemeUIProvider } from "theme-ui";
+import { Themed } from "@theme-ui/mdx";
+import WorkLibrarySelector from "components/WorkLibrarySelector";
+import theme from "theme/theme";
+
+interface ItemLandingPageProps {
+  workId: string;
+}
+
+const ItemLandingPage: React.FC<ItemLandingPageProps> = ({ workId }) => (
+  <ThemeUIProvider theme={theme}>
+    <Themed.root
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        minHeight: "100vh",
+        m: 3
+      }}
+    >
+      <h1>Find a Library</h1>
+      <WorkLibrarySelector workId={workId} />
+    </Themed.root>
+  </ThemeUIProvider>
+);
+
+export default ItemLandingPage;

--- a/src/components/WorkLibrarySelector.tsx
+++ b/src/components/WorkLibrarySelector.tsx
@@ -1,0 +1,284 @@
+import * as React from "react";
+import useSWR from "swr";
+import { useRouter } from "next/router";
+import type { ClientLibrary, LibrariesResponse } from "pages/api/libraries";
+import type { CatalogUrlResponse } from "pages/api/catalog-url";
+import LibraryFilterList from "components/LibraryFilterList";
+import { fetchLibraries } from "dataflow/fetchLibraries";
+import { buildWorkUrl } from "utils/workUrl";
+
+/*
+ * Bounds a selection resolve (catalog URL lookup plus availability pre-flight)
+ * so a hung server cannot leave every card blocked. On timeout the in-flight
+ * fetch aborts and the generic connectivity error is shown.
+ */
+export const RESOLVE_TIMEOUT_MS = 15000;
+
+interface WorkLibrarySelectorProps {
+  workId: string;
+}
+
+const WorkLibrarySelector: React.FC<WorkLibrarySelectorProps> = ({
+  workId
+}) => {
+  const { data, error } = useSWR<LibrariesResponse>(
+    "/api/libraries",
+    fetchLibraries
+  );
+  const searchContainerRef = React.useRef<HTMLDivElement>(null);
+  /*
+   * Slug of the card currently resolving a selection, or null. Held here
+   * rather than per card so a resolve in flight blocks selection on every
+   * card; otherwise two cards could race and the later navigation would win.
+   */
+  const [resolvingSlug, setResolvingSlug] = React.useState<string | null>(null);
+
+  function focusSearch() {
+    const input = searchContainerRef.current?.querySelector("input");
+    input?.focus();
+    searchContainerRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest"
+    });
+  }
+
+  if (error) return <p>Unable to load the library list.</p>;
+  if (!data?.libraries) return null;
+
+  const sorted = [...data.libraries].sort((a, b) => {
+    const titleA = a.title || a.slug;
+    const titleB = b.title || b.slug;
+    return titleA.localeCompare(titleB);
+  });
+  const librariesBySlug = new Map(sorted.map(lib => [lib.slug, lib]));
+
+  return (
+    <div ref={searchContainerRef}>
+      <LibraryFilterList
+        heading={<h2>Choose your library to view this item:</h2>}
+        items={sorted.map(lib => ({
+          slug: lib.slug,
+          label: lib.title || lib.slug
+        }))}
+        resultsListId="work-library-selector-results"
+        renderItem={({ slug, label, highlighted }) => {
+          const library = librariesBySlug.get(slug);
+          if (!library) return null;
+          return (
+            <LibrarySelectorCard
+              library={library}
+              workId={workId}
+              label={label}
+              highlighted={highlighted}
+              onBackToSearch={focusSearch}
+              resolvingSlug={resolvingSlug}
+              onResolvingChange={setResolvingSlug}
+            />
+          );
+        }}
+      />
+    </div>
+  );
+};
+
+export default WorkLibrarySelector;
+
+interface LibrarySelectorCardProps {
+  library: ClientLibrary;
+  workId: string;
+  label: string;
+  highlighted: React.ReactNode;
+  onBackToSearch: () => void;
+  /** Slug of the card currently resolving a selection, or null. */
+  resolvingSlug: string | null;
+  onResolvingChange: (slug: string | null) => void;
+}
+
+const LibrarySelectorCard: React.FC<LibrarySelectorCardProps> = ({
+  library,
+  workId,
+  label,
+  highlighted,
+  onBackToSearch,
+  resolvingSlug,
+  onResolvingChange
+}) => {
+  const router = useRouter();
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const abortRef = React.useRef<AbortController | null>(null);
+  const userCancelledRef = React.useRef(false);
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+  const anyResolving = resolvingSlug !== null;
+  const isResolving = resolvingSlug === library.slug;
+
+  /*
+   * Escape cancels an in-flight resolve. Only the resolving card attaches the
+   * listener, and it listens on document rather than the button so the cancel
+   * works no matter where focus is. A user cancel aborts the same controller
+   * as the timeout; userCancelledRef tells the catch below to reset quietly
+   * instead of showing the connectivity error.
+   */
+  React.useEffect(() => {
+    if (!isResolving) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        userCancelledRef.current = true;
+        abortRef.current?.abort();
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isResolving]);
+
+  async function handleSelect() {
+    // Reentrancy guard: buttons stay enabled while a resolve is in flight
+    // (see the aria-disabled comment below), so activations during that time,
+    // whether on this card or another, must be ignored here instead.
+    if (anyResolving) return;
+    onResolvingChange(library.slug);
+    setErrorMessage(null);
+    userCancelledRef.current = false;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const timeoutId = setTimeout(() => controller.abort(), RESOLVE_TIMEOUT_MS);
+    let destination = "";
+    try {
+      const res = await fetch(
+        `/api/catalog-url?slug=${encodeURIComponent(library.slug)}`,
+        { signal: controller.signal }
+      );
+      if (res.status === 404) {
+        setErrorMessage("This library is unavailable.");
+        onResolvingChange(null);
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const { catalogUrl }: CatalogUrlResponse = await res.json();
+      const bookUrl = buildWorkUrl(catalogUrl, workId);
+
+      // Pre-flight check: confirm the item exists in this library before
+      // navigating away. A 404 means the item is not in the collection; 5xx
+      // and network errors are reachability problems. Other error statuses
+      // (e.g. 401 from a catalog that requires authentication to view
+      // entries) leave availability unknown, so navigation proceeds and the
+      // book page's own auth flow takes over. Only the status is needed, so
+      // the body is cancelled rather than downloaded; the book page
+      // re-fetches the entry after navigation. cancel is optionally called
+      // because the whatwg-fetch polyfill used in tests has a non-stream body.
+      const check = await fetch(bookUrl, { signal: controller.signal });
+      check.body?.cancel?.();
+      if (check.status === 404) {
+        setErrorMessage(
+          `The item with identifier “${workId}” is not currently ` +
+            `available through this library (“${label}”).`
+        );
+        onResolvingChange(null);
+        return;
+      }
+      if (check.status >= 500) throw new Error(`HTTP ${check.status}`);
+
+      destination = `/${library.slug}/book/${encodeURIComponent(bookUrl)}`;
+    } catch {
+      if (!userCancelledRef.current) {
+        setErrorMessage("Unable to reach this library.");
+      }
+      onResolvingChange(null);
+      return;
+    } finally {
+      clearTimeout(timeoutId);
+      abortRef.current = null;
+    }
+    // Outside the try above so a navigation failure is not mislabeled as a
+    // library connectivity error.
+    try {
+      await router.push(destination);
+    } catch {
+      setErrorMessage("Unable to open this item.");
+      onResolvingChange(null);
+    }
+  }
+
+  return (
+    <div sx={{ mb: 1 }}>
+      {/*
+       * A <button> rather than <a> is correct here: the destination URL is not
+       * known until the async /api/catalog-url call resolves, so there is no
+       * href to give a link. aria-busy signals the loading state to screen
+       * readers; the visual "Opening…" span (which also advertises the Escape
+       * cancel) is aria-hidden to avoid duplication.
+       * aria-disabled is used instead of disabled while a resolve is in
+       * flight so keyboard focus stays on the button (disabled would drop
+       * focus to the body); handleSelect ignores activations made during the
+       * resolve. Every card is marked disabled during a resolve because
+       * selection is blocked everywhere, not just on the resolving card.
+       * role="alert" on errors makes them announced without requiring focus;
+       * it wraps only the message text so the buttons in the error panel are
+       * not announced as live-region content.
+       */}
+      <button
+        ref={buttonRef}
+        onClick={handleSelect}
+        aria-disabled={anyResolving}
+        aria-busy={isResolving}
+        sx={{
+          background: "none",
+          border: "none",
+          p: 0,
+          cursor: isResolving
+            ? "wait"
+            : anyResolving
+              ? "not-allowed"
+              : "pointer",
+          color: "inherit",
+          font: "inherit",
+          textAlign: "left",
+          textDecoration: "underline"
+        }}
+      >
+        {highlighted}
+        {isResolving && (
+          <span aria-hidden="true" sx={{ ml: 2, fontSize: 0 }}>
+            Opening… (Esc to cancel)
+          </span>
+        )}
+      </button>
+      {errorMessage && (
+        <div
+          sx={{
+            mt: 1,
+            p: 2,
+            border: "1px solid",
+            borderColor: "ui.error",
+            borderRadius: 2
+          }}
+        >
+          <span
+            role="alert"
+            sx={{ display: "block", color: "ui.error", fontSize: 1, mb: 1 }}
+          >
+            {errorMessage}
+          </span>
+          <button
+            onClick={() => {
+              setErrorMessage(null);
+              onBackToSearch();
+            }}
+            sx={{ mr: 2, cursor: "pointer" }}
+          >
+            Back to search
+          </button>
+          <button
+            onClick={() => {
+              setErrorMessage(null);
+              requestAnimationFrame(() => buttonRef.current?.focus());
+            }}
+            sx={{ cursor: "pointer" }}
+          >
+            OK
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/__tests__/ItemLandingPage.test.tsx
+++ b/src/components/__tests__/ItemLandingPage.test.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { render, screen } from "test-utils";
+import useSWR from "swr";
+import ItemLandingPage from "../ItemLandingPage";
+import { makeSwrResponse } from "test-utils/mockSwr";
+
+jest.mock("swr");
+
+const mockedSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+
+test("renders a heading and passes workId down to the library selector", () => {
+  mockedSWR.mockReturnValue(
+    makeSwrResponse<any>({
+      data: {
+        libraries: [
+          {
+            id: "urn:testlib",
+            slug: "testlib",
+            title: "Test Library",
+            authDocUrl: "https://example.com/testlib/auth"
+          }
+        ]
+      }
+    })
+  );
+
+  render(<ItemLandingPage workId="work-1" />);
+
+  expect(
+    screen.getByRole("heading", { level: 1, name: "Find a Library" })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", { name: "Test Library" })
+  ).toBeInTheDocument();
+});

--- a/src/components/__tests__/WorkLibrarySelector.test.tsx
+++ b/src/components/__tests__/WorkLibrarySelector.test.tsx
@@ -1,0 +1,433 @@
+import * as React from "react";
+import { act, render, screen, fireEvent, setup, waitFor } from "test-utils";
+import useSWR from "swr";
+import fetchMock from "jest-fetch-mock";
+import WorkLibrarySelector, {
+  RESOLVE_TIMEOUT_MS
+} from "../WorkLibrarySelector";
+import { makeSwrResponse } from "test-utils/mockSwr";
+import { mockPush } from "test-utils/mockNextRouter";
+import type { LibrariesResponse } from "pages/api/libraries";
+
+jest.mock("swr");
+
+const mockedSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+
+function mockLibraries(libraries: LibrariesResponse["libraries"]) {
+  mockedSWR.mockReturnValue(makeSwrResponse<any>({ data: { libraries } }));
+}
+
+function lib(slug: string, title?: string) {
+  return {
+    id: `urn:${slug}`,
+    slug,
+    title: title ?? slug,
+    authDocUrl: `https://example.com/${slug}/auth`
+  };
+}
+
+// jsdom has no scrollIntoView implementation.
+Element.prototype.scrollIntoView = jest.fn();
+
+/*
+ * Mocks a fetch that never settles until its abort signal fires, then rejects
+ * the way a real aborted fetch does. jest-fetch-mock does not react to the
+ * signal option on its own.
+ */
+function mockPendingFetchOnce() {
+  fetchMock.mockImplementationOnce(
+    (input?: string | Request, init?: RequestInit) =>
+      new Promise<Response>((resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(new DOMException("The operation was aborted.", "AbortError"))
+        );
+      })
+  );
+}
+
+describe("WorkLibrarySelector", () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null while loading", () => {
+    mockedSWR.mockReturnValue(makeSwrResponse<any>({ data: undefined }));
+    const { container } = render(<WorkLibrarySelector workId="work-1" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("displays an error message on fetch error", () => {
+    mockedSWR.mockReturnValue(
+      makeSwrResponse<any>({
+        data: undefined,
+        error: new Error("fetch failed")
+      })
+    );
+    render(<WorkLibrarySelector workId="work-1" />);
+    expect(
+      screen.getByText("Unable to load the library list.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders a heading and a card for each library", () => {
+    mockLibraries([lib("alpha", "Alpha Library"), lib("beta", "Beta Library")]);
+    render(<WorkLibrarySelector workId="work-1" />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Choose your library to view this item:"
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Alpha Library" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Beta Library" })
+    ).toBeInTheDocument();
+  });
+
+  it("sorts libraries by title", () => {
+    mockLibraries([
+      lib("zebra", "Zebra Library"),
+      lib("alpha", "Alpha Library")
+    ]);
+    render(<WorkLibrarySelector workId="work-1" />);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons[0]).toHaveTextContent("Alpha Library");
+    expect(buttons[1]).toHaveTextContent("Zebra Library");
+  });
+
+  it("navigates to the book page when the item is available", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 200 }]
+    );
+    const { user } = setup(<WorkLibrarySelector workId="work-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+
+    const expectedBookUrl = "https://alpha.example.com/catalog/works/work-1";
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith(
+        `/alpha/book/${encodeURIComponent(expectedBookUrl)}`
+      )
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/catalog-url?slug=alpha",
+      {
+        signal: expect.any(AbortSignal)
+      }
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(2, expectedBookUrl, {
+      signal: expect.any(AbortSignal)
+    });
+  });
+
+  it("shows an 'Opening…' loading state while resolving", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 200 }]
+    );
+    render(<WorkLibrarySelector workId="work-1" />);
+
+    const button = screen.getByRole("button", { name: "Alpha Library" });
+    fireEvent.click(button);
+
+    expect(screen.getByText("Opening… (Esc to cancel)")).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button).toHaveAttribute("aria-disabled", "true");
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalled());
+  });
+
+  it("cancels the resolve without an error when the user presses Escape", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    mockPendingFetchOnce();
+    render(<WorkLibrarySelector workId="work-1" />);
+
+    const button = screen.getByRole("button", { name: "Alpha Library" });
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(button).toHaveAttribute("aria-disabled", "false")
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  // Fake timers are enabled globally (jest.config.js), so the resolve
+  // timeout can be advanced directly without installing or restoring timers.
+  it("aborts the resolve and shows an error when it times out", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    mockPendingFetchOnce();
+    render(<WorkLibrarySelector workId="work-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Alpha Library" }));
+    act(() => {
+      jest.advanceTimersByTime(RESOLVE_TIMEOUT_MS);
+    });
+
+    expect(
+      await screen.findByText("Unable to reach this library.")
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("ignores additional activations while resolving", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 200 }]
+    );
+    render(<WorkLibrarySelector workId="work-1" />);
+
+    const button = screen.getByRole("button", { name: "Alpha Library" });
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("blocks selection on every card while one is resolving", async () => {
+    mockLibraries([lib("alpha", "Alpha Library"), lib("beta", "Beta Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 200 }]
+    );
+    render(<WorkLibrarySelector workId="work-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Alpha Library" }));
+    const betaButton = screen.getByRole("button", { name: "Beta Library" });
+    expect(betaButton).toHaveAttribute("aria-disabled", "true");
+    fireEvent.click(betaButton);
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledTimes(1));
+    expect(mockPush).toHaveBeenCalledWith(
+      `/alpha/book/${encodeURIComponent(
+        "https://alpha.example.com/catalog/works/work-1"
+      )}`
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).not.toHaveBeenCalledWith("/api/catalog-url?slug=beta");
+  });
+
+  it("shows an unavailable-library error when catalog-url lookup 404s", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponseOnce("", { status: 404 });
+    const { user } = setup(<WorkLibrarySelector workId="work-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+
+    expect(
+      await screen.findByText("This library is unavailable.")
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows the error panel when the catalog-url request fails", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockRejectOnce(new Error("network down"));
+    const { user } = setup(<WorkLibrarySelector workId="work-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+
+    expect(
+      await screen.findByText("Unable to reach this library.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Back to search" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "OK" })).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("shows a generic error when the catalog-url request returns a non-404 error status", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponseOnce("", { status: 500 });
+    const { user } = setup(<WorkLibrarySelector workId="work-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+
+    expect(
+      await screen.findByText("Unable to reach this library.")
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("percent-encodes the workId when building the book URL", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 200 }]
+    );
+    const { user } = setup(<WorkLibrarySelector workId="urn:uuid:1/2" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+
+    const expectedBookUrl =
+      "https://alpha.example.com/catalog/works/urn%3Auuid%3A1%2F2";
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith(
+        `/alpha/book/${encodeURIComponent(expectedBookUrl)}`
+      )
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(2, expectedBookUrl, {
+      signal: expect.any(AbortSignal)
+    });
+  });
+
+  it("shows a generic error when the pre-flight check returns a 5xx status", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 500 }]
+    );
+    const { user } = setup(<WorkLibrarySelector workId="work-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+
+    expect(
+      await screen.findByText("Unable to reach this library.")
+    ).toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("navigates when the pre-flight check returns an auth-gated status", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 401 }]
+    );
+    const { user } = setup(<WorkLibrarySelector workId="work-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+
+    const expectedBookUrl = "https://alpha.example.com/catalog/works/work-1";
+    await waitFor(() =>
+      expect(mockPush).toHaveBeenCalledWith(
+        `/alpha/book/${encodeURIComponent(expectedBookUrl)}`
+      )
+    );
+  });
+
+  it("shows an error and makes the card selectable again when navigation fails", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 200 }]
+    );
+    mockPush.mockRejectedValueOnce(new Error("route load failed"));
+    const { user } = setup(<WorkLibrarySelector workId="work-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+
+    expect(
+      await screen.findByText("Unable to open this item.")
+    ).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: "Alpha Library" });
+    expect(button).toHaveAttribute("aria-disabled", "false");
+    expect(button).toHaveFocus();
+  });
+
+  it("shows an item-unavailable panel when the pre-flight check fails", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 404 }]
+    );
+    const { user } = setup(<WorkLibrarySelector workId="work-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(
+      "The item with identifier “work-1” is not currently available through this library (“Alpha Library”)."
+    );
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("dismisses the unavailable panel and refocuses search on 'Back to search'", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 404 }]
+    );
+    const { user } = setup(<WorkLibrarySelector workId="work-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+    await screen.findByRole("alert");
+
+    await user.click(screen.getByRole("button", { name: "Back to search" }));
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("searchbox", { name: /filter libraries/i })
+    ).toHaveFocus();
+  });
+
+  it("dismisses the unavailable panel and refocuses the card on 'OK'", async () => {
+    mockLibraries([lib("alpha", "Alpha Library")]);
+    fetchMock.mockResponses(
+      [
+        JSON.stringify({ catalogUrl: "https://alpha.example.com/catalog" }),
+        { status: 200 }
+      ],
+      ["", { status: 404 }]
+    );
+    const { user } = setup(<WorkLibrarySelector workId="work-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Alpha Library" }));
+    await screen.findByRole("alert");
+
+    await user.click(screen.getByRole("button", { name: "OK" }));
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Alpha Library" })
+      ).toHaveFocus()
+    );
+  });
+});

--- a/src/config/fallbackAppConfig.ts
+++ b/src/config/fallbackAppConfig.ts
@@ -1,4 +1,5 @@
 import type { AppConfig } from "interfaces";
+import { DEFAULT_ITEM_LANDING_SLUG } from "constants/app";
 
 const FALLBACK_APP_CONFIG: AppConfig = {
   instanceName: "",
@@ -7,7 +8,8 @@ const FALLBACK_APP_CONFIG: AppConfig = {
   showMedium: true,
   bugsnagApiKey: null,
   openebooks: null,
-  authenticationDocuments: null
+  authenticationDocuments: null,
+  itemLandingSlugs: [DEFAULT_ITEM_LANDING_SLUG]
 };
 
 export default FALLBACK_APP_CONFIG;

--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -1,0 +1,15 @@
+/**
+ * Default path segment for the cross-library item landing route, served by
+ * src/pages/[library]/[workId].tsx when the first path segment matches. The
+ * active values (this default, or the item_landing_slugs config override) are
+ * reserved: a library whose slug matches one is shadowed by the landing page.
+ */
+export const DEFAULT_ITEM_LANDING_SLUG = "_item_";
+
+/**
+ * First path segments that Next.js consumes before page routing reaches
+ * src/pages (API routes and build assets). An item landing slug equal to one
+ * of these can never serve the landing page, so colliding item_landing_slugs
+ * entries are disabled with an error at config load.
+ */
+export const RESERVED_NEXT_SLUGS = ["api", "_next"];

--- a/src/dataflow/__tests__/itemLanding.test.ts
+++ b/src/dataflow/__tests__/itemLanding.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test, beforeEach } from "@jest/globals";
+import fetchMock from "jest-fetch-mock";
+import {
+  getItemLandingProps,
+  getItemLandingRouteProps,
+  parseWorkId
+} from "../itemLanding";
+import { DEFAULT_ITEM_LANDING_SLUG } from "constants/app";
+import { resetAuthDocCache } from "../getLibraryData";
+import { getLibraries } from "server/libraryRegistry";
+import { getAppConfig } from "server/appConfig";
+import { config } from "test-utils/fixtures/config";
+import { authDoc } from "test-utils/fixtures/auth-document";
+
+jest.mock("server/libraryRegistry", () => ({
+  getLibraries: jest.fn()
+}));
+
+jest.mock("server/appConfig", () => ({
+  getAppConfig: jest.fn()
+}));
+
+const mockGetLibraries = getLibraries as jest.MockedFunction<
+  typeof getLibraries
+>;
+const mockGetAppConfig = getAppConfig as jest.MockedFunction<
+  typeof getAppConfig
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchMock.resetMocks();
+  resetAuthDocCache();
+  mockGetAppConfig.mockResolvedValue(config);
+  fetchMock.mockResponse(JSON.stringify(authDoc));
+});
+
+describe("parseWorkId", () => {
+  test("returns a plain string param unchanged", () => {
+    expect(parseWorkId({ workId: "abc123" })).toBe("abc123");
+  });
+
+  test("joins an array param with a slash", () => {
+    expect(parseWorkId({ workId: ["urn", "isbn", "123"] })).toBe(
+      "urn/isbn/123"
+    );
+  });
+
+  test("returns an empty string when the param is missing", () => {
+    expect(parseWorkId(undefined)).toBe("");
+    expect(parseWorkId({})).toBe("");
+  });
+});
+
+describe("getItemLandingProps", () => {
+  test("redirects to the sole configured library", async () => {
+    mockGetLibraries.mockResolvedValue({
+      testlib: { title: "Test Library", authDocUrl: "http://auth.doc/document" }
+    });
+
+    const result = await getItemLandingProps("work-1");
+
+    expect(result).toEqual({
+      redirect: {
+        destination: `/testlib/book/${encodeURIComponent(
+          "/catalog-root/works/work-1"
+        )}`,
+        permanent: false
+      }
+    });
+  });
+
+  test("percent-encodes the workId in the redirect destination", async () => {
+    mockGetLibraries.mockResolvedValue({
+      testlib: { title: "Test Library", authDocUrl: "http://auth.doc/document" }
+    });
+
+    const result = await getItemLandingProps("urn:uuid:1/2");
+
+    expect(result).toEqual({
+      redirect: {
+        destination: `/testlib/book/${encodeURIComponent(
+          "/catalog-root/works/urn%3Auuid%3A1%2F2"
+        )}`,
+        permanent: false
+      }
+    });
+  });
+
+  test("redirects to the Open eBooks default library even when the registry has more than one library", async () => {
+    mockGetAppConfig.mockResolvedValue({
+      ...config,
+      openebooks: { defaultLibrary: "oebooks" }
+    });
+    mockGetLibraries.mockResolvedValue({
+      oebooks: { title: "Open eBooks", authDocUrl: "http://auth.doc/document" },
+      other: { title: "Other Library", authDocUrl: "http://auth.doc/other" }
+    });
+
+    const result = await getItemLandingProps("work-1");
+
+    expect(result).toMatchObject({
+      redirect: { destination: expect.stringContaining("/oebooks/book/") }
+    });
+  });
+
+  test("renders the selector when more than one library is configured", async () => {
+    mockGetLibraries.mockResolvedValue({
+      lib1: { title: "Library One", authDocUrl: "http://auth.doc/one" },
+      lib2: { title: "Library Two", authDocUrl: "http://auth.doc/two" }
+    });
+
+    const result = await getItemLandingProps("work-1");
+
+    expect(result).toEqual({ props: { workId: "work-1", appConfig: config } });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("renders the selector when no libraries are configured", async () => {
+    mockGetLibraries.mockResolvedValue({});
+
+    const result = await getItemLandingProps("work-1");
+
+    expect(result).toEqual({ props: { workId: "work-1", appConfig: config } });
+  });
+
+  test("falls through to the selector when the auth document fetch fails", async () => {
+    mockGetLibraries.mockResolvedValue({
+      testlib: { title: "Test Library", authDocUrl: "http://auth.doc/document" }
+    });
+    fetchMock.mockReject(new Error("connection refused"));
+
+    const result = await getItemLandingProps("work-1");
+
+    expect(result).toEqual({ props: { workId: "work-1", appConfig: config } });
+  });
+});
+
+describe("getItemLandingRouteProps", () => {
+  const twoLibraries = {
+    lib1: { title: "Library One", authDocUrl: "http://auth.doc/one" },
+    lib2: { title: "Library Two", authDocUrl: "http://auth.doc/two" }
+  };
+
+  test("returns notFound when the first segment is not the landing slug", async () => {
+    const result = await getItemLandingRouteProps({
+      library: "some-library",
+      workId: "work-1"
+    });
+
+    expect(result).toEqual({ notFound: true });
+    expect(mockGetLibraries).not.toHaveBeenCalled();
+  });
+
+  test("serves the landing page at the default slug", async () => {
+    mockGetLibraries.mockResolvedValue(twoLibraries);
+
+    const result = await getItemLandingRouteProps({
+      library: DEFAULT_ITEM_LANDING_SLUG,
+      workId: "work-1"
+    });
+
+    expect(result).toEqual({ props: { workId: "work-1", appConfig: config } });
+  });
+
+  test("uses configured item_landing_slugs instead of the default", async () => {
+    const configWithSlugs = { ...config, itemLandingSlugs: ["find"] };
+    mockGetAppConfig.mockResolvedValue(configWithSlugs);
+    mockGetLibraries.mockResolvedValue(twoLibraries);
+
+    expect(
+      await getItemLandingRouteProps({ library: "find", workId: "work-1" })
+    ).toEqual({ props: { workId: "work-1", appConfig: configWithSlugs } });
+    expect(
+      await getItemLandingRouteProps({
+        library: DEFAULT_ITEM_LANDING_SLUG,
+        workId: "work-1"
+      })
+    ).toEqual({ notFound: true });
+  });
+
+  test("serves the landing page at every configured slug during a migration", async () => {
+    const configWithSlugs = {
+      ...config,
+      itemLandingSlugs: [DEFAULT_ITEM_LANDING_SLUG, "item"]
+    };
+    mockGetAppConfig.mockResolvedValue(configWithSlugs);
+    mockGetLibraries.mockResolvedValue(twoLibraries);
+
+    expect(
+      await getItemLandingRouteProps({
+        library: DEFAULT_ITEM_LANDING_SLUG,
+        workId: "work-1"
+      })
+    ).toEqual({ props: { workId: "work-1", appConfig: configWithSlugs } });
+    expect(
+      await getItemLandingRouteProps({ library: "item", workId: "work-1" })
+    ).toEqual({ props: { workId: "work-1", appConfig: configWithSlugs } });
+    expect(
+      await getItemLandingRouteProps({ library: "other", workId: "work-1" })
+    ).toEqual({ notFound: true });
+  });
+
+  test("returns notFound for every request when the landing page is disabled", async () => {
+    mockGetAppConfig.mockResolvedValue({ ...config, itemLandingSlugs: [] });
+
+    const result = await getItemLandingRouteProps({
+      library: DEFAULT_ITEM_LANDING_SLUG,
+      workId: "work-1"
+    });
+
+    expect(result).toEqual({ notFound: true });
+    expect(mockGetLibraries).not.toHaveBeenCalled();
+  });
+});

--- a/src/dataflow/itemLanding.ts
+++ b/src/dataflow/itemLanding.ts
@@ -1,0 +1,94 @@
+import { GetServerSidePropsResult } from "next";
+import { ParsedUrlQuery } from "querystring";
+import type { AppConfig } from "interfaces";
+import { getAppConfig } from "server/appConfig";
+import { getLibraries } from "server/libraryRegistry";
+import {
+  getAuthDocUrl,
+  fetchAuthDocument,
+  buildLibraryData
+} from "dataflow/getLibraryData";
+import { buildWorkUrl } from "utils/workUrl";
+
+export interface ItemLandingProps {
+  workId: string;
+  /*
+   * Included in pageProps so _app.tsx initializes Bugsnag and media support
+   * from the real config instead of FALLBACK_APP_CONFIG.
+   */
+  appConfig: AppConfig;
+}
+
+/** Extracts the workId path param, joining segments if Next ever supplies an array. */
+export function parseWorkId(params: ParsedUrlQuery | undefined): string {
+  return Array.isArray(params?.workId)
+    ? params.workId.join("/")
+    : (params?.workId ?? "");
+}
+
+/**
+ * Resolves server-side props for the /[library]/[workId] route, which serves
+ * the item landing page when the first path segment matches one of the
+ * configured item landing slugs and 404s otherwise. Multiple slugs all serve
+ * the page so a deployment can migrate from one slug to another with both
+ * active. This check runs before the segment is treated as a library, so a
+ * library with a colliding slug is shadowed here; server/libraryRegistry.ts
+ * logs a warning when it detects such a collision.
+ */
+export async function getItemLandingRouteProps(
+  params: ParsedUrlQuery | undefined
+): Promise<GetServerSidePropsResult<ItemLandingProps>> {
+  const appConfig = await getAppConfig();
+  const segment = params?.library;
+  if (
+    typeof segment !== "string" ||
+    !appConfig.itemLandingSlugs.includes(segment)
+  ) {
+    return { notFound: true };
+  }
+  return getItemLandingProps(parseWorkId(params));
+}
+
+/**
+ * Resolves server-side props for the cross-library item landing page. When
+ * exactly one library is configured (or Open eBooks mode names a default),
+ * redirects straight to that library's book page instead of rendering the
+ * library selector.
+ */
+export async function getItemLandingProps(
+  workId: string
+): Promise<GetServerSidePropsResult<ItemLandingProps>> {
+  const appConfig = await getAppConfig();
+
+  let singleSlug: string | null = null;
+  if (appConfig.openebooks) {
+    singleSlug = appConfig.openebooks.defaultLibrary;
+  } else {
+    const libraries = await getLibraries(appConfig);
+    const slugs = Object.keys(libraries).filter(s => libraries[s] != null);
+    if (slugs.length === 1) singleSlug = slugs[0];
+  }
+
+  if (singleSlug) {
+    try {
+      const authDocUrl = await getAuthDocUrl(singleSlug, appConfig);
+      const authDoc = await fetchAuthDocument(
+        authDocUrl,
+        appConfig.authenticationDocuments ?? undefined
+      );
+      const { catalogUrl } = buildLibraryData(authDoc, singleSlug);
+      const bookUrl = buildWorkUrl(catalogUrl, workId);
+      return {
+        redirect: {
+          destination: `/${singleSlug}/book/${encodeURIComponent(bookUrl)}`,
+          permanent: false
+        }
+      };
+    } catch {
+      // Auth doc fetch failed; fall through to render the selector so the
+      // user is not left with a blank page.
+    }
+  }
+
+  return { props: { workId, appConfig } };
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,6 +26,8 @@ export type AppConfig = {
   showMedium: boolean;
   bugsnagApiKey: string | null;
   openebooks: OpenEbooksConfig | null;
+  /** Reserved item landing path segments. See constants/app.ts. */
+  itemLandingSlugs: string[];
 };
 
 export type OpenEbooksConfig = {

--- a/src/pages/[library]/[workId].tsx
+++ b/src/pages/[library]/[workId].tsx
@@ -1,0 +1,36 @@
+/**
+ * Cross-library item landing page: /{itemLandingSlug}/{workId} for each
+ * configured landing slug
+ * (default: /_item_/{workId}; see constants/app.ts).
+ *
+ * Accepts a work identifier (the path segment after /works/ in a Palace CM OPDS
+ * entry URL) and lets the user choose which of their libraries to open it in.
+ * On selection the page navigates to /{slug}/book/{encodedBookUrl}, where
+ * bookUrl is constructed as {catalogUrl}/works/{encodedWorkId}.
+ *
+ * The route is dynamic so the landing slugs can be configured at runtime via
+ * the item_landing_slugs config property (multiple slugs may be active at
+ * once, e.g. during a slug migration). Static sibling routes take precedence
+ * over this dynamic segment, so only two-segment URLs that match no other
+ * route reach this page; those whose first segment is not a landing slug 404.
+ *
+ * This file is intentionally thin: the slug check and redirect/selector logic
+ * live in dataflow/itemLanding.ts and the page body in
+ * components/ItemLandingPage.tsx.
+ */
+import { GetServerSideProps, NextPage } from "next";
+import ItemLandingPage from "components/ItemLandingPage";
+import {
+  getItemLandingRouteProps,
+  ItemLandingProps
+} from "dataflow/itemLanding";
+
+const ItemLandingRoute: NextPage<ItemLandingProps> = ({ workId }) => (
+  <ItemLandingPage workId={workId} />
+);
+
+export const getServerSideProps: GetServerSideProps<
+  ItemLandingProps
+> = async ctx => getItemLandingRouteProps(ctx.params);
+
+export default ItemLandingRoute;

--- a/src/pages/api/catalog-url.ts
+++ b/src/pages/api/catalog-url.ts
@@ -1,0 +1,59 @@
+/**
+ * GET /api/catalog-url?slug={slug}
+ *
+ * Returns the OPDS catalog root URL for a single library, resolved by fetching
+ * its authentication document server-side. The auth document is cached in the
+ * same in-process store used by withAppProps, so repeated calls for the same
+ * library are cheap.
+ */
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getAppConfig } from "server/appConfig";
+import {
+  getAuthDocUrl,
+  fetchAuthDocument,
+  buildLibraryData
+} from "dataflow/getLibraryData";
+import { PageNotFoundError } from "errors";
+
+export interface CatalogUrlResponse {
+  catalogUrl: string;
+}
+
+export interface CatalogUrlErrorResponse {
+  error: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CatalogUrlResponse | CatalogUrlErrorResponse>
+): Promise<void> {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    res.status(405).json({ error: "Method not allowed." });
+    return;
+  }
+
+  const { slug } = req.query;
+  if (typeof slug !== "string" || !slug) {
+    res.status(400).json({ error: "slug query parameter is required." });
+    return;
+  }
+
+  try {
+    const appConfig = await getAppConfig();
+    const authDocUrl = await getAuthDocUrl(slug, appConfig);
+    const authDoc = await fetchAuthDocument(
+      authDocUrl,
+      appConfig.authenticationDocuments ?? undefined
+    );
+    const { catalogUrl } = buildLibraryData(authDoc, slug);
+    res.status(200).json({ catalogUrl });
+  } catch (err) {
+    if (err instanceof PageNotFoundError) {
+      res.status(404).json({ error: `Library not found: ${slug}` });
+      return;
+    }
+    console.error("GET /api/catalog-url failed:", err);
+    res.status(500).json({ error: "Failed to resolve catalog URL." });
+  }
+}

--- a/src/server/__tests__/appConfig.test.ts
+++ b/src/server/__tests__/appConfig.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../appConfig";
 import { AppSetupError } from "errors";
 import { DEFAULT_REGISTRY_FETCH_TIMEOUT } from "constants/registry";
+import { DEFAULT_ITEM_LANDING_SLUG } from "constants/app";
 import { expectAndSuppressConsole } from "test-utils/suppressConsole";
 
 jest.mock("fs", () => ({ readFileSync: jest.fn() }));
@@ -387,6 +388,87 @@ describe("config parsing", () => {
       expect((await load(yaml)).openebooks).toEqual({
         defaultLibrary: "nyc-lib"
       });
+    });
+  });
+
+  // --- itemLandingSlugs ---
+
+  describe("itemLandingSlugs", () => {
+    it("defaults to the reserved item landing slug when absent", async () => {
+      expect((await load(MINIMAL_YAML)).itemLandingSlugs).toEqual([
+        DEFAULT_ITEM_LANDING_SLUG
+      ]);
+    });
+
+    it("wraps a scalar item_landing_slugs value in a one-element list", async () => {
+      expect(
+        (await load(`item_landing_slugs: custom-item`)).itemLandingSlugs
+      ).toEqual(["custom-item"]);
+    });
+
+    it("parses a list of slugs", async () => {
+      const yaml = "item_landing_slugs:\n  - _item_\n  - item";
+      expect((await load(yaml)).itemLandingSlugs).toEqual(["_item_", "item"]);
+    });
+
+    it("accepts an empty list", async () => {
+      expect((await load(`item_landing_slugs: []`)).itemLandingSlugs).toEqual(
+        []
+      );
+    });
+
+    it("throws AppSetupError when an entry contains a slash", async () => {
+      const yaml = 'item_landing_slugs:\n  - _item_\n  - "a/b"';
+      await expect(load(yaml)).rejects.toThrow(AppSetupError);
+    });
+
+    it.each(["", " ", "a?b", "a#b", "a%20b", ".."])(
+      "throws AppSetupError when an entry is not a non-empty single path segment (%j)",
+      async slug => {
+        await expect(load(`item_landing_slugs: "${slug}"`)).rejects.toThrow(
+          AppSetupError
+        );
+      }
+    );
+
+    it.each(["item", "a b", "urn:item", "café"])(
+      "accepts a single-path-segment entry (%j)",
+      async slug => {
+        expect(
+          (await load(`item_landing_slugs: "${slug}"`)).itemLandingSlugs
+        ).toEqual([slug]);
+      }
+    );
+
+    it("collapses duplicate entries", async () => {
+      const yaml = "item_landing_slugs:\n  - _item_\n  - item\n  - _item_";
+      expect((await load(yaml)).itemLandingSlugs).toEqual(["_item_", "item"]);
+    });
+
+    it("disables an entry that collides with a reserved Next.js segment", async () => {
+      const errorSpy = expectAndSuppressConsole(
+        "error",
+        "reserved Next.js path segment"
+      );
+
+      const yaml = "item_landing_slugs:\n  - api\n  - _item_";
+      expect((await load(yaml)).itemLandingSlugs).toEqual(["_item_"]);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('"api"'));
+
+      errorSpy.mockRestore();
+    });
+
+    it("disables the landing page entirely when every entry is reserved", async () => {
+      const errorSpy = expectAndSuppressConsole(
+        "error",
+        "reserved Next.js path segment"
+      );
+
+      expect(
+        (await load(`item_landing_slugs: _next`)).itemLandingSlugs
+      ).toEqual([]);
+
+      errorSpy.mockRestore();
     });
   });
 

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_REGISTRY_REFRESH_MIN_INTERVAL,
   DEFAULT_REGISTRY_REFRESH_MAX_INTERVAL
 } from "constants/registry";
+import { DEFAULT_ITEM_LANDING_SLUG } from "constants/app";
 import { expectAndSuppressConsole } from "test-utils/suppressConsole";
 
 // ---------------------------------------------------------------------------
@@ -36,6 +37,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     openebooks: null,
     mediaSupport: {},
     authenticationDocuments: null,
+    itemLandingSlugs: [DEFAULT_ITEM_LANDING_SLUG],
     ...overrides
   };
 }
@@ -922,6 +924,114 @@ describe("getLibraries", () => {
 
     await getLibraries(config);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reserved item landing slug collision warning
+// ---------------------------------------------------------------------------
+
+describe("reserved item landing slug collision warning", () => {
+  const COLLISION_MESSAGE = "collides with a reserved item landing slug";
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetRegistryCaches();
+    warnSpy = expectAndSuppressConsole(
+      "warn",
+      COLLISION_MESSAGE,
+      "has no order=modified facet"
+    );
+  });
+
+  afterEach(() => warnSpy.mockRestore());
+
+  function collisionWarningCount(): number {
+    return warnSpy.mock.calls.filter(args =>
+      String(args[0]).includes(COLLISION_MESSAGE)
+    ).length;
+  }
+
+  it("warns about a colliding static library but keeps it in the result", async () => {
+    const staticLibraries = {
+      [DEFAULT_ITEM_LANDING_SLUG]: {
+        title: "Colliding Lib",
+        authDocUrl: "https://c.example.com/auth"
+      }
+    };
+
+    const result = await getLibraries(makeConfig({ staticLibraries }));
+
+    expect(result[DEFAULT_ITEM_LANDING_SLUG]).toBeDefined();
+    expect(collisionWarningCount()).toBe(1);
+  });
+
+  it("warns only once across repeated calls", async () => {
+    const staticLibraries = {
+      [DEFAULT_ITEM_LANDING_SLUG]: {
+        title: "Colliding Lib",
+        authDocUrl: "https://c.example.com/auth"
+      }
+    };
+    const config = makeConfig({ staticLibraries });
+
+    await getLibraries(config);
+    await getLibraries(config);
+
+    expect(collisionWarningCount()).toBe(1);
+  });
+
+  it("checks against a configured item_landing_slugs override", async () => {
+    const feed = makePagedFeed([
+      {
+        id: "urn:uuid:reg",
+        title: "Registry Lib",
+        authDocUrl: "https://r.example.com/"
+      }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+
+    const result = await getLibraries(
+      makeConfig({
+        registries: [makeRegistryConfig()],
+        itemLandingSlugs: ["urn:uuid:reg"]
+      })
+    );
+
+    expect(result["urn:uuid:reg"]).toBeDefined();
+    expect(collisionWarningCount()).toBe(1);
+  });
+
+  it("warns separately for each colliding slug", async () => {
+    const staticLibraries = {
+      [DEFAULT_ITEM_LANDING_SLUG]: {
+        title: "Colliding Lib",
+        authDocUrl: "https://c.example.com/auth"
+      },
+      item: {
+        title: "Also Colliding",
+        authDocUrl: "https://i.example.com/auth"
+      }
+    };
+
+    await getLibraries(
+      makeConfig({
+        staticLibraries,
+        itemLandingSlugs: [DEFAULT_ITEM_LANDING_SLUG, "item"]
+      })
+    );
+
+    expect(collisionWarningCount()).toBe(2);
+  });
+
+  it("does not warn when no library uses the reserved slug", async () => {
+    const staticLibraries = {
+      "my-lib": { title: "My Lib", authDocUrl: "https://my.lib/auth" }
+    };
+
+    await getLibraries(makeConfig({ staticLibraries }));
+
+    expect(collisionWarningCount()).toBe(0);
   });
 });
 

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -20,6 +20,7 @@ import type {
 import { AppSetupError } from "errors";
 import { isHttpUrl } from "utils/parse";
 import { DEFAULT_REGISTRY_FETCH_TIMEOUT } from "constants/registry";
+import { DEFAULT_ITEM_LANDING_SLUG, RESERVED_NEXT_SLUGS } from "constants/app";
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -46,7 +47,8 @@ const RawConfigSchema = type({
   "staticLibraries?": "Record<string, unknown>",
   "authenticationDocuments?": AuthDocConfigSchema,
   "mediaSupport?": "Record<string, string | Record<string, string>>",
-  "openebooks?": { defaultLibrary: "string" }
+  "openebooks?": { defaultLibrary: "string" },
+  "itemLandingSlugs?": "string | string[]"
 });
 
 const DEFAULT_MIN_INTERVAL = 60;
@@ -144,6 +146,23 @@ function parseLibrariesConfig(
   );
 }
 
+/**
+ * Whether a value survives being interpolated into a URL path and parsed back
+ * as the same single decoded segment. Delegating to the URL parser avoids
+ * enumerating reserved characters. Anything that terminates the path ("?",
+ * "#"), splits the segment ("/", "\"), collapses during normalization (".",
+ * ".."), or decodes differently ("%xx") fails the round-trip, while values
+ * the parser merely percent-encodes (spaces, non-ASCII) pass.
+ */
+function isSinglePathSegment(value: string): boolean {
+  try {
+    const segments = new URL(`https://host/${value}/x`).pathname.split("/");
+    return segments.length === 3 && decodeURIComponent(segments[1]) === value;
+  } catch {
+    return false;
+  }
+}
+
 function parseYaml(input: Record<string, unknown>): AppConfig {
   const normalized = normalizeConfigKeys(input, [
     "instanceName",
@@ -153,7 +172,8 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     "gtmId",
     "staticLibraries",
     "authenticationDocuments",
-    "mediaSupport"
+    "mediaSupport",
+    "itemLandingSlugs"
   ]);
 
   if ("bugsnagApiKey" in normalized) {
@@ -215,6 +235,42 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
   const openebooks = result.openebooks
     ? { defaultLibrary: result.openebooks.defaultLibrary }
     : null;
+
+  /*
+   * A scalar is accepted as shorthand for a one-element list. Multiple slugs
+   * all serve the landing page, which allows migrating from one slug to
+   * another with both active; an empty list disables the landing page.
+   * Duplicate entries are collapsed.
+   */
+  const rawItemLandingSlugs =
+    result.itemLandingSlugs ?? DEFAULT_ITEM_LANDING_SLUG;
+  const allItemLandingSlugs = [
+    ...new Set(
+      Array.isArray(rawItemLandingSlugs)
+        ? rawItemLandingSlugs
+        : [rawItemLandingSlugs]
+    )
+  ];
+  for (const slug of allItemLandingSlugs) {
+    if (slug.trim() === "" || !isSinglePathSegment(slug)) {
+      throw new AppSetupError(
+        `CONFIG_FILE: 'item_landing_slugs' entry "${slug}" must be a non-empty single URL path segment.`
+      );
+    }
+  }
+  /*
+   * Next.js consumes reserved segments (API routes, build assets) before page
+   * routing, so a colliding slug could never serve the landing page. Such
+   * entries are disabled with an error instead of being served dead.
+   */
+  const itemLandingSlugs = allItemLandingSlugs.filter(slug => {
+    if (!RESERVED_NEXT_SLUGS.includes(slug)) return true;
+    console.error(
+      `CONFIG_FILE: 'item_landing_slugs' entry "${slug}" collides with the ` +
+        `reserved Next.js path segment "/${slug}" and has been disabled.`
+    );
+    return false;
+  });
 
   const baseRegistries: RegistryConfig[] = (result.registries ?? []).map(r => ({
     url: r.url,
@@ -319,7 +375,8 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     bugsnagApiKey: process.env.BUGSNAG_API_KEY ?? null,
     companionApp,
     showMedium,
-    openebooks
+    openebooks,
+    itemLandingSlugs
   };
 }
 

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -81,6 +81,35 @@ const emptyState: RegistryState = {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/*
+ * Slugs already warned about, so the reserved-slug collision warning is logged
+ * once per process instead of on every request. Per-bundle duplication of this
+ * module-level state is acceptable for a log-only concern.
+ */
+const warnedReservedSlugCollisions = new Set<string>();
+
+/**
+ * Logs a warning when a configured or registry-provided library slug collides
+ * with one of the reserved item landing slugs. The library is intentionally
+ * kept (the service should run, not fail); its routes are shadowed by the
+ * item landing page, and the warning makes the collision findable in the logs.
+ */
+function warnOnReservedSlugCollision(
+  libraries: LibrariesConfig,
+  config: AppConfig
+): void {
+  for (const slug of config.itemLandingSlugs) {
+    if (libraries[slug] && !warnedReservedSlugCollisions.has(slug)) {
+      warnedReservedSlugCollisions.add(slug);
+      console.warn(
+        `Library slug "${slug}" collides with a reserved item landing ` +
+          `slug; the item landing route takes precedence, so this library ` +
+          `will be unreachable at /${slug}.`
+      );
+    }
+  }
+}
+
 /**
  * Extracts the href of the `order=modified` sort facet from the first page
  * of a registry feed. Returns null if the feed does not advertise that facet.
@@ -379,7 +408,10 @@ export async function getLibraries(
 ): Promise<LibrariesConfig> {
   const { registries = [], staticLibraries = {} } = config;
 
-  if (registries.length === 0) return staticLibraries;
+  if (registries.length === 0) {
+    warnOnReservedSlugCollision(staticLibraries, config);
+    return staticLibraries;
+  }
 
   const nowSeconds = Date.now() / 1000;
 
@@ -401,7 +433,9 @@ export async function getLibraries(
     }
   }
 
-  return { ...mergedRegistryLibraries, ...staticLibraries };
+  const merged = { ...mergedRegistryLibraries, ...staticLibraries };
+  warnOnReservedSlugCollision(merged, config);
+  return merged;
 }
 
 /**
@@ -414,4 +448,5 @@ export async function getLibraries(
 export function resetRegistryCaches(): void {
   registryCaches.clear();
   pendingRefreshes.clear();
+  warnedReservedSlugCollisions.clear();
 }

--- a/src/test-utils/fixtures/config.ts
+++ b/src/test-utils/fixtures/config.ts
@@ -1,4 +1,5 @@
 import { AppConfig } from "interfaces";
+import { DEFAULT_ITEM_LANDING_SLUG } from "constants/app";
 
 export const config: AppConfig = {
   instanceName: "Test Instance",
@@ -7,6 +8,7 @@ export const config: AppConfig = {
   showMedium: true,
   openebooks: null,
   authenticationDocuments: null,
+  itemLandingSlugs: [DEFAULT_ITEM_LANDING_SLUG],
   mediaSupport: {
     "application/epub+zip": "show",
     "application/kepub+zip": "show",

--- a/src/utils/__tests__/workUrl.test.ts
+++ b/src/utils/__tests__/workUrl.test.ts
@@ -1,0 +1,21 @@
+import { buildWorkUrl } from "../workUrl";
+
+describe("buildWorkUrl", () => {
+  test("joins the catalog url and workId under /works/", () => {
+    expect(buildWorkUrl("https://cm.example.com/catalog", "work-1")).toBe(
+      "https://cm.example.com/catalog/works/work-1"
+    );
+  });
+
+  test("strips a trailing slash from the catalog url", () => {
+    expect(buildWorkUrl("https://cm.example.com/catalog/", "work-1")).toBe(
+      "https://cm.example.com/catalog/works/work-1"
+    );
+  });
+
+  test("percent-encodes reserved characters in the workId", () => {
+    expect(buildWorkUrl("https://cm.example.com", "urn:uuid:1/2")).toBe(
+      "https://cm.example.com/works/urn%3Auuid%3A1%2F2"
+    );
+  });
+});

--- a/src/utils/workUrl.ts
+++ b/src/utils/workUrl.ts
@@ -1,0 +1,9 @@
+/**
+ * Builds the OPDS entry URL for a work in a library's catalog. The workId is
+ * percent-encoded because Next.js decodes route params, and identifiers may
+ * contain characters (URN colons, encoded slashes) that must not appear raw
+ * in a single path segment.
+ */
+export function buildWorkUrl(catalogUrl: string, workId: string): string {
+  return `${catalogUrl.replace(/\/$/, "")}/works/${encodeURIComponent(workId)}`;
+}

--- a/tests/pages/api/catalog-url.test.ts
+++ b/tests/pages/api/catalog-url.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for the GET /api/catalog-url route.
+ * Run under jest.config.node.js.
+ */
+
+import type { NextApiRequest, NextApiResponse } from "next";
+import type {
+  CatalogUrlResponse,
+  CatalogUrlErrorResponse
+} from "pages/api/catalog-url";
+
+// Mock both server modules so we can control their behavior.
+jest.mock("server/libraryRegistry", () => ({
+  getLibraries: jest.fn()
+}));
+jest.mock("server/appConfig", () => ({
+  getAppConfig: jest.fn()
+}));
+
+import { getLibraries } from "server/libraryRegistry";
+import { getAppConfig } from "server/appConfig";
+import handler from "pages/api/catalog-url";
+import { resetAuthDocCache } from "dataflow/getLibraryData";
+import { config } from "test-utils/fixtures/config";
+import { authDoc } from "test-utils/fixtures/auth-document";
+import { expectAndSuppressConsole } from "test-utils/suppressConsole";
+
+const mockGetLibraries = getLibraries as jest.MockedFunction<
+  typeof getLibraries
+>;
+const mockGetAppConfig = getAppConfig as jest.MockedFunction<
+  typeof getAppConfig
+>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReq(
+  query: Record<string, unknown>,
+  method = "GET"
+): NextApiRequest {
+  return { query, method } as unknown as NextApiRequest;
+}
+
+function makeRes() {
+  const json = jest.fn();
+  const status = jest.fn(() => ({ json }));
+  const setHeader = jest.fn();
+  const res = { status, setHeader } as unknown as NextApiResponse<
+    CatalogUrlResponse | CatalogUrlErrorResponse
+  >;
+  return { res, status, json, setHeader };
+}
+
+beforeEach(() => {
+  resetAuthDocCache();
+  mockGetAppConfig.mockResolvedValue(config);
+  mockGetLibraries.mockResolvedValue({
+    testlib: { title: "Test Library", authDocUrl: "http://auth.doc/document" }
+  });
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => authDoc
+  }) as unknown as typeof fetch;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/catalog-url", () => {
+  test("returns the catalog root URL for a configured library", async () => {
+    const { res, status, json } = makeRes();
+
+    await handler(makeReq({ slug: "testlib" }), res);
+
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ catalogUrl: "/catalog-root" });
+  });
+
+  test("returns 405 for non-GET methods", async () => {
+    const { res, status, json, setHeader } = makeRes();
+
+    await handler(makeReq({ slug: "testlib" }, "POST"), res);
+
+    expect(status).toHaveBeenCalledWith(405);
+    expect(setHeader).toHaveBeenCalledWith("Allow", "GET");
+    expect(json).toHaveBeenCalledWith({ error: "Method not allowed." });
+  });
+
+  test("returns 400 when the slug parameter is missing", async () => {
+    const { res, status, json } = makeRes();
+
+    await handler(makeReq({}), res);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({
+      error: "slug query parameter is required."
+    });
+  });
+
+  test("returns 400 when the slug parameter is repeated", async () => {
+    const { res, status } = makeRes();
+
+    await handler(makeReq({ slug: ["a", "b"] }), res);
+
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
+  test("returns 404 for an unknown library", async () => {
+    mockGetLibraries.mockResolvedValue({});
+    const { res, status, json } = makeRes();
+
+    await handler(makeReq({ slug: "nope" }), res);
+
+    expect(status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith({ error: "Library not found: nope" });
+  });
+
+  test("returns 500 when the auth document fetch fails", async () => {
+    const errorSpy = expectAndSuppressConsole(
+      "error",
+      "GET /api/catalog-url failed:"
+    );
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(
+        new Error("connection refused")
+      ) as unknown as typeof fetch;
+    const { res, status, json } = makeRes();
+
+    await handler(makeReq({ slug: "testlib" }), res);
+
+    expect(status).toHaveBeenCalledWith(500);
+    expect(json).toHaveBeenCalledWith({
+      error: "Failed to resolve catalog URL."
+    });
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/pages/api/libraries.test.ts
+++ b/tests/pages/api/libraries.test.ts
@@ -11,6 +11,7 @@ import type {
   LibrariesErrorResponse
 } from "pages/api/libraries";
 import type { AppConfig } from "interfaces";
+import { DEFAULT_ITEM_LANDING_SLUG } from "constants/app";
 
 // Mock both server modules so we can control their behavior.
 jest.mock("server/libraryRegistry", () => ({
@@ -43,7 +44,8 @@ const VALID_APP_CONFIG: AppConfig = {
   showMedium: true,
   openebooks: null,
   mediaSupport: {},
-  authenticationDocuments: null
+  authenticationDocuments: null,
+  itemLandingSlugs: [DEFAULT_ITEM_LANDING_SLUG]
 };
 
 function makeRes() {


### PR DESCRIPTION
## Description

- Adds an experimental cross-library item landing page at `/{landing-slug}/{workId}` (default slug: `_item_`), giving each work a canonical URL that is not tied to any one library. The page lets the patron choose a library (with type-ahead filtering), confirms the item is available there, and then opens the item's book page in that library's catalog.
- Deployments with a single library skip the selector and redirect straight to the item's book page.
- The landing slugs are configurable at runtime via a new `item_landing_slugs` config option: multiple item-level resource slugs can be active at once (mainly to support migrations from one to another), an empty list disables the page, entries colliding with reserved Next.js path segments are rejected, and a library whose slug collides with a landing slug is kept but logged as shadowed.
- Adds a `GET /api/catalog-url` endpoint that resolves a library's OPDS catalog root from its authentication document (served from the existing in-process cache).
- Selector resilience: selection is blocked while a lookup is in flight, lookups are bounded by a 15-second timeout and can be canceled with Escape, and all failure states (library unreachable, library unavailable, item not in collection, navigation failure) share one dismissible error panel with "Back to search" and "OK" actions that manage focus.

## Motivation and Context

Proof of concept. OPDS entry URLs are library-specific, so there has been no stable way to link to an item without already knowing the patron's library. A canonical item-level URL can be shared or referenced externally. The landing page bridges it to whichever library the patron uses.

[Jira PP-3760]

## How Has This Been Tested?

- Manual testing in local dev environment.
- New / updated tests for the new functionality.
- All tests and checks pass locally.
- [CI checks / build](https://github.com/ThePalaceProject/web-patron/actions/runs/29600814227) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
