### PR TITLE
Support alternate SAML auth flow via the "force_authn=true" param (PP-4792)

### DIFF
--- a/src/auth/OidcAuthHandler.tsx
+++ b/src/auth/OidcAuthHandler.tsx
@@ -1,18 +1,16 @@
 import * as React from "react";
-import { useRouter } from "next/router";
 import { ClientOidcMethod } from "interfaces";
-import LoadingIndicator from "components/LoadingIndicator";
-import Stack from "components/Stack";
-import useUser from "components/context/UserContext";
-import useLoginRedirectUrl from "auth/useLoginRedirect";
 import { clientOnly } from "components/ClientOnly";
-import extractParam from "dataflow/utils";
-import Button from "components/Button";
-import { useRedirectCancelDetection } from "auth/useRedirectCancelDetection";
-import { AuthFeedbackPanel } from "auth/AuthFeedbackPanel";
+import { RedirectAuthHandler } from "auth/RedirectAuthHandler";
 
 export const oidcRedirectFlag = (id: string) => `cpw-oidc-redirect-${id}`;
 export const oidcCancelFlag = (id: string) => `cpw-oidc-cancelled-${id}`;
+
+/*
+ * prompt=select_account asks the OIDC provider to show its account chooser
+ * instead of silently reusing an existing session.
+ */
+const switchAccountParam = { name: "prompt", value: "select_account" };
 
 /**
  * The OIDC Auth handler sends you off to an external website to complete
@@ -20,73 +18,13 @@ export const oidcCancelFlag = (id: string) => `cpw-oidc-cancelled-${id}`;
  */
 const OidcAuthHandler: React.FC<{ method: ClientOidcMethod }> = ({
   method
-}) => {
-  const { token } = useUser();
-  const { fullSuccessUrl } = useLoginRedirectUrl();
-  const router = useRouter();
-  const loginError = extractParam(router.query, "loginError");
-
-  const authUrl = appendSearchParam(
-    method.href,
-    "redirect_uri",
-    fullSuccessUrl
-  );
-  const altAuthUrl = appendSearchParam(authUrl, "prompt", "select_account");
-
-  const { cancelDetected, handleTryAgain, handleCancel } =
-    useRedirectCancelDetection({
-      authUrl,
-      redirectFlagKey: oidcRedirectFlag(method.id),
-      cancelFlagKey: oidcCancelFlag(method.id),
-      loginError,
-      token
-    });
-
-  const handleSwitchAccount = React.useCallback(() => {
-    sessionStorage.removeItem(oidcRedirectFlag(method.id));
-    sessionStorage.removeItem(oidcCancelFlag(method.id));
-    window.location.href = altAuthUrl;
-  }, [altAuthUrl, method.id]);
-
-  const switchAccountAction = React.useMemo(
-    () => ({ label: "Use a different account", onClick: handleSwitchAccount }),
-    [handleSwitchAccount]
-  );
-
-  if (loginError) {
-    return (
-      <AuthFeedbackPanel
-        message={loginError}
-        isError
-        onTryAgain={handleTryAgain}
-        secondaryAction={switchAccountAction}
-      />
-    );
-  }
-  if (cancelDetected) {
-    return (
-      <AuthFeedbackPanel
-        message="Login was cancelled."
-        onTryAgain={handleTryAgain}
-        secondaryAction={switchAccountAction}
-      />
-    );
-  }
-  return (
-    <Stack direction="column" sx={{ alignItems: "center", gap: 3 }}>
-      <Stack direction="column" sx={{ alignItems: "center" }}>
-        <LoadingIndicator />
-        Logging in with {method.description}...
-      </Stack>
-      <Button onClick={handleCancel}>Cancel</Button>
-    </Stack>
-  );
-};
-
-function appendSearchParam(href: string, name: string, value: string): string {
-  const url = new URL(href);
-  url.searchParams.set(name, value);
-  return url.toString();
-}
+}) => (
+  <RedirectAuthHandler
+    method={method}
+    redirectFlagKey={oidcRedirectFlag(method.id)}
+    cancelFlagKey={oidcCancelFlag(method.id)}
+    switchAccountParam={switchAccountParam}
+  />
+);
 
 export default clientOnly(OidcAuthHandler);

--- a/src/auth/RedirectAuthHandler.tsx
+++ b/src/auth/RedirectAuthHandler.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+import { useRouter } from "next/router";
+import { ClientOidcMethod, ClientSamlMethod } from "interfaces";
+import LoadingIndicator from "components/LoadingIndicator";
+import Stack from "components/Stack";
+import useUser from "components/context/UserContext";
+import useLoginRedirectUrl from "auth/useLoginRedirect";
+import extractParam from "dataflow/utils";
+import Button from "components/Button";
+import { useRedirectCancelDetection } from "auth/useRedirectCancelDetection";
+import { AuthFeedbackPanel } from "auth/AuthFeedbackPanel";
+import { appendSearchParam } from "utils/url";
+
+/**
+ * Shared handler for auth methods (SAML, OIDC) that send the user to an
+ * external provider to complete auth. When login fails or is cancelled, the
+ * user can retry or switch accounts; switchAccountParam is the query
+ * parameter that asks the provider for a fresh account choice.
+ */
+export const RedirectAuthHandler: React.FC<{
+  method: ClientSamlMethod | ClientOidcMethod;
+  redirectFlagKey: string;
+  cancelFlagKey: string;
+  switchAccountParam: { name: string; value: string };
+}> = ({ method, redirectFlagKey, cancelFlagKey, switchAccountParam }) => {
+  const { token } = useUser();
+  const { fullSuccessUrl } = useLoginRedirectUrl();
+  const router = useRouter();
+  const loginError = extractParam(router.query, "loginError");
+
+  const authUrl = appendSearchParam(
+    method.href,
+    "redirect_uri",
+    fullSuccessUrl
+  );
+  const altAuthUrl = appendSearchParam(
+    authUrl,
+    switchAccountParam.name,
+    switchAccountParam.value
+  );
+
+  const { cancelDetected, handleTryAgain, handleCancel } =
+    useRedirectCancelDetection({
+      authUrl,
+      redirectFlagKey,
+      cancelFlagKey,
+      loginError,
+      token
+    });
+
+  const handleSwitchAccount = React.useCallback(() => {
+    // Set the redirect flag before leaving so a return without completing
+    // auth is detected as a cancel.
+    sessionStorage.setItem(redirectFlagKey, "1");
+    sessionStorage.removeItem(cancelFlagKey);
+    window.location.href = altAuthUrl;
+  }, [altAuthUrl, redirectFlagKey, cancelFlagKey]);
+
+  const switchAccountAction = React.useMemo(
+    () => ({ label: "Use a different account", onClick: handleSwitchAccount }),
+    [handleSwitchAccount]
+  );
+
+  if (loginError) {
+    return (
+      <AuthFeedbackPanel
+        message={loginError}
+        isError
+        onTryAgain={handleTryAgain}
+        secondaryAction={switchAccountAction}
+      />
+    );
+  }
+  if (cancelDetected) {
+    return (
+      <AuthFeedbackPanel
+        message="Login was cancelled."
+        onTryAgain={handleTryAgain}
+        secondaryAction={switchAccountAction}
+      />
+    );
+  }
+  return (
+    <Stack direction="column" sx={{ alignItems: "center", gap: 3 }}>
+      <Stack direction="column" sx={{ alignItems: "center" }}>
+        <LoadingIndicator />
+        Logging in with {method.description}...
+      </Stack>
+      <Button onClick={handleCancel}>Cancel</Button>
+    </Stack>
+  );
+};

--- a/src/auth/SamlAuthHandler.tsx
+++ b/src/auth/SamlAuthHandler.tsx
@@ -1,18 +1,17 @@
 import * as React from "react";
-import { useRouter } from "next/router";
 import { ClientSamlMethod } from "interfaces";
-import LoadingIndicator from "components/LoadingIndicator";
-import Stack from "components/Stack";
-import useUser from "components/context/UserContext";
-import useLoginRedirectUrl from "auth/useLoginRedirect";
 import { clientOnly } from "components/ClientOnly";
-import extractParam from "dataflow/utils";
-import Button from "components/Button";
-import { useRedirectCancelDetection } from "auth/useRedirectCancelDetection";
-import { AuthFeedbackPanel } from "auth/AuthFeedbackPanel";
+import { RedirectAuthHandler } from "auth/RedirectAuthHandler";
 
 export const samlRedirectFlag = (id: string) => `cpw-saml-redirect-${id}`;
 export const samlCancelFlag = (id: string) => `cpw-saml-cancelled-${id}`;
+
+/*
+ * force_authn=true tells the Circulation Manager to set ForceAuthn on the
+ * SAML AuthnRequest, making the IdP re-authenticate the user instead of
+ * reusing an existing session.
+ */
+const switchAccountParam = { name: "force_authn", value: "true" };
 
 /**
  * The SAML Auth handler sends you off to an external website to complete
@@ -20,49 +19,13 @@ export const samlCancelFlag = (id: string) => `cpw-saml-cancelled-${id}`;
  */
 const SamlAuthHandler: React.FC<{ method: ClientSamlMethod }> = ({
   method
-}) => {
-  const { token } = useUser();
-  const { fullSuccessUrl } = useLoginRedirectUrl();
-  const router = useRouter();
-  const loginError = extractParam(router.query, "loginError");
-
-  const authUrl = `${method.href}&redirect_uri=${encodeURIComponent(fullSuccessUrl)}`;
-
-  const { cancelDetected, handleTryAgain, handleCancel } =
-    useRedirectCancelDetection({
-      authUrl,
-      redirectFlagKey: samlRedirectFlag(method.id),
-      cancelFlagKey: samlCancelFlag(method.id),
-      loginError,
-      token
-    });
-
-  if (loginError) {
-    return (
-      <AuthFeedbackPanel
-        message={loginError}
-        isError
-        onTryAgain={handleTryAgain}
-      />
-    );
-  }
-  if (cancelDetected) {
-    return (
-      <AuthFeedbackPanel
-        message="Login was cancelled."
-        onTryAgain={handleTryAgain}
-      />
-    );
-  }
-  return (
-    <Stack direction="column" sx={{ alignItems: "center", gap: 3 }}>
-      <Stack direction="column" sx={{ alignItems: "center" }}>
-        <LoadingIndicator />
-        Logging in with {method.description}...
-      </Stack>
-      <Button onClick={handleCancel}>Cancel</Button>
-    </Stack>
-  );
-};
+}) => (
+  <RedirectAuthHandler
+    method={method}
+    redirectFlagKey={samlRedirectFlag(method.id)}
+    cancelFlagKey={samlCancelFlag(method.id)}
+    switchAccountParam={switchAccountParam}
+  />
+);
 
 export default clientOnly(SamlAuthHandler);

--- a/src/auth/__tests__/OidcAuthHandler.test.tsx
+++ b/src/auth/__tests__/OidcAuthHandler.test.tsx
@@ -147,7 +147,7 @@ test('clicking "Try Again" after cancel clears flags and redirects', async () =>
   await utils.user.click(utils.getByRole("button", { name: "Try Again" }));
 
   await waitFor(() => {
-    expect(window.location.href).toContain("oidc-auth.com");
+    expect(new URL(window.location.href).host).toBe("oidc-auth.com");
   });
 });
 
@@ -162,7 +162,7 @@ test("proceeds with redirect when navigating back to sign in after cancel", asyn
   });
 
   await waitFor(() => {
-    expect(window.location.href).toContain("oidc-auth.com");
+    expect(new URL(window.location.href).host).toBe("oidc-auth.com");
   });
 });
 
@@ -241,9 +241,10 @@ test('clicking "Use a different account" from error state redirects with prompt=
     utils.getByRole("button", { name: "Use a different account" })
   );
 
-  expect(window.location.href).toContain("prompt=select_account");
-  expect(window.location.href).toContain("oidc-auth.com");
-  expect(sessionStorage.getItem(oidcRedirectKey)).toBeNull();
+  const redirectUrl = new URL(window.location.href);
+  expect(redirectUrl.host).toBe("oidc-auth.com");
+  expect(redirectUrl.searchParams.get("prompt")).toBe("select_account");
+  expect(sessionStorage.getItem(oidcRedirectKey)).toBe("1");
   expect(sessionStorage.getItem(oidcCancelKey)).toBeNull();
 });
 
@@ -262,8 +263,9 @@ test('clicking "Use a different account" from cancel state redirects with prompt
     utils.getByRole("button", { name: "Use a different account" })
   );
 
-  expect(window.location.href).toContain("prompt=select_account");
-  expect(window.location.href).toContain("oidc-auth.com");
-  expect(sessionStorage.getItem(oidcRedirectKey)).toBeNull();
+  const redirectUrl = new URL(window.location.href);
+  expect(redirectUrl.host).toBe("oidc-auth.com");
+  expect(redirectUrl.searchParams.get("prompt")).toBe("select_account");
+  expect(sessionStorage.getItem(oidcRedirectKey)).toBe("1");
   expect(sessionStorage.getItem(oidcCancelKey)).toBeNull();
 });

--- a/src/auth/__tests__/SamlAuthHandler.test.tsx
+++ b/src/auth/__tests__/SamlAuthHandler.test.tsx
@@ -30,7 +30,7 @@ test("redirects to proper auth url", async () => {
   });
   await waitFor(() => {
     expect(window.location.href).toBe(
-      "https://saml-auth.com/0&redirect_uri=http%3A%2F%2Ftest-domain.com%2Ftestlib"
+      "https://saml-auth.com/0?redirect_uri=http%3A%2F%2Ftest-domain.com%2Ftestlib"
     );
   });
 });
@@ -145,7 +145,7 @@ test('clicking "Try Again" after cancel clears flags and redirects', async () =>
   await utils.user.click(utils.getByRole("button", { name: "Try Again" }));
 
   await waitFor(() => {
-    expect(window.location.href).toContain("saml-auth.com");
+    expect(new URL(window.location.href).host).toBe("saml-auth.com");
   });
 });
 
@@ -160,7 +160,7 @@ test("proceeds with redirect when navigating back to sign in after cancel", asyn
   });
 
   await waitFor(() => {
-    expect(window.location.href).toContain("saml-auth.com");
+    expect(new URL(window.location.href).host).toBe("saml-auth.com");
   });
 });
 
@@ -202,4 +202,68 @@ test('clicking "Cancel" while redirecting shows cancel UI', async () => {
     expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
   });
   expect(utils.getByRole("button", { name: "Try Again" })).toBeInTheDocument();
+});
+
+test('shows "Use a different account" button on error state', () => {
+  const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+    router: { query: { loginError: "Authentication failed" } },
+    user: { token: undefined }
+  });
+  expect(
+    utils.getByRole("button", { name: "Use a different account" })
+  ).toBeInTheDocument();
+});
+
+test('shows "Use a different account" button on cancel state', async () => {
+  sessionStorage.setItem(samlRedirectKey, "1");
+
+  const utils = render(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+  expect(
+    utils.getByRole("button", { name: "Use a different account" })
+  ).toBeInTheDocument();
+});
+
+test('clicking "Use a different account" from error state redirects with force_authn=true', async () => {
+  const utils = setup(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+    router: { query: { loginError: "Authentication failed" } },
+    user: { token: undefined }
+  });
+
+  await utils.user.click(
+    utils.getByRole("button", { name: "Use a different account" })
+  );
+
+  const redirectUrl = new URL(window.location.href);
+  expect(redirectUrl.host).toBe("saml-auth.com");
+  expect(redirectUrl.searchParams.get("force_authn")).toBe("true");
+  expect(sessionStorage.getItem(samlRedirectKey)).toBe("1");
+  expect(sessionStorage.getItem(samlCancelKey)).toBeNull();
+});
+
+test('clicking "Use a different account" from cancel state redirects with force_authn=true', async () => {
+  sessionStorage.setItem(samlRedirectKey, "1");
+
+  const utils = setup(<SamlAuthHandler method={fixtures.clientSamlMethod} />, {
+    user: { token: undefined }
+  });
+
+  await waitFor(() => {
+    expect(utils.getByText("Login was cancelled.")).toBeInTheDocument();
+  });
+
+  await utils.user.click(
+    utils.getByRole("button", { name: "Use a different account" })
+  );
+
+  const redirectUrl = new URL(window.location.href);
+  expect(redirectUrl.host).toBe("saml-auth.com");
+  expect(redirectUrl.searchParams.get("force_authn")).toBe("true");
+  expect(sessionStorage.getItem(samlRedirectKey)).toBe("1");
+  expect(sessionStorage.getItem(samlCancelKey)).toBeNull();
 });

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,13 @@
+/**
+ * Appends a query parameter to an absolute URL, preserving any existing
+ * query string and encoding the value.
+ */
+export function appendSearchParam(
+  href: string,
+  name: string,
+  value: string
+): string {
+  const url = new URL(href);
+  url.searchParams.set(name, value);
+  return url.toString();
+}


### PR DESCRIPTION
## Description

Adds a "Use a different account" option to the SAML login error and cancelled-login screens, the SAML analogue of the OIDC account switching added in #146. Clicking it sends the patron to the Palace Manager login URL with `force_authn=true`, which the PM translates into `ForceAuthn` on the SAML AuthnRequest so the IdP re-authenticates the patron instead of reusing an existing session.

Along the way:
- The external-redirect login flow (redirect, cancel detection, error/cancel screens, account switching) is now shared between the SAML and OIDC handlers instead of duplicated. Each handler supplies only its storage keys and its provider-specific "switch account" query parameter.
- Auth URLs are now built via a shared helper.
- Fixes a bug in the OIDC flow (from #146) in which switching accounts cleared the redirect flag before leaving the app, so backing out of the provider silently redirected the patron to the provider again instead of showing the cancel screen.

## Motivation and Context

When a SAML login fails (for example, the IdP session belongs to an account with no patron record, or a shared device holds someone else's session), retrying just reuses the same IdP session and fails the same way. Patrons need a way to force the IdP to re-authenticate so they can sign in with a different account. The Palace Manager side of this was added in ThePalaceProject/circulation#3574.

[Jira PP-4792]

## How Has This Been Tested?

- New tests cover the "Use a different account" button in both the error and cancelled states for SAML and OIDC. The redirect URL is parsed and checked by host and query parameter; and the redirect/cancel flags are verified to be in the right state on the way out so backing out of the IdP is detected as a cancel.
- All checks / build pass locally.
- [CI checks / build](https://github.com/ThePalaceProject/web-patron/actions/runs/29627225847) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
