### PR TITLE
OPDS 2 support MVP (PP-2718)

### DIFF
--- a/.env
+++ b/.env
@@ -6,5 +6,9 @@ CONFIG_FILE=/community-config.yml
 # unexpectedly turn it on.
 # REACT_AXE=true
 
+# turn this on to request OPDS 2 (JSON) catalogs from the circulation
+# manager, falling back to OPDS 1 (Atom) when the server does not serve it
+# PALACE_CPW_FEATURE_OPDS2=true
+
 # turn this on to enable api mocking with mock service worker
-# NEXT_PUBLIC_API_MOCKING=true 
+# NEXT_PUBLIC_API_MOCKING=true

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The following environment variables can be set to further configure the applicat
 
 - Set `BUGSNAG_API_KEY` to your Bugsnag project API key to enable error tracking. If unset, Bugsnag is disabled.
 - Set `GTM_ID` to your Google Tag Manager container ID (format: `GTM-XXXXXXXX`) to enable web analytics. If unset, GTM is not loaded.
+- Set `PALACE_CPW_FEATURE_OPDS2=true` to request OPDS 2 (JSON) catalogs from the circulation manager via content negotiation, with automatic fallback to OPDS 1 (Atom) when the server does not serve OPDS 2. This is an experimental feature flag; the default is `false`. Boolean values follow the circulation manager's conventions (`true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`).
 - Set `REACT_AXE=true` to run the application with `react-axe` enabled (only works when `NODE_ENV` is "development").
 - Set `ANALYZE=true` to generate bundle analysis files inside `.next/analyze` which will show bundle sizes for server and client, as well as composition.
 

--- a/community-config.yml
+++ b/community-config.yml
@@ -49,6 +49,11 @@ media_support:
 # default is "simplye"
 companion_app: simplye
 
+# OPDS 2 CATALOGS (experimental): set the PALACE_CPW_FEATURE_OPDS2 environment
+# variable to true to request OPDS 2 (JSON) catalogs from the circulation
+# manager via content negotiation, falling back automatically to OPDS 1 (Atom)
+# when the server does not serve OPDS 2. Default is false.
+
 # BUGSNAG: set the BUGSNAG_API_KEY environment variable to integrate error tracking.
 # (Setting bugsnag_api_key in this file is deprecated and will be ignored.)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       CONFIG_FILE: /config/config.yml
       NODE_ENV: production
+      PALACE_CPW_FEATURE_OPDS2: ${PALACE_CPW_FEATURE_OPDS2:-false}
     volumes:
       - ./config:/app/config
     ports:

--- a/jest.config.js
+++ b/jest.config.js
@@ -120,7 +120,7 @@ module.exports = {
   // resolver: undefined,
 
   // Automatically restore mock state between every test
-  // restoreMocks: false,
+  restoreMocks: true,
 
   // The root directory that Jest should scan for tests and modules within
   // rootDir: undefined,

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -16,7 +16,7 @@ import BookCover from "./BookCover";
 import BorrowOrReserveOrPreview from "./BorrowOrReserveOrPreview";
 import CancelOrReturnOrPreview from "./CancelOrReturnOrPreview";
 import { AnyBook, CollectionData, LaneData } from "interfaces";
-import { fetchCollection } from "dataflow/opds1/fetch";
+import { fetchCollection } from "dataflow/catalog";
 import useSWRInfinite from "swr/infinite";
 import useUser from "components/context/UserContext";
 import Stack from "components/Stack";

--- a/src/components/CancelOrReturn.tsx
+++ b/src/components/CancelOrReturn.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import useLibraryContext from "components/context/LibraryContext";
 import useUser from "components/context/UserContext";
-import { fetchBook } from "dataflow/opds1/fetch";
+import { fetchBook } from "dataflow/catalog";
 import Button from "components/Button";
 import useError from "hooks/useError";
 import { useFulfillmentButtonStackError } from "components/layouts/FulfillmentButtonStack";

--- a/src/components/__tests__/BookList.test.tsx
+++ b/src/components/__tests__/BookList.test.tsx
@@ -4,7 +4,7 @@ import { BookList, InfiniteBookList } from "../BookList";
 import merge from "deepmerge";
 import { BorrowableBook, CollectionData } from "interfaces";
 import useSWRInfinite from "swr/infinite";
-import { fetchCollection } from "dataflow/opds1/fetch";
+import { fetchCollection } from "dataflow/catalog";
 
 const books = fixtures.makeBorrowableBooks(3);
 

--- a/src/components/__tests__/BookListItem.test.tsx
+++ b/src/components/__tests__/BookListItem.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { screen, setup, fireEvent, fixtures, waitFor } from "test-utils";
 import { BookListItem } from "components/BookList";
-import * as fetch from "dataflow/opds1/fetch";
+import * as fetch from "dataflow/catalog";
 import {
   BorrowableBook,
   FulfillableBook,
@@ -228,7 +228,13 @@ describe("ReservedBook", () => {
       "user-token"
     );
 
-    expect(mockSetBook).toHaveBeenCalledWith(unreservedBook, reservedBook.id);
+    await waitFor(() =>
+      expect(mockSetBook).toHaveBeenCalledWith(unreservedBook, reservedBook.id)
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Cancel Reservation" })
+    ).toBeInTheDocument();
   });
 
   test("displays number of patrons in queue and your position", () => {

--- a/src/components/__tests__/BorrowOrReserve.test.tsx
+++ b/src/components/__tests__/BorrowOrReserve.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "test-utils";
 import BorrowOrReserve from "components/BorrowOrReserve";
 import BorrowOrReserveOrPreview from "components/BorrowOrReserveOrPreview";
-import * as fetch from "dataflow/opds1/fetch";
+import * as fetch from "dataflow/catalog";
 import { mockPush, mockReplace } from "test-utils/mockNextRouter";
 
 test("shows correct button for borrowable book", async () => {

--- a/src/components/__tests__/BorrowOrReserveOrPreview.test.tsx
+++ b/src/components/__tests__/BorrowOrReserveOrPreview.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { screen, setup, waitFor } from "test-utils";
 import BorrowOrReserveOrPreview from "components/BorrowOrReserveOrPreview";
-import * as fetch from "dataflow/opds1/fetch";
+import * as fetch from "dataflow/catalog";
 import { ServerError } from "errors";
 import { makeMockTab } from "test-utils/mockTab";
 

--- a/src/components/__tests__/CancelOrReturnOrPreview.test.tsx
+++ b/src/components/__tests__/CancelOrReturnOrPreview.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { screen, setup, waitFor } from "test-utils";
 import CancelOrReturnOrPreview from "components/CancelOrReturnOrPreview";
-import * as fetch from "dataflow/opds1/fetch";
+import * as fetch from "dataflow/catalog";
 import { ServerError } from "errors";
 import { makeMockTab } from "test-utils/mockTab";
 

--- a/src/components/__tests__/Collection.test.tsx
+++ b/src/components/__tests__/Collection.test.tsx
@@ -3,7 +3,7 @@ import { render, fixtures } from "test-utils";
 import { Collection } from "../Collection";
 import { CollectionData, LaneData } from "interfaces";
 import { makeSwrResponse, MockSwr } from "test-utils/mockSwr";
-import { fetchCollection } from "dataflow/opds1/fetch";
+import { fetchCollection } from "dataflow/catalog";
 import useSWR from "swr";
 // import useSWRInfinite from "swr/infinite";
 import "test-utils/mockScrollTo";

--- a/src/components/bookDetails/Recommendations.tsx
+++ b/src/components/bookDetails/Recommendations.tsx
@@ -3,7 +3,7 @@ import LoadingIndicator from "../LoadingIndicator";
 import { H3, H2 } from "components/Text";
 import Lane from "components/Lane";
 import { AnyBook } from "interfaces";
-import { fetchCollection } from "dataflow/opds1/fetch";
+import { fetchCollection } from "dataflow/catalog";
 import useSWR from "swr";
 import useUser from "components/context/UserContext";
 

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -362,16 +362,17 @@ describe("book details page", () => {
   });
 });
 
-/**
- * mock fetchComplaintTypes and postComplaint
- */
 const mockBoundFetchComplaintTypes = jest
   .fn()
   .mockResolvedValue(["complaint-type"]);
-const fetchComplaintTypesSpy = jest
-  .spyOn(complaintActions, "fetchComplaintTypes")
-  .mockReturnValue(mockBoundFetchComplaintTypes);
-const postComplaintSpy = jest.spyOn(complaintActions, "postComplaint");
+let fetchComplaintTypesSpy: jest.SpyInstance;
+let postComplaintSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  fetchComplaintTypesSpy = jest
+    .spyOn(complaintActions, "fetchComplaintTypes")
+    .mockReturnValue(mockBoundFetchComplaintTypes);
+});
 
 const bookWithReportUrl = merge<AnyBook>(fixtures.book, {
   raw: {
@@ -391,6 +392,10 @@ const bookWithReportUrl = merge<AnyBook>(fixtures.book, {
 });
 
 describe("report problem", () => {
+  beforeEach(() => {
+    postComplaintSpy = jest.spyOn(complaintActions, "postComplaint");
+  });
+
   test("shows report problem link", () => {
     mockSwr({ data: fixtures.book });
     setup(<BookDetails />);

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -18,7 +18,7 @@ import {
 } from "interfaces";
 import { ProblemDocument } from "types/opds1";
 import fetchMock from "jest-fetch-mock";
-import * as fetch from "dataflow/opds1/fetch";
+import * as fetch from "dataflow/catalog";
 import { ServerError } from "errors";
 import { MOCK_DATE_STRING } from "test-utils/mockToDateString";
 import { makeMockTab } from "test-utils/mockTab";
@@ -26,7 +26,7 @@ import { makeMockTab } from "test-utils/mockTab";
 jest.mock("downloadjs");
 window.open = jest.fn();
 
-jest.mock("dataflow/opds1/fetch");
+jest.mock("dataflow/catalog");
 
 (fetch as any).fetchBook = jest.fn();
 const mockFetchBook = fetch.fetchBook as jest.MockedFunction<

--- a/src/components/bookDetails/__tests__/Recommendations.test.tsx
+++ b/src/components/bookDetails/__tests__/Recommendations.test.tsx
@@ -3,7 +3,7 @@ import { render, fixtures, waitFor } from "test-utils";
 import { CollectionData } from "interfaces";
 import Recommendations from "../Recommendations";
 import useSWR, { SWRResponse } from "swr";
-import { fetchCollection } from "dataflow/opds1/fetch";
+import { fetchCollection } from "dataflow/catalog";
 
 jest.mock("swr");
 

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -17,7 +17,7 @@ import GooglePlayBadge from "components/storeBadges/GooglePlayBadge";
 import { useRouter } from "next/router";
 import extractParam from "dataflow/utils";
 import useSWR from "swr";
-import { fetchBook } from "dataflow/opds1/fetch";
+import { fetchBook } from "dataflow/catalog";
 import useUser from "components/context/UserContext";
 import useBreadcrumbContext from "components/context/BreadcrumbContext";
 import { useAppConfig } from "components/context/AppConfigContext";

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -1,7 +1,7 @@
 import { fetchAuthToken } from "auth/fetch";
 import useCredentials from "auth/useCredentials";
 import useLibraryContext from "components/context/LibraryContext";
-import { fetchCollection } from "dataflow/opds1/fetch";
+import { fetchCollection } from "dataflow/catalog";
 import { ServerError } from "errors";
 import {
   AppAuthMethod,

--- a/src/components/context/__tests__/ContextProvider.test.tsx
+++ b/src/components/context/__tests__/ContextProvider.test.tsx
@@ -8,8 +8,9 @@ import { MockNextRouterContextProvider } from "test-utils/mockNextRouter";
 import * as modal from "components/Modal";
 
 // react portals not supported by hooks testing library
-const mockModal = jest.spyOn(modal, "default");
-mockModal.mockReturnValue(<div>modal</div>);
+beforeEach(() => {
+  jest.spyOn(modal, "default").mockReturnValue(<div>modal</div>);
+});
 
 // const TestComponent: React.FC = () => <div>test child</div>;
 

--- a/src/components/context/__tests__/UserContext.test.tsx
+++ b/src/components/context/__tests__/UserContext.test.tsx
@@ -11,18 +11,17 @@ import mockAuthenticated from "test-utils/mockAuthState";
 import * as swr from "swr";
 import { makeSwrResponse } from "test-utils/mockSwr";
 
-const mockSWR = jest.spyOn(swr, "default");
+let mockSWR: jest.SpiedFunction<typeof swr.default>;
+let useRouterSpy: jest.SpiedFunction<typeof router.useRouter>;
 
 const str = JSON.stringify;
 const mockCookie = Cookie as any;
-const useRouterSpy = jest.spyOn(router, "useRouter");
 
 const mutateMock = jest.fn();
 const defaultMock = makeSwrResponse<any>({
   data: fixtures.emptyCollection,
   mutate: mutateMock as any
 });
-mockSWR.mockReturnValue(defaultMock as any);
 
 /**
  * This file tests both UserContext and useCredentials, as
@@ -35,8 +34,9 @@ function renderUserContext() {
 }
 
 beforeEach(() => {
+  mockSWR = jest.spyOn(swr, "default").mockReturnValue(defaultMock as any);
   window.location.hash = "";
-  useRouterSpy.mockReturnValue({
+  useRouterSpy = jest.spyOn(router, "useRouter").mockReturnValue({
     query: {},
     replace: jest.fn()
   } as any);

--- a/src/config/fallbackAppConfig.ts
+++ b/src/config/fallbackAppConfig.ts
@@ -6,6 +6,7 @@ const FALLBACK_APP_CONFIG: AppConfig = {
   mediaSupport: {},
   companionApp: "simplye",
   showMedium: true,
+  enableOpds2: false,
   bugsnagApiKey: null,
   openebooks: null,
   authenticationDocuments: null,

--- a/src/dataflow/__tests__/catalog.test.ts
+++ b/src/dataflow/__tests__/catalog.test.ts
@@ -12,6 +12,10 @@ import rawOpdsFeed from "test-utils/fixtures/raw-opds-feed";
 import rawOpdsEntry from "test-utils/fixtures/raw-opds-entry";
 import * as opds2 from "test-utils/fixtures/opds2-catalog";
 
+afterEach(() => {
+  mockConfig();
+});
+
 const OPDS2_FEED_HEADERS = { "content-type": "application/opds+json" };
 const OPDS2_PUBLICATION_HEADERS = {
   "content-type": "application/opds-publication+json"

--- a/src/dataflow/__tests__/catalog.test.ts
+++ b/src/dataflow/__tests__/catalog.test.ts
@@ -105,6 +105,15 @@ describe("with OPDS 2 enabled", () => {
     expect(book.authors).toHaveLength(2);
   });
 
+  test("fetchCollection throws if an OPDS 2 response is a publication", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(opds2.loanedPublication), {
+      headers: OPDS2_PUBLICATION_HEADERS
+    });
+    await expect(fetchCollection(opds2.CATALOG_URL)).rejects.toThrow(
+      "Could not parse fetch response into an OPDS Feed or Entry"
+    );
+  });
+
   test("fetchBook throws if an OPDS 2 response is a feed", async () => {
     fetchMock.mockResponseOnce(JSON.stringify(opds2.groupedFeed), {
       headers: OPDS2_PUBLICATION_HEADERS

--- a/src/dataflow/__tests__/catalog.test.ts
+++ b/src/dataflow/__tests__/catalog.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "@jest/globals";
+import fetchMock from "jest-fetch-mock";
+import {
+  fetchBook,
+  fetchCollection,
+  OPDS2_ENTRY_ACCEPT_HEADER,
+  OPDS2_FEED_ACCEPT_HEADER
+} from "dataflow/catalog";
+import ApplicationError, { ServerError } from "errors";
+import mockConfig from "test-utils/mockConfig";
+import rawOpdsFeed from "test-utils/fixtures/raw-opds-feed";
+import rawOpdsEntry from "test-utils/fixtures/raw-opds-entry";
+import * as opds2 from "test-utils/fixtures/opds2-catalog";
+
+const OPDS2_FEED_HEADERS = { "content-type": "application/opds+json" };
+const OPDS2_PUBLICATION_HEADERS = {
+  "content-type": "application/opds-publication+json"
+};
+const ATOM_HEADERS = {
+  "content-type": "application/atom+xml;profile=opds-catalog;kind=acquisition"
+};
+
+describe("with OPDS 2 disabled (default)", () => {
+  test("fetchCollection sends no Accept header and parses OPDS 1", async () => {
+    fetchMock.mockResponseOnce(rawOpdsFeed);
+    const collection = await fetchCollection("http://somewhere");
+    expect(collection.books).toHaveLength(6);
+    expect(fetchMock).toHaveBeenCalledWith("http://somewhere", {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        "Accept-Language": "*"
+      },
+      method: "GET"
+    });
+  });
+
+  test("fetchBook sends no Accept header and parses OPDS 1", async () => {
+    fetchMock.mockResponseOnce(rawOpdsEntry);
+    const book = await fetchBook("/somewhere", "http://catalog.com");
+    expect(book.authors).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledWith("/somewhere", {
+      headers: { "X-Requested-With": "XMLHttpRequest" },
+      method: "GET"
+    });
+  });
+});
+
+describe("with OPDS 2 enabled", () => {
+  beforeEach(() => {
+    mockConfig({ enableOpds2: true });
+  });
+
+  test("fetchCollection negotiates OPDS 2 and parses a JSON feed", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(opds2.groupedFeed), {
+      headers: OPDS2_FEED_HEADERS
+    });
+    const collection = await fetchCollection(opds2.CATALOG_URL, "token");
+    expect(collection.lanes).toHaveLength(2);
+    expect(collection.title).toBe("Test Library");
+    expect(fetchMock).toHaveBeenCalledWith(opds2.CATALOG_URL, {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        "Accept-Language": "*",
+        Accept: OPDS2_FEED_ACCEPT_HEADER,
+        Authorization: "token"
+      },
+      method: "GET"
+    });
+  });
+
+  test("fetchCollection falls back to OPDS 1 for Atom responses", async () => {
+    fetchMock.mockResponseOnce(rawOpdsFeed, { headers: ATOM_HEADERS });
+    const collection = await fetchCollection("http://somewhere");
+    expect(collection.books).toHaveLength(6);
+  });
+
+  test("fetchCollection falls back to OPDS 1 when content-type is missing", async () => {
+    fetchMock.mockResponseOnce(rawOpdsFeed);
+    const collection = await fetchCollection("http://somewhere");
+    expect(collection.books).toHaveLength(6);
+  });
+
+  test("fetchBook negotiates OPDS 2 and parses a publication", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(opds2.loanedPublication), {
+      headers: OPDS2_PUBLICATION_HEADERS
+    });
+    const book = await fetchBook(
+      "https://cm.example.com/works/6",
+      opds2.CATALOG_URL
+    );
+    expect(book.title).toBe("Loaned Book");
+    expect(book.status).toBe("fulfillable");
+    expect(fetchMock).toHaveBeenCalledWith("https://cm.example.com/works/6", {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        Accept: OPDS2_ENTRY_ACCEPT_HEADER
+      },
+      method: "GET"
+    });
+  });
+
+  test("fetchBook parses an Atom entry response", async () => {
+    fetchMock.mockResponseOnce(rawOpdsEntry, { headers: ATOM_HEADERS });
+    const book = await fetchBook("/somewhere", "http://catalog.com");
+    expect(book.authors).toHaveLength(2);
+  });
+
+  test("fetchBook throws if an OPDS 2 response is a feed", async () => {
+    fetchMock.mockResponseOnce(JSON.stringify(opds2.groupedFeed), {
+      headers: OPDS2_PUBLICATION_HEADERS
+    });
+    await expect(
+      fetchBook("https://cm.example.com/works/6", opds2.CATALOG_URL)
+    ).rejects.toThrow(ApplicationError);
+  });
+
+  test("throws ServerError if the response is not ok", async () => {
+    fetchMock.mockResponseOnce(
+      JSON.stringify({ detail: "nope", title: "wrong", status: 418 }),
+      { status: 418 }
+    );
+    await expect(fetchCollection("/some-url")).rejects.toThrow(ServerError);
+  });
+
+  test("throws ApplicationError on invalid JSON with an OPDS 2 content type", async () => {
+    fetchMock.mockResponseOnce("this is not json", {
+      headers: OPDS2_FEED_HEADERS
+    });
+    await expect(fetchCollection("/some-url")).rejects.toThrow(
+      "Could not parse the response as OPDS 2 JSON"
+    );
+  });
+
+  test("throws ApplicationError on unparseable non-OPDS 2 responses", async () => {
+    fetchMock.mockResponseOnce("<html>an error page</html>", {
+      headers: { "content-type": "text/html" }
+    });
+    await expect(fetchCollection("/some-url")).rejects.toThrow(
+      ApplicationError
+    );
+  });
+});

--- a/src/dataflow/catalog.ts
+++ b/src/dataflow/catalog.ts
@@ -1,0 +1,158 @@
+import { OPDSEntry, OPDSFeed } from "opds-feed-parser";
+import ApplicationError, { ServerError } from "errors";
+import { AnyBook, CollectionData, OPDS2 } from "interfaces";
+import fetchWithHeaders from "dataflow/fetch";
+import {
+  fetchBook as fetchOpds1Book,
+  fetchCollection as fetchOpds1Collection,
+  parseOPDSText
+} from "dataflow/opds1/fetch";
+import {
+  entryToBook,
+  feedToCollection as opds1FeedToCollection
+} from "dataflow/opds1/parse";
+import {
+  feedToCollection as opds2FeedToCollection,
+  publicationToBook
+} from "dataflow/opds2/parse";
+import {
+  lenientValidate,
+  Opds2FeedSchema,
+  Opds2PublicationSchema
+} from "validation/opds2Catalog";
+
+/**
+ * Format-agnostic catalog fetching. When OPDS 2 is enabled, requests are
+ * made with an Accept header preferring OPDS 2 (JSON) and the response
+ * Content-Type decides which parser handles the body; servers that do not
+ * serve OPDS 2 (including any that ignore the Accept header) fall back to
+ * the OPDS 1.x (Atom) parser. When disabled, requests are delegated
+ * unchanged to the OPDS 1.x fetchers.
+ */
+
+// Quality-ranked so that a Palace Circulation Manager negotiates OPDS 2
+// while servers without OPDS 2 support still get an Accept value they can
+// satisfy.
+export const OPDS2_FEED_ACCEPT_HEADER = `${OPDS2.BaseDocumentMediaType}, application/atom+xml;q=0.9, */*;q=0.1`;
+export const OPDS2_ENTRY_ACCEPT_HEADER = `${OPDS2.PublicationMediaType}, application/atom+xml;q=0.9, */*;q=0.1`;
+
+let _opds2Enabled = false;
+
+/** Sets whether to negotiate OPDS 2. Called once at app startup from _app.tsx. */
+export function setOpds2Enabled(enabled: boolean): void {
+  _opds2Enabled = enabled;
+}
+
+function isOpds2ContentType(contentType: string): boolean {
+  return (
+    contentType.includes(OPDS2.BaseDocumentMediaType) ||
+    contentType.includes(OPDS2.PublicationMediaType)
+  );
+}
+
+function parseOpds2Json(text: string, url: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (e) {
+    throw new ApplicationError(
+      {
+        title: "OPDS 2 Error",
+        detail: `Could not parse the response as OPDS 2 JSON. Url: ${url}`
+      },
+      e
+    );
+  }
+}
+
+async function fetchNegotiated(
+  url: string,
+  token: string | undefined,
+  additionalHeaders: { [key: string]: string }
+): Promise<{ contentType: string; text: string }> {
+  const response = await fetchWithHeaders(url, token, additionalHeaders);
+  if (!response.ok) {
+    const json = await response.json();
+    throw new ServerError(url, response.status, json);
+  }
+  return {
+    contentType: response.headers.get("content-type") ?? "",
+    text: await response.text()
+  };
+}
+
+/**
+ * Fetches a feed and converts it to a collection
+ */
+export async function fetchCollection(
+  url: string,
+  token?: string
+): Promise<CollectionData> {
+  if (!_opds2Enabled) {
+    return fetchOpds1Collection(url, token);
+  }
+
+  const { contentType, text } = await fetchNegotiated(url, token, {
+    // Explicitly accept all languages when fetching feeds. Otherwise, the browser will send an
+    // Accept-Language header for its current language, which causes books in other languages to
+    // be filtered out of search results.
+    "Accept-Language": "*",
+    Accept: OPDS2_FEED_ACCEPT_HEADER
+  });
+
+  if (isOpds2ContentType(contentType)) {
+    const json = parseOpds2Json(text, url);
+    const feed = lenientValidate(Opds2FeedSchema, json, url);
+    return opds2FeedToCollection(feed, url);
+  }
+
+  const result = await parseOPDSText(text);
+  if (result instanceof OPDSFeed) {
+    return opds1FeedToCollection(result, url);
+  }
+  throw new ApplicationError({
+    title: "OPDS Error",
+    detail: `Network response was expected to be an OPDS 1.x Feed, but was not parseable as such. Url: ${url}`
+  });
+}
+
+/**
+ * Fetches an entry and converts it to a book
+ */
+export async function fetchBook(
+  url: string,
+  catalogUrl: string,
+  token?: string
+): Promise<AnyBook> {
+  if (!_opds2Enabled) {
+    return fetchOpds1Book(url, catalogUrl, token);
+  }
+
+  const { contentType, text } = await fetchNegotiated(url, token, {
+    Accept: OPDS2_ENTRY_ACCEPT_HEADER
+  });
+
+  if (isOpds2ContentType(contentType)) {
+    const json = parseOpds2Json(text, url);
+    if (
+      json !== null &&
+      typeof json === "object" &&
+      ("publications" in json || "groups" in json || "navigation" in json)
+    ) {
+      throw new ApplicationError({
+        title: "OPDS 2 Error",
+        detail: `Network response was expected to be an OPDS 2 Publication, but was a Feed. Url: ${url}`
+      });
+    }
+    const publication = lenientValidate(Opds2PublicationSchema, json, url);
+    return publicationToBook(publication, catalogUrl);
+  }
+
+  const result = await parseOPDSText(text);
+  if (result instanceof OPDSEntry) {
+    return entryToBook(result, catalogUrl);
+  }
+  throw new ApplicationError({
+    title: "OPDS Error",
+    detail: `Network response was expected to be an OPDS 1.x Entry, but was not parseable as such. Url: ${url}`
+  });
+}

--- a/src/dataflow/catalog.ts
+++ b/src/dataflow/catalog.ts
@@ -43,10 +43,17 @@ export function setOpds2Enabled(enabled: boolean): void {
   _opds2Enabled = enabled;
 }
 
+type Opds2CatalogMediaType =
+  | typeof OPDS2.BaseDocumentMediaType
+  | typeof OPDS2.PublicationMediaType;
+
 // Each fetcher matches only the OPDS 2 media types it can handle; anything
 // else falls through to the Atom parser, which fails with a clear error
 // instead of leniently mis-parsing the wrong document kind.
-function isOpds2ContentType(contentType: string, expected: string[]): boolean {
+function isOpds2ContentType(
+  contentType: string,
+  expected: Opds2CatalogMediaType[]
+): boolean {
   return expected.some(type => contentType.includes(type));
 }
 

--- a/src/dataflow/catalog.ts
+++ b/src/dataflow/catalog.ts
@@ -141,7 +141,10 @@ export async function fetchBook(
     if (
       json !== null &&
       typeof json === "object" &&
-      ("publications" in json || "groups" in json || "navigation" in json)
+      ("publications" in json ||
+        "groups" in json ||
+        "navigation" in json ||
+        "facets" in json)
     ) {
       throw new ApplicationError({
         title: "OPDS 2 Error",

--- a/src/dataflow/catalog.ts
+++ b/src/dataflow/catalog.ts
@@ -43,11 +43,11 @@ export function setOpds2Enabled(enabled: boolean): void {
   _opds2Enabled = enabled;
 }
 
-function isOpds2ContentType(contentType: string): boolean {
-  return (
-    contentType.includes(OPDS2.BaseDocumentMediaType) ||
-    contentType.includes(OPDS2.PublicationMediaType)
-  );
+// Each fetcher matches only the OPDS 2 media types it can handle; anything
+// else falls through to the Atom parser, which fails with a clear error
+// instead of leniently mis-parsing the wrong document kind.
+function isOpds2ContentType(contentType: string, expected: string[]): boolean {
+  return expected.some(type => contentType.includes(type));
 }
 
 function parseOpds2Json(text: string, url: string): unknown {
@@ -99,7 +99,7 @@ export async function fetchCollection(
     Accept: OPDS2_FEED_ACCEPT_HEADER
   });
 
-  if (isOpds2ContentType(contentType)) {
+  if (isOpds2ContentType(contentType, [OPDS2.BaseDocumentMediaType])) {
     const json = parseOpds2Json(text, url);
     const feed = lenientValidate(Opds2FeedSchema, json, url);
     return opds2FeedToCollection(feed, url);
@@ -131,7 +131,12 @@ export async function fetchBook(
     Accept: OPDS2_ENTRY_ACCEPT_HEADER
   });
 
-  if (isOpds2ContentType(contentType)) {
+  if (
+    isOpds2ContentType(contentType, [
+      OPDS2.PublicationMediaType,
+      OPDS2.BaseDocumentMediaType
+    ])
+  ) {
     const json = parseOpds2Json(text, url);
     if (
       json !== null &&

--- a/src/dataflow/opds1/fetch.ts
+++ b/src/dataflow/opds1/fetch.ts
@@ -6,6 +6,26 @@ import fetchWithHeaders from "dataflow/fetch";
 import parseSearchData from "dataflow/opds1/parseSearchData";
 
 const parser = new OPDSParser();
+
+/**
+ * Parses OPDS 1.x text into either a Feed or an Entry
+ */
+export async function parseOPDSText(
+  text: string
+): Promise<OPDSEntry | OPDSFeed> {
+  try {
+    return await parser.parse(text);
+  } catch (e) {
+    throw new ApplicationError(
+      {
+        title: "OPDS Error",
+        detail: "Could not parse fetch response into an OPDS Feed or Entry"
+      },
+      e
+    );
+  }
+}
+
 /**
  * Function that will fetch opds and parse it into either
  * a Feed or an Entry
@@ -24,19 +44,7 @@ export async function fetchOPDS(
   }
 
   const text = await response.text();
-
-  try {
-    // parse the text into an opds feed or entry
-    return await parser.parse(text);
-  } catch (e) {
-    throw new ApplicationError(
-      {
-        title: "OPDS Error",
-        detail: "Could not parse fetch response into an OPDS Feed or Entry"
-      },
-      e
-    );
-  }
+  return await parseOPDSText(text);
 }
 
 /**

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -547,7 +547,7 @@ function dedupeBooks(books: AnyBook[]): AnyBook[] {
   return Array.from(bookIndex.values());
 }
 
-function formatDate(inputDate: string): string {
+export function formatDate(inputDate: string): string {
   const monthNames = [
     "January",
     "February",

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -537,7 +537,7 @@ function entryToLink(entry: OPDSEntry, feedUrl: string): LinkData | null {
   return null;
 }
 
-function dedupeBooks(books: AnyBook[]): AnyBook[] {
+export function dedupeBooks(books: AnyBook[]): AnyBook[] {
   // using Map because it preserves key order
   const bookIndex = books.reduce((index, book) => {
     index.set(book.id, book);

--- a/src/dataflow/opds2/__tests__/parse.test.ts
+++ b/src/dataflow/opds2/__tests__/parse.test.ts
@@ -373,6 +373,36 @@ describe("feedToCollection", () => {
     expect(collection.nextPageUrl).toBe("https://cm.example.com/next-page");
   });
 
+  test("does not throw when publications is not an array", () => {
+    const collection = feedToCollection(
+      {
+        metadata: { title: "Malformed" },
+        links: [],
+        publications: "not-an-array"
+      } as unknown as Opds2Feed,
+      CATALOG_URL
+    );
+    expect(collection.books).toEqual([]);
+  });
+
+  test("does not throw when a group's publications is not an array", () => {
+    const collection = feedToCollection(
+      {
+        metadata: { title: "Malformed Group" },
+        links: [],
+        groups: [
+          {
+            metadata: { title: "Broken Group" },
+            links: [],
+            publications: "not-an-array"
+          }
+        ]
+      } as unknown as Opds2Feed,
+      CATALOG_URL
+    );
+    expect(collection.lanes).toEqual([]);
+  });
+
   test("maps an empty document to an empty collection", () => {
     const collection = feedToCollection({} as Opds2Feed, CATALOG_URL);
     expect(collection).toMatchObject({

--- a/src/dataflow/opds2/__tests__/parse.test.ts
+++ b/src/dataflow/opds2/__tests__/parse.test.ts
@@ -46,12 +46,13 @@ describe("publicationToBook", () => {
       asPublication(fixtures.borrowablePublication),
       CATALOG_URL
     );
-    expect(book.status).toBe("borrowable");
-    if (book.status !== "borrowable") throw new Error();
-    expect(book.borrowUrl).toBe("https://cm.example.com/works/1/borrow");
-    expect(book.availability?.status).toBe("available");
-    expect(book.copies).toEqual({ total: 5, available: 3 });
-    expect(book.holds).toEqual({ total: 0, position: undefined });
+    expect(book).toMatchObject({
+      status: "borrowable",
+      borrowUrl: "https://cm.example.com/works/1/borrow",
+      availability: { status: "available" },
+      copies: { total: 5, available: 3 },
+      holds: { total: 0, position: undefined }
+    });
   });
 
   test("parses a reservable book", () => {
@@ -59,10 +60,11 @@ describe("publicationToBook", () => {
       asPublication(fixtures.reservablePublication),
       CATALOG_URL
     );
-    expect(book.status).toBe("reservable");
-    if (book.status !== "reservable") throw new Error();
-    expect(book.reserveUrl).toBe("https://cm.example.com/works/2/borrow");
-    expect(book.copies).toEqual({ total: 2, available: 0 });
+    expect(book).toMatchObject({
+      status: "reservable",
+      reserveUrl: "https://cm.example.com/works/2/borrow",
+      copies: { total: 2, available: 0 }
+    });
   });
 
   test("parses an on-hold (ready) book", () => {
@@ -70,10 +72,11 @@ describe("publicationToBook", () => {
       asPublication(fixtures.onHoldPublication),
       CATALOG_URL
     );
-    expect(book.status).toBe("on-hold");
-    if (book.status !== "on-hold") throw new Error();
-    expect(book.borrowUrl).toBe("https://cm.example.com/works/3/borrow");
-    expect(book.availability?.until).toBe("2026-02-01T00:00:00+00:00");
+    expect(book).toMatchObject({
+      status: "on-hold",
+      borrowUrl: "https://cm.example.com/works/3/borrow",
+      availability: { until: "2026-02-01T00:00:00+00:00" }
+    });
   });
 
   test("parses a reserved book with hold position and revoke url", () => {
@@ -81,10 +84,11 @@ describe("publicationToBook", () => {
       asPublication(fixtures.reservedPublication),
       CATALOG_URL
     );
-    expect(book.status).toBe("reserved");
-    if (book.status !== "reserved") throw new Error();
-    expect(book.revokeUrl).toBe("https://cm.example.com/loans/4/revoke");
-    expect(book.holds).toEqual({ total: 10, position: 3 });
+    expect(book).toMatchObject({
+      status: "reserved",
+      revokeUrl: "https://cm.example.com/loans/4/revoke",
+      holds: { total: 10, position: 3 }
+    });
   });
 
   test("parses an open access book as fulfillable", () => {
@@ -92,16 +96,36 @@ describe("publicationToBook", () => {
       asPublication(fixtures.openAccessPublication),
       CATALOG_URL
     );
-    expect(book.status).toBe("fulfillable");
-    if (book.status !== "fulfillable") throw new Error();
-    expect(book.fulfillmentLinks).toEqual([
-      {
-        url: "https://cm.example.com/works/5/open-access.epub",
-        contentType: "application/epub+zip",
-        supportLevel: "show"
-      }
-    ]);
-    expect(book.revokeUrl).toBeNull();
+    expect(book).toMatchObject({
+      status: "fulfillable",
+      fulfillmentLinks: [
+        {
+          url: "https://cm.example.com/works/5/open-access.epub",
+          contentType: "application/epub+zip",
+          supportLevel: "show"
+        }
+      ],
+      revokeUrl: null
+    });
+  });
+
+  test("parses an open-access link with an indirection chain by its resolved format, not its wrapper type", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.openAccessBearerTokenPublication),
+      CATALOG_URL
+    );
+    expect(book).toMatchObject({
+      status: "fulfillable",
+      fulfillmentLinks: [
+        {
+          url: "https://cm.example.com/works/12/fulfill",
+          contentType: "application/pdf",
+          indirectionType:
+            "application/vnd.librarysimplified.bearer-token+json",
+          supportLevel: "redirect"
+        }
+      ]
+    });
   });
 
   test("parses an active loan as fulfillable with indirection", () => {
@@ -109,17 +133,18 @@ describe("publicationToBook", () => {
       asPublication(fixtures.loanedPublication),
       CATALOG_URL
     );
-    expect(book.status).toBe("fulfillable");
-    if (book.status !== "fulfillable") throw new Error();
-    expect(book.fulfillmentLinks).toEqual([
-      {
-        url: "https://cm.example.com/loans/6/fulfill",
-        contentType: "application/epub+zip",
-        indirectionType: "application/vnd.adobe.adept+xml",
-        supportLevel: "redirect-and-show"
-      }
-    ]);
-    expect(book.revokeUrl).toBe("https://cm.example.com/loans/6/revoke");
+    expect(book).toMatchObject({
+      status: "fulfillable",
+      fulfillmentLinks: [
+        {
+          url: "https://cm.example.com/loans/6/fulfill",
+          contentType: "application/epub+zip",
+          indirectionType: "application/vnd.adobe.adept+xml",
+          supportLevel: "redirect-and-show"
+        }
+      ],
+      revokeUrl: "https://cm.example.com/loans/6/revoke"
+    });
   });
 
   test("parses a streaming loan, normalizing OPDS entry indirection", () => {
@@ -159,16 +184,19 @@ describe("publicationToBook", () => {
       asPublication(fixtures.audiobookPublication),
       CATALOG_URL
     );
-    expect(book.format).toBe("Audiobook");
-    expect(book.duration).toBe("2 hours, 7 minutes");
-    expect(book.narrators).toEqual(["First Narrator", "Second Narrator"]);
-    expect(book.status).toBe("fulfillable");
-    if (book.status !== "fulfillable") throw new Error();
-    expect(book.fulfillmentLinks[0]).toEqual({
-      url: "https://cm.example.com/loans/7/fulfill",
-      contentType: "application/audiobook+json",
-      indirectionType: undefined,
-      supportLevel: "redirect"
+    expect(book).toMatchObject({
+      format: "Audiobook",
+      duration: "2 hours, 7 minutes",
+      narrators: ["First Narrator", "Second Narrator"],
+      status: "fulfillable",
+      fulfillmentLinks: [
+        {
+          url: "https://cm.example.com/loans/7/fulfill",
+          contentType: "application/audiobook+json",
+          indirectionType: undefined,
+          supportLevel: "redirect"
+        }
+      ]
     });
   });
 

--- a/src/dataflow/opds2/__tests__/parse.test.ts
+++ b/src/dataflow/opds2/__tests__/parse.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test } from "@jest/globals";
+import { feedToCollection, publicationToBook } from "dataflow/opds2/parse";
+import {
+  Opds2Feed,
+  Opds2FeedSchema,
+  Opds2Publication,
+  Opds2PublicationSchema
+} from "validation/opds2Catalog";
+import * as fixtures from "test-utils/fixtures/opds2-catalog";
+
+const { CATALOG_URL } = fixtures;
+
+/**
+ * Schema-asserting helpers: they both type the fixture for the mapper and
+ * prove the fixture matches what the CM actually serializes.
+ */
+function asFeed(data: unknown): Opds2Feed {
+  return Opds2FeedSchema.assert(data);
+}
+function asPublication(data: unknown): Opds2Publication {
+  return Opds2PublicationSchema.assert(data);
+}
+
+describe("publicationToBook", () => {
+  test("parses bibliographic metadata", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.borrowablePublication),
+      CATALOG_URL
+    );
+    expect(book.id).toBe("urn:isbn:9780000000001");
+    expect(book.title).toBe("Borrowable Book");
+    expect(book.authors).toEqual(["Test Author"]);
+    expect(book.publisher).toBe("Test Publisher");
+    expect(book.language).toBe("en");
+    expect(book.published).toBe("June 15, 2020");
+    expect(book.summary).toBe("A <b>very</b> good book.");
+    expect(book.audience).toBe("Adult");
+    expect(book.categories).toEqual(["Fiction"]);
+    expect(book.imageUrl).toBe("https://cm.example.com/covers/1-thumb.png");
+    expect(book.url).toBe("https://cm.example.com/works/1");
+    expect(book.format).toBe("ePub");
+  });
+
+  test("parses a borrowable book", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.borrowablePublication),
+      CATALOG_URL
+    );
+    expect(book.status).toBe("borrowable");
+    if (book.status !== "borrowable") throw new Error();
+    expect(book.borrowUrl).toBe("https://cm.example.com/works/1/borrow");
+    expect(book.availability?.status).toBe("available");
+    expect(book.copies).toEqual({ total: 5, available: 3 });
+    expect(book.holds).toEqual({ total: 0, position: undefined });
+  });
+
+  test("parses a reservable book", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.reservablePublication),
+      CATALOG_URL
+    );
+    expect(book.status).toBe("reservable");
+    if (book.status !== "reservable") throw new Error();
+    expect(book.reserveUrl).toBe("https://cm.example.com/works/2/borrow");
+    expect(book.copies).toEqual({ total: 2, available: 0 });
+  });
+
+  test("parses an on-hold (ready) book", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.onHoldPublication),
+      CATALOG_URL
+    );
+    expect(book.status).toBe("on-hold");
+    if (book.status !== "on-hold") throw new Error();
+    expect(book.borrowUrl).toBe("https://cm.example.com/works/3/borrow");
+    expect(book.availability?.until).toBe("2026-02-01T00:00:00+00:00");
+  });
+
+  test("parses a reserved book with hold position and revoke url", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.reservedPublication),
+      CATALOG_URL
+    );
+    expect(book.status).toBe("reserved");
+    if (book.status !== "reserved") throw new Error();
+    expect(book.revokeUrl).toBe("https://cm.example.com/loans/4/revoke");
+    expect(book.holds).toEqual({ total: 10, position: 3 });
+  });
+
+  test("parses an open access book as fulfillable", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.openAccessPublication),
+      CATALOG_URL
+    );
+    expect(book.status).toBe("fulfillable");
+    if (book.status !== "fulfillable") throw new Error();
+    expect(book.fulfillmentLinks).toEqual([
+      {
+        url: "https://cm.example.com/works/5/open-access.epub",
+        contentType: "application/epub+zip",
+        supportLevel: "show"
+      }
+    ]);
+    expect(book.revokeUrl).toBeNull();
+  });
+
+  test("parses an active loan as fulfillable with indirection", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.loanedPublication),
+      CATALOG_URL
+    );
+    expect(book.status).toBe("fulfillable");
+    if (book.status !== "fulfillable") throw new Error();
+    expect(book.fulfillmentLinks).toEqual([
+      {
+        url: "https://cm.example.com/loans/6/fulfill",
+        contentType: "application/epub+zip",
+        indirectionType: "application/vnd.adobe.adept+xml",
+        supportLevel: "redirect-and-show"
+      }
+    ]);
+    expect(book.revokeUrl).toBe("https://cm.example.com/loans/6/revoke");
+  });
+
+  test("parses a streaming loan, normalizing OPDS entry indirection", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.streamingLoanedPublication),
+      CATALOG_URL
+    );
+    expect(book).toMatchObject({
+      status: "fulfillable",
+      fulfillmentLinks: [
+        {
+          url: "https://cm.example.com/loans/10/fulfill",
+          contentType:
+            'text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"',
+          indirectionType:
+            "application/atom+xml;type=entry;profile=opds-catalog",
+          supportLevel: "show"
+        }
+      ],
+      revokeUrl: "https://cm.example.com/loans/10/revoke"
+    });
+  });
+
+  test("treats a streaming-only format behind a borrow link as supported", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.streamingBorrowablePublication),
+      CATALOG_URL
+    );
+    expect(book).toMatchObject({
+      status: "borrowable",
+      borrowUrl: "https://cm.example.com/works/11/borrow"
+    });
+  });
+
+  test("parses an audiobook loan", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.audiobookPublication),
+      CATALOG_URL
+    );
+    expect(book.format).toBe("Audiobook");
+    expect(book.duration).toBe("2 hours, 7 minutes");
+    expect(book.narrators).toEqual(["First Narrator", "Second Narrator"]);
+    expect(book.status).toBe("fulfillable");
+    if (book.status !== "fulfillable") throw new Error();
+    expect(book.fulfillmentLinks[0]).toEqual({
+      url: "https://cm.example.com/loans/7/fulfill",
+      contentType: "application/audiobook+json",
+      indirectionType: undefined,
+      supportLevel: "redirect"
+    });
+  });
+
+  test("parses a book with only unsupported formats as unsupported", () => {
+    const book = publicationToBook(
+      asPublication(fixtures.unsupportedPublication),
+      CATALOG_URL
+    );
+    expect(book.status).toBe("unsupported");
+  });
+
+  test("accepts LanguageMap objects for title and contributor names", () => {
+    const book = publicationToBook(
+      asPublication({
+        metadata: {
+          identifier: "urn:x:1",
+          title: { en: "English Title" },
+          author: [{ name: { fr: "Auteur" } }, "Plain Author"]
+        }
+      }),
+      CATALOG_URL
+    );
+    expect(book.title).toBe("English Title");
+    expect(book.authors).toEqual(["Auteur", "Plain Author"]);
+  });
+
+  test("parses series name and position", () => {
+    const book = publicationToBook(
+      asPublication({
+        metadata: {
+          identifier: "urn:x:2",
+          title: "In a Series",
+          belongsTo: { series: { name: "Test Series", position: 2 } }
+        }
+      }),
+      CATALOG_URL
+    );
+    expect(book.series).toEqual({ name: "Test Series", position: 2 });
+  });
+
+  test("falls back to the feed url when there is no alternate link", () => {
+    const book = publicationToBook(
+      asPublication({ metadata: { identifier: "urn:x:3", title: "No Links" } }),
+      CATALOG_URL
+    );
+    expect(book.url).toBe(CATALOG_URL);
+  });
+
+  test("does not throw on malformed leaf values", () => {
+    const book = publicationToBook(
+      {
+        metadata: {
+          title: 42,
+          author: { name: { weird: 7 } },
+          belongsTo: "nope"
+        },
+        links: "not-an-array",
+        images: [{ href: 12 }]
+      } as unknown as Opds2Publication,
+      CATALOG_URL
+    );
+    expect(book.title).toBe("");
+    expect(book.status).toBe("unsupported");
+    expect(book.url).toBe(CATALOG_URL);
+  });
+});
+
+describe("feedToCollection", () => {
+  test("parses a grouped feed into lanes", () => {
+    const collection = feedToCollection(
+      asFeed(fixtures.groupedFeed),
+      CATALOG_URL
+    );
+    expect(collection.title).toBe("Test Library");
+    expect(collection.books).toHaveLength(0);
+    expect(collection.lanes).toHaveLength(2);
+    expect(collection.lanes[0]).toMatchObject({
+      title: "Popular Books",
+      url: "https://cm.example.com/groups/popular"
+    });
+    expect(collection.lanes[0].books).toHaveLength(2);
+    expect(collection.lanes[1].books).toHaveLength(2);
+    expect(collection.searchDataUrl).toBe("https://cm.example.com/search");
+  });
+
+  test("parses a paginated feed with facets", () => {
+    const collection = feedToCollection(
+      asFeed(fixtures.paginatedFeed),
+      "https://cm.example.com/catalog/all"
+    );
+    expect(collection.title).toBe("All Books");
+    expect(collection.id).toBe("https://cm.example.com/catalog/all");
+    expect(collection.books).toHaveLength(2);
+    expect(collection.nextPageUrl).toBe(
+      "https://cm.example.com/catalog/all?page=2"
+    );
+    expect(collection.parentLink?.url).toBe(CATALOG_URL);
+    expect(collection.catalogRootLink?.url).toBe(CATALOG_URL);
+    expect(collection.facetGroups).toEqual([
+      {
+        label: "Sort by",
+        facets: [
+          {
+            label: "Author",
+            href: "https://cm.example.com/catalog/all?order=author",
+            active: true
+          },
+          {
+            label: "Title",
+            href: "https://cm.example.com/catalog/all?order=title",
+            active: false
+          }
+        ]
+      }
+    ]);
+  });
+
+  test("parses a navigation feed", () => {
+    const collection = feedToCollection(
+      asFeed(fixtures.navigationFeed),
+      CATALOG_URL
+    );
+    expect(collection.books).toHaveLength(0);
+    expect(collection.navigationLinks).toEqual([
+      {
+        id: "https://cm.example.com/catalog/fiction",
+        text: "Fiction",
+        url: "https://cm.example.com/catalog/fiction"
+      },
+      {
+        id: "https://cm.example.com/catalog/nonfiction",
+        text: "Nonfiction",
+        url: "https://cm.example.com/catalog/nonfiction"
+      }
+    ]);
+  });
+
+  test("drops publications with no acquisition links", () => {
+    const collection = feedToCollection(
+      asFeed(fixtures.loansFeed),
+      "https://cm.example.com/loans"
+    );
+    expect(collection.books.map(book => book.title)).toEqual([
+      "Loaned Book",
+      "Reserved Book",
+      "Audiobook on Loan"
+    ]);
+  });
+
+  test("dedupes books by id", () => {
+    const collection = feedToCollection(
+      asFeed({
+        metadata: { title: "Dupes" },
+        links: [],
+        publications: [
+          fixtures.borrowablePublication,
+          fixtures.borrowablePublication
+        ]
+      }),
+      CATALOG_URL
+    );
+    expect(collection.books).toHaveLength(1);
+  });
+
+  test("resolves relative urls against the feed url", () => {
+    const collection = feedToCollection(
+      asFeed({
+        metadata: { title: "Relative" },
+        links: [{ href: "/next-page", rel: "next" }],
+        publications: []
+      }),
+      CATALOG_URL
+    );
+    expect(collection.nextPageUrl).toBe("https://cm.example.com/next-page");
+  });
+
+  test("maps an empty document to an empty collection", () => {
+    const collection = feedToCollection({} as Opds2Feed, CATALOG_URL);
+    expect(collection).toMatchObject({
+      id: CATALOG_URL,
+      url: CATALOG_URL,
+      title: "",
+      lanes: [],
+      books: [],
+      navigationLinks: [],
+      facetGroups: [],
+      searchDataUrl: null
+    });
+  });
+});

--- a/src/dataflow/opds2/parse.ts
+++ b/src/dataflow/opds2/parse.ts
@@ -1,0 +1,658 @@
+import {
+  AnyBook,
+  Book,
+  BookAvailability,
+  BookFormat,
+  CollectionData,
+  FacetGroupData,
+  FulfillmentLink,
+  LaneData,
+  LinkData,
+  OPDS1,
+  OPDS2
+} from "interfaces";
+import {
+  AcquisitionLinkRel,
+  BorrowLinkRel,
+  EPUB_MEDIA_TYPES,
+  HTMLMediaType,
+  PdfMediaType,
+  PreviewRel,
+  RevokeLinkRel,
+  ShelfLinkRel,
+  TrackOpenBookRel
+} from "types/opds1";
+import {
+  Opds2Feed,
+  Opds2Group,
+  Opds2Link,
+  Opds2Publication
+} from "validation/opds2Catalog";
+import { fixMimeType, formatDate } from "dataflow/opds1/parse";
+import { getAppSupportLevel } from "utils/fulfill";
+import { formatDuration } from "utils/duration";
+import DOMPurify from "dompurify";
+
+/**
+ * Parses an OPDS 2 catalog feed or publication from a Palace Circulation
+ * Manager into a Collection or Book, producing the same internal model as
+ * dataflow/opds1/parse.ts does for Atom feeds.
+ *
+ * Because validation of the incoming JSON is lenient (see
+ * validation/opds2Catalog.ts), every leaf value here is treated defensively:
+ * helpers accept unknown-ish data and return undefined rather than throwing
+ * when a field has an unexpected shape.
+ */
+
+const OpenAccessLinkRel = "http://opds-spec.org/acquisition/open-access";
+const ThumbnailImageRel = "http://opds-spec.org/image/thumbnail";
+const AudiobookType = "http://schema.org/Audiobook";
+
+/**
+ * Utils
+ */
+
+function isDefined<T>(value: T | undefined | null): value is T {
+  return value !== undefined && value !== null;
+}
+
+// Lenient validation means array-typed fields may not actually be arrays at
+// runtime; treat anything else as empty.
+function asArray<T>(value: T[] | undefined): T[] {
+  return Array.isArray(value) ? value.filter(isDefined) : [];
+}
+
+function resolveOptional(base: string, href: unknown): string | undefined {
+  if (typeof href !== "string" || href.length === 0) return undefined;
+  try {
+    return new URL(href, base).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function rels(link: Opds2Link): string[] {
+  if (typeof link.rel === "string") return [link.rel];
+  if (Array.isArray(link.rel)) {
+    return link.rel.filter((r): r is string => typeof r === "string");
+  }
+  return [];
+}
+
+function hasRel(link: Opds2Link, rel: string): boolean {
+  return rels(link).includes(rel);
+}
+
+// Matches every acquisition rel (generic, open-access, borrow, buy, sample,
+// subscribe), mirroring how opds-feed-parser classifies acquisition links.
+function isAcquisitionLink(link: Opds2Link): boolean {
+  return rels(link).some(rel => rel.startsWith(AcquisitionLinkRel));
+}
+
+function linkHref(link: Opds2Link | undefined): string | undefined {
+  return typeof link?.href === "string" && link.href.length > 0
+    ? link.href
+    : undefined;
+}
+
+/**
+ * A LanguageMap serializes as either a plain string or a
+ * {language: translation} object; take the first translation in the
+ * latter case.
+ */
+function languageMapToString(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value !== null && typeof value === "object") {
+    return Object.values(value).find((v): v is string => typeof v === "string");
+  }
+  return undefined;
+}
+
+/**
+ * Contributor-role and subject fields serialize as a string, an object, or
+ * an array of either. Normalizes to an array of the object-or-string
+ * entries.
+ */
+function toEntryArray(field: unknown): (string | Record<string, unknown>)[] {
+  if (field === null || field === undefined) return [];
+  const arr = Array.isArray(field) ? field : [field];
+  return arr.filter(
+    (entry): entry is string | Record<string, unknown> =>
+      typeof entry === "string" ||
+      (entry !== null && typeof entry === "object" && !Array.isArray(entry))
+  );
+}
+
+function entryName(
+  entry: string | Record<string, unknown>
+): string | undefined {
+  if (typeof entry === "string") return entry;
+  return languageMapToString(entry.name);
+}
+
+function contributorNames(field: unknown): string[] {
+  return toEntryArray(field).map(entryName).filter(isDefined);
+}
+
+/**
+ * Acquisition format parsing
+ */
+
+type AcquisitionObject = { type?: string; child?: unknown[] };
+
+function asAcquisitionObject(value: unknown): AcquisitionObject | undefined {
+  if (value === null || typeof value !== "object") return undefined;
+  const { type, child } = value as Record<string, unknown>;
+  return {
+    type: typeof type === "string" ? type : undefined,
+    child: Array.isArray(child) ? child : undefined
+  };
+}
+
+function indirectAcquisitions(link: Opds2Link): AcquisitionObject[] {
+  const raw = link.properties?.indirectAcquisition;
+  if (!Array.isArray(raw)) return [];
+  return raw.map(asAcquisitionObject).filter(isDefined);
+}
+
+type ParsedFormat = {
+  contentType: OPDS1.AnyBookMediaType;
+  indirectionType?: OPDS1.IndirectAcquisitionType;
+};
+
+/**
+ * The CM types the OPDS-entry indirection level of an acquisition chain as
+ * the OPDS 2 publication media type in OPDS 2 feeds (it is the same semantic
+ * link type the OPDS 1 serializer writes as the Atom entry type). The
+ * internal model, the media-support configuration, and the entry-indirection
+ * fulfillment flow all identify that level by the OPDS 1 entry media type,
+ * so acquisition types are normalized to it.
+ */
+function normalizeAcquisitionType(
+  type: string | undefined
+): string | undefined {
+  return type === OPDS2.PublicationMediaType ? OPDS1.OPDSEntryMediaType : type;
+}
+
+/**
+ * The content type of an acquisition is the innermost nested type, and the
+ * wrapping type becomes the indirection type — the same rule
+ * dataflow/opds1/parse.ts applies to opds:indirectAcquisition elements.
+ */
+function parseEntryFormat(entry: AcquisitionObject): ParsedFormat {
+  const childType = asAcquisitionObject(entry.child?.[0])?.type;
+  const entryType = normalizeAcquisitionType(entry.type);
+  const contentType = (childType ?? entryType) as OPDS1.AnyBookMediaType;
+  const indirectionType = childType
+    ? (entryType as OPDS1.IndirectAcquisitionType)
+    : undefined;
+  return { contentType, indirectionType };
+}
+
+function parseLinkFormat(link: Opds2Link): ParsedFormat {
+  const indirectType = indirectAcquisitions(link)[0]?.type;
+  const linkType = normalizeAcquisitionType(link.type);
+  const contentType = (indirectType ?? linkType) as OPDS1.AnyBookMediaType;
+  const indirectionType = indirectType
+    ? (linkType as OPDS1.IndirectAcquisitionType)
+    : undefined;
+  return { contentType, indirectionType };
+}
+
+function buildFulfillmentLink(feedUrl: string) {
+  return (link: Opds2Link): FulfillmentLink | undefined => {
+    const url = resolveOptional(feedUrl, link.href);
+    if (!url) return undefined;
+    const { contentType, indirectionType } = parseLinkFormat(link);
+    return {
+      url,
+      contentType,
+      indirectionType: indirectionType && fixMimeType(indirectionType),
+      supportLevel: getAppSupportLevel(contentType, indirectionType)
+    };
+  };
+}
+
+/**
+ * Finds the first borrow link with at least one format the app supports,
+ * matching getBorrowLink in dataflow/opds1/parse.ts.
+ */
+function getBorrowLink(links: Opds2Link[]): Opds2Link | null {
+  return (
+    links.find(link => {
+      if (!hasRel(link, BorrowLinkRel) || !linkHref(link)) return false;
+      return indirectAcquisitions(link).some(entry => {
+        const { contentType, indirectionType } = parseEntryFormat(entry);
+        return (
+          getAppSupportLevel(contentType, indirectionType) !== "unsupported"
+        );
+      });
+    }) ?? null
+  );
+}
+
+/**
+ * Preserves the ordering rule from dataflow/opds1/parse.ts: the first
+ * linearized acquisition type wins when inferring an eBook format.
+ */
+function inferEBookFormat(
+  fulfillmentLinks: FulfillmentLink[],
+  borrowLink: Opds2Link | null
+): BookFormat | undefined {
+  let mimeType: string | undefined;
+
+  if (fulfillmentLinks.length > 0) {
+    mimeType = fulfillmentLinks[0]?.contentType;
+  } else if (borrowLink) {
+    mimeType = indirectAcquisitions(borrowLink)
+      .flatMap(entry =>
+        entry.child && entry.child.length > 0
+          ? entry.child.map(child => asAcquisitionObject(child)?.type)
+          : [entry.type]
+      )
+      .filter(isDefined)
+      .at(0);
+  }
+
+  if (mimeType) {
+    if (EPUB_MEDIA_TYPES.includes(mimeType as OPDS1.AnyBookMediaType)) {
+      return "ePub";
+    }
+    if (mimeType === PdfMediaType) {
+      return "PDF";
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Converters
+ */
+
+export function publicationToBook(
+  pub: Opds2Publication,
+  feedUrl: string
+): AnyBook {
+  const metadata: NonNullable<Opds2Publication["metadata"]> =
+    pub.metadata ?? {};
+  const links = asArray(pub.links);
+  const images = asArray(pub.images);
+
+  const title = languageMapToString(metadata.title) ?? "";
+  const subtitle = languageMapToString(metadata.subtitle);
+
+  const authors = contributorNames(metadata.author);
+  const narratorNames = contributorNames(metadata.narrator);
+  const narrators = narratorNames.length > 0 ? narratorNames : undefined;
+  const contributors = contributorNames(metadata.contributor);
+
+  const thumbnailLink =
+    images.find(link => hasRel(link, ThumbnailImageRel)) ?? images[0];
+  const imageUrl = resolveOptional(feedUrl, thumbnailLink?.href);
+
+  const detailLink =
+    links.find(
+      link =>
+        hasRel(link, "alternate") && link.type === OPDS2.PublicationMediaType
+    ) ??
+    links.find(link => hasRel(link, "alternate")) ??
+    links.find(link => hasRel(link, "self"));
+  const detailUrl = resolveOptional(feedUrl, detailLink?.href) ?? feedUrl;
+
+  const subjects = toEntryArray(metadata.subject);
+  const isAudienceSubject = (entry: string | Record<string, unknown>) =>
+    typeof entry !== "string" && entry.scheme === "http://schema.org/audience";
+  const audience = subjects.filter(isAudienceSubject).map(entryName)[0];
+  const categories = subjects
+    .filter(entry => !isAudienceSubject(entry))
+    .map(entryName)
+    .filter(isDefined);
+
+  const acquisitionLinks = links.filter(isAcquisitionLink);
+  const borrowLink = getBorrowLink(acquisitionLinks);
+
+  const availability = borrowLink?.properties?.availability;
+  // The OPDS 2 availability state defaults to "available" when omitted, so a
+  // borrow link without explicit availability is treated as available.
+  const borrowState: BookAvailability | undefined = borrowLink
+    ? (availability?.state ?? "available")
+    : undefined;
+
+  const holds = borrowLink?.properties?.holds;
+  const copies = borrowLink?.properties?.copies;
+
+  const openAccessLinks: FulfillmentLink[] = acquisitionLinks
+    .filter(link => hasRel(link, OpenAccessLinkRel))
+    .map(link => {
+      const url = resolveOptional(feedUrl, link.href);
+      if (!url) return undefined;
+      const { contentType, indirectionType } = parseLinkFormat(link);
+      return {
+        url,
+        contentType: link.type as OPDS1.AnyBookMediaType,
+        supportLevel: getAppSupportLevel(contentType, indirectionType)
+      };
+    })
+    .filter(isDefined);
+
+  const fulfillmentLinks = acquisitionLinks
+    .filter(link => hasRel(link, AcquisitionLinkRel))
+    .map(buildFulfillmentLink(feedUrl))
+    .filter(isDefined);
+
+  const supportedFulfillmentLinks = fulfillmentLinks.filter(
+    link => link.supportLevel !== "unsupported"
+  );
+
+  const format =
+    metadata["@type"] === AudiobookType
+      ? "Audiobook"
+      : inferEBookFormat(fulfillmentLinks, borrowLink);
+
+  const revokeUrl =
+    linkHref(links.find(link => hasRel(link, RevokeLinkRel))) ?? null;
+
+  const trackOpenBookUrl =
+    linkHref(links.find(link => hasRel(link, TrackOpenBookRel))) ?? null;
+
+  const previewUrl =
+    linkHref(
+      links.find(
+        link => hasRel(link, PreviewRel) && link.type === HTMLMediaType
+      )
+    ) ?? null;
+
+  const relatedUrl =
+    linkHref(links.find(link => hasRel(link, "related"))) ?? null;
+
+  const seriesEntry = toEntryArray(metadata.belongsTo?.series)[0];
+  const seriesName = seriesEntry ? entryName(seriesEntry) : undefined;
+  const seriesPosition =
+    typeof seriesEntry === "object" && typeof seriesEntry.position === "number"
+      ? seriesEntry.position
+      : undefined;
+  // The CM's OPDS 2 output carries no series feed link, so series.url is
+  // always undefined here (unlike the OPDS 1 parser).
+  const series = seriesName
+    ? { name: seriesName, position: seriesPosition }
+    : undefined;
+
+  const language =
+    typeof metadata.language === "string"
+      ? metadata.language
+      : Array.isArray(metadata.language)
+        ? metadata.language.find(l => typeof l === "string")
+        : undefined;
+
+  const book: Book = {
+    id:
+      typeof metadata.identifier === "string" ? metadata.identifier : detailUrl,
+    title,
+    subtitle,
+    authors,
+    contributors,
+    narrators,
+    summary:
+      typeof metadata.description === "string"
+        ? DOMPurify.sanitize(metadata.description)
+        : undefined,
+    imageUrl,
+    availability: {
+      since: availability?.since,
+      until: availability?.until,
+      // borrowState is undefined when there is no borrow link, matching the
+      // OPDS 1 parser; our internal type is stricter, hence the cast.
+      status: borrowState as BookAvailability
+    },
+    holds:
+      holds && typeof holds.total === "number"
+        ? { total: holds.total, position: holds.position }
+        : undefined,
+    copies:
+      copies &&
+      typeof copies.total === "number" &&
+      typeof copies.available === "number"
+        ? { total: copies.total, available: copies.available }
+        : undefined,
+    audience,
+    categories,
+    publisher: contributorNames(metadata.publisher)[0],
+    published:
+      typeof metadata.published === "string"
+        ? formatDate(metadata.published)
+        : undefined,
+    language,
+    duration:
+      typeof metadata.duration === "number"
+        ? formatDuration(metadata.duration)
+        : undefined,
+    format,
+    series,
+    url: detailUrl,
+    relatedUrl,
+    trackOpenBookUrl,
+    previewUrl,
+    raw: pub
+  };
+
+  // The status cascade below mirrors entryToBook in dataflow/opds1/parse.ts
+  // exactly, including its ordering.
+
+  // It's fulfillable
+  if (
+    supportedFulfillmentLinks.length > 0 ||
+    (!borrowLink && openAccessLinks.length > 0)
+  ) {
+    return {
+      ...book,
+      status: "fulfillable",
+      fulfillmentLinks: [...supportedFulfillmentLinks, ...openAccessLinks],
+      revokeUrl
+    };
+  }
+
+  // it's a reserved book
+  if (borrowState === "reserved") {
+    return {
+      ...book,
+      status: "reserved",
+      revokeUrl
+    };
+  }
+
+  const borrowUrl = borrowLink ? linkHref(borrowLink) : undefined;
+
+  // it's a reservable book
+  if (borrowUrl && borrowState === "unavailable") {
+    return {
+      ...book,
+      status: "reservable",
+      reserveUrl: borrowUrl
+    };
+  }
+
+  // it is on hold and ready to borrow
+  if (borrowUrl && borrowState === "ready") {
+    return {
+      ...book,
+      status: "on-hold",
+      borrowUrl
+    };
+  }
+
+  // it's a borrowable book
+  if (borrowUrl && borrowState === "available") {
+    return {
+      ...book,
+      status: "borrowable",
+      borrowUrl
+    };
+  }
+
+  // it is unsupported
+  return {
+    ...book,
+    status: "unsupported"
+  };
+}
+
+function linkToLinkData(
+  feedUrl: string,
+  link: Opds2Link | undefined
+): LinkData | null {
+  if (!link) return null;
+  const url = resolveOptional(feedUrl, link.href);
+  if (!url) return null;
+  return {
+    url,
+    text: typeof link.title === "string" ? link.title : undefined,
+    type: rels(link)[0]
+  };
+}
+
+function navigationToLinkData(
+  feedUrl: string,
+  navigation: Opds2Link[]
+): LinkData[] {
+  return navigation
+    .map((link): LinkData | null => {
+      const url = resolveOptional(feedUrl, link.href);
+      if (!url) return null;
+      return {
+        id: linkHref(link),
+        text: typeof link.title === "string" ? link.title : undefined,
+        url
+      };
+    })
+    .filter((link): link is LinkData => link !== null);
+}
+
+function dedupeBooks(books: AnyBook[]): AnyBook[] {
+  const bookIndex = books.reduce((index, book) => {
+    index.set(book.id, book);
+    return index;
+  }, new Map<string, AnyBook>());
+  return Array.from(bookIndex.values());
+}
+
+/**
+ * Maps publications to books, dropping publications with no acquisition
+ * links at all (e.g. a loan for a title removed from the collection): they
+ * cannot be fulfilled by any application. This mirrors the entry
+ * classification in the OPDS 1 feedToCollection.
+ */
+function publicationsToBooks(
+  publications: Opds2Publication[],
+  feedUrl: string
+): AnyBook[] {
+  return publications
+    .filter(pub => asArray(pub.links).some(isAcquisitionLink))
+    .map(pub => publicationToBook(pub, feedUrl));
+}
+
+function groupToLane(group: Opds2Group, feedUrl: string): LaneData | null {
+  const publications = group.publications ?? [];
+  if (publications.length === 0) return null;
+  const selfLink = asArray(group.links).find(link => hasRel(link, "self"));
+  return {
+    title: languageMapToString(group.metadata?.title) ?? "",
+    url: resolveOptional(feedUrl, selfLink?.href) ?? feedUrl,
+    books: dedupeBooks(publicationsToBooks(publications, feedUrl))
+  };
+}
+
+export function feedToCollection(
+  feed: Opds2Feed,
+  feedUrl: string
+): CollectionData {
+  const feedLinks = asArray(feed.links);
+  const selfUrl = resolveOptional(
+    feedUrl,
+    feedLinks.find(link => hasRel(link, "self"))?.href
+  );
+
+  const books = dedupeBooks(
+    publicationsToBooks(feed.publications ?? [], feedUrl)
+  );
+
+  const lanes: LaneData[] = [];
+  const navigationLinks = navigationToLinkData(
+    feedUrl,
+    asArray(feed.navigation)
+  );
+  for (const group of asArray(feed.groups)) {
+    const lane = groupToLane(group, feedUrl);
+    if (lane) {
+      lanes.push(lane);
+    } else {
+      // A navigation-only group (allowed by the OPDS 2 model, though the CM
+      // does not currently emit one) folds into the top-level navigation.
+      navigationLinks.push(
+        ...navigationToLinkData(feedUrl, asArray(group.navigation))
+      );
+    }
+  }
+
+  const facetGroups: FacetGroupData[] = asArray(feed.facets)
+    .map(facet => {
+      const facetLinks = asArray(facet.links);
+      return {
+        label: languageMapToString(facet.metadata?.title) ?? "",
+        facets: facetLinks
+          .map(link => {
+            const href = resolveOptional(feedUrl, link.href);
+            if (!href) return null;
+            return {
+              label: typeof link.title === "string" ? link.title : "",
+              href,
+              // The CM marks the currently applied facet with rel="self".
+              active: hasRel(link, "self")
+            };
+          })
+          .filter(isDefined)
+      };
+    })
+    .filter(group => group.facets.length > 0);
+
+  const nextPageUrl = resolveOptional(
+    feedUrl,
+    feedLinks.find(link => hasRel(link, "next"))?.href
+  );
+
+  const catalogRootLink = linkToLinkData(
+    feedUrl,
+    feedLinks.find(link => hasRel(link, OPDS1.CatalogRootRel))
+  );
+  const parentLink = linkToLinkData(
+    feedUrl,
+    feedLinks.find(link => hasRel(link, "up"))
+  );
+
+  const shelfUrl = linkHref(feedLinks.find(link => hasRel(link, ShelfLinkRel)));
+
+  // The CM includes an OpenSearch description link in OPDS 2 feeds too, so
+  // the existing OpenSearch-based search flow keeps working unchanged.
+  const searchDataUrl =
+    linkHref(feedLinks.find(link => hasRel(link, "search"))) ?? null;
+
+  const links = feedLinks
+    .map(link => linkToLinkData(feedUrl, link))
+    .filter((link): link is LinkData => link !== null);
+
+  return {
+    id: selfUrl ?? feedUrl,
+    url: feedUrl,
+    title: languageMapToString(feed.metadata?.title) ?? "",
+    lanes,
+    books,
+    navigationLinks,
+    facetGroups,
+    nextPageUrl,
+    catalogRootLink,
+    parentLink,
+    shelfUrl,
+    links,
+    searchDataUrl,
+    raw: feed
+  };
+}

--- a/src/dataflow/opds2/parse.ts
+++ b/src/dataflow/opds2/parse.ts
@@ -28,7 +28,7 @@ import {
   Opds2Link,
   Opds2Publication
 } from "validation/opds2Catalog";
-import { fixMimeType, formatDate } from "dataflow/opds1/parse";
+import { dedupeBooks, fixMimeType, formatDate } from "dataflow/opds1/parse";
 import { getAppSupportLevel } from "utils/fulfill";
 import { formatDuration } from "utils/duration";
 import DOMPurify from "dompurify";
@@ -180,7 +180,9 @@ function normalizeAcquisitionType(
  * dataflow/opds1/parse.ts applies to opds:indirectAcquisition elements.
  */
 function parseEntryFormat(entry: AcquisitionObject): ParsedFormat {
-  const childType = asAcquisitionObject(entry.child?.[0])?.type;
+  const childType = normalizeAcquisitionType(
+    asAcquisitionObject(entry.child?.[0])?.type
+  );
   const entryType = normalizeAcquisitionType(entry.type);
   const contentType = (childType ?? entryType) as OPDS1.AnyBookMediaType;
   const indirectionType = childType
@@ -190,7 +192,9 @@ function parseEntryFormat(entry: AcquisitionObject): ParsedFormat {
 }
 
 function parseLinkFormat(link: Opds2Link): ParsedFormat {
-  const indirectType = indirectAcquisitions(link)[0]?.type;
+  const indirectType = normalizeAcquisitionType(
+    indirectAcquisitions(link)[0]?.type
+  );
   const linkType = normalizeAcquisitionType(link.type);
   const contentType = (indirectType ?? linkType) as OPDS1.AnyBookMediaType;
   const indirectionType = indirectType
@@ -321,18 +325,13 @@ export function publicationToBook(
   const holds = borrowLink?.properties?.holds;
   const copies = borrowLink?.properties?.copies;
 
+  // Built the same way as fulfillmentLinks below: an open-access link can
+  // carry its own indirection chain (e.g. a bearer-token-wrapped format for
+  // anonymous direct fulfillment), so contentType, indirectionType, and
+  // supportLevel must all come from the same parsed chain.
   const openAccessLinks: FulfillmentLink[] = acquisitionLinks
     .filter(link => hasRel(link, OpenAccessLinkRel))
-    .map(link => {
-      const url = resolveOptional(feedUrl, link.href);
-      if (!url) return undefined;
-      const { contentType, indirectionType } = parseLinkFormat(link);
-      return {
-        url,
-        contentType: link.type as OPDS1.AnyBookMediaType,
-        supportLevel: getAppSupportLevel(contentType, indirectionType)
-      };
-    })
+    .map(buildFulfillmentLink(feedUrl))
     .filter(isDefined);
 
   const fulfillmentLinks = acquisitionLinks
@@ -525,14 +524,6 @@ function navigationToLinkData(
       };
     })
     .filter((link): link is LinkData => link !== null);
-}
-
-function dedupeBooks(books: AnyBook[]): AnyBook[] {
-  const bookIndex = books.reduce((index, book) => {
-    index.set(book.id, book);
-    return index;
-  }, new Map<string, AnyBook>());
-  return Array.from(bookIndex.values());
 }
 
 /**

--- a/src/dataflow/opds2/parse.ts
+++ b/src/dataflow/opds2/parse.ts
@@ -540,7 +540,7 @@ function publicationsToBooks(
 }
 
 function groupToLane(group: Opds2Group, feedUrl: string): LaneData | null {
-  const publications = group.publications ?? [];
+  const publications = asArray(group.publications);
   if (publications.length === 0) return null;
   const selfLink = asArray(group.links).find(link => hasRel(link, "self"));
   return {
@@ -561,7 +561,7 @@ export function feedToCollection(
   );
 
   const books = dedupeBooks(
-    publicationsToBooks(feed.publications ?? [], feedUrl)
+    publicationsToBooks(asArray(feed.publications), feedUrl)
   );
 
   const lanes: LaneData[] = [];

--- a/src/dataflow/opds2/parse.ts
+++ b/src/dataflow/opds2/parse.ts
@@ -16,10 +16,12 @@ import {
   BorrowLinkRel,
   EPUB_MEDIA_TYPES,
   HTMLMediaType,
+  OpenAccessLinkRel,
   PdfMediaType,
   PreviewRel,
   RevokeLinkRel,
   ShelfLinkRel,
+  ThumbnailImageRel,
   TrackOpenBookRel
 } from "types/opds1";
 import {
@@ -43,10 +45,6 @@ import DOMPurify from "dompurify";
  * helpers accept unknown-ish data and return undefined rather than throwing
  * when a field has an unexpected shape.
  */
-
-const OpenAccessLinkRel = "http://opds-spec.org/acquisition/open-access";
-const ThumbnailImageRel = "http://opds-spec.org/image/thumbnail";
-const AudiobookType = "http://schema.org/Audiobook";
 
 /**
  * Utils
@@ -344,7 +342,7 @@ export function publicationToBook(
   );
 
   const format =
-    metadata["@type"] === AudiobookType
+    metadata["@type"] === OPDS2.AudiobookMetadataType
       ? "Audiobook"
       : inferEBookFormat(fulfillmentLinks, borrowLink);
 

--- a/src/hooks/useBorrow.ts
+++ b/src/hooks/useBorrow.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { fetchBook } from "dataflow/opds1/fetch";
+import { fetchBook } from "dataflow/catalog";
 import useUser from "components/context/UserContext";
 import useLibraryContext from "components/context/LibraryContext";
 import useError from "hooks/useError";

--- a/src/hooks/useCollection.ts
+++ b/src/hooks/useCollection.ts
@@ -1,6 +1,6 @@
 import useLibraryContext from "components/context/LibraryContext";
 import useUser from "components/context/UserContext";
-import { fetchCollection } from "dataflow/opds1/fetch";
+import { fetchCollection } from "dataflow/catalog";
 import extractParam from "dataflow/utils";
 import ApplicationError from "errors";
 import { CollectionData } from "interfaces";

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -46,6 +46,9 @@ export async function register() {
     const { getLibraries } = await import("server/libraryRegistry");
     try {
       const appConfig = await getAppConfig();
+      console.log(
+        `OPDS 2 negotiation is ${appConfig.enableOpds2 ? "enabled" : "disabled"} (PALACE_CPW_FEATURE_OPDS2).`
+      );
       /*
        * Pre-warm the registry cache before any requests are served.
        * getLibraries() sets pendingRefreshes synchronously before its first

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,6 +24,7 @@ export type AppConfig = {
   authenticationDocuments: AuthDocConfig | null;
   companionApp: "simplye" | "openebooks";
   showMedium: boolean;
+  enableOpds2: boolean;
   bugsnagApiKey: string | null;
   openebooks: OpenEbooksConfig | null;
   /** Reserved item landing path segments. See constants/app.ts. */

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,6 +10,7 @@ import { BreadcrumbProvider } from "components/context/BreadcrumbContext";
 import AppConfigContext from "components/context/AppConfigContext";
 import { initBugsnag } from "analytics/bugsnag";
 import { setMediaSupportConfig } from "utils/fulfill";
+import { setOpds2Enabled } from "dataflow/catalog";
 import type { AppConfig } from "interfaces";
 import FALLBACK_APP_CONFIG from "config/fallbackAppConfig";
 
@@ -36,13 +37,15 @@ const MyApp = (props: AppProps) => {
   //    the first commit, so the Bugsnag boundary would never be set for the initial render,
   //    silently dropping error coverage on first load.
   //
-  // 2. setMediaSupportConfig must run during SSR: useEffect is skipped on the server, so
-  //    moving it there would leave _mediaSupport as {} for every SSR pass, causing all books
-  //    to appear unsupported on first load.
+  // 2. setMediaSupportConfig and setOpds2Enabled must run during SSR: useEffect is skipped
+  //    on the server, so moving them there would leave _mediaSupport as {} for every SSR
+  //    pass, causing all books to appear unsupported on first load.
   //
-  // Both functions are idempotent, so repeated calls from concurrent-mode retries are safe.
+  // All of these functions are idempotent, so repeated calls from concurrent-mode retries
+  // are safe.
   initBugsnag(appConfig);
   setMediaSupportConfig(appConfig.mediaSupport);
+  setOpds2Enabled(appConfig.enableOpds2);
 
   return (
     <AppConfigContext.Provider value={appConfig}>

--- a/src/server/__tests__/appConfig.test.ts
+++ b/src/server/__tests__/appConfig.test.ts
@@ -376,6 +376,46 @@ describe("config parsing", () => {
     });
   });
 
+  // --- enableOpds2 ---
+
+  describe("enableOpds2", () => {
+    it("defaults to false when PALACE_CPW_FEATURE_OPDS2 is not set", async () => {
+      delete process.env.PALACE_CPW_FEATURE_OPDS2;
+      expect((await load(MINIMAL_YAML)).enableOpds2).toBe(false);
+    });
+
+    it("defaults to false when PALACE_CPW_FEATURE_OPDS2 is empty", async () => {
+      process.env.PALACE_CPW_FEATURE_OPDS2 = "";
+      expect((await load(MINIMAL_YAML)).enableOpds2).toBe(false);
+    });
+
+    it.each(["true", "TRUE", "1", "yes", "on", "t", "y"])(
+      "is true when PALACE_CPW_FEATURE_OPDS2 is %s",
+      async value => {
+        process.env.PALACE_CPW_FEATURE_OPDS2 = value;
+        expect((await load(MINIMAL_YAML)).enableOpds2).toBe(true);
+      }
+    );
+
+    it.each(["false", "FALSE", "0", "no", "off", "f", "n"])(
+      "is false when PALACE_CPW_FEATURE_OPDS2 is %s",
+      async value => {
+        process.env.PALACE_CPW_FEATURE_OPDS2 = value;
+        expect((await load(MINIMAL_YAML)).enableOpds2).toBe(false);
+      }
+    );
+
+    it("rejects unrecognized PALACE_CPW_FEATURE_OPDS2 values", async () => {
+      process.env.PALACE_CPW_FEATURE_OPDS2 = "yes please";
+      await expect(load(MINIMAL_YAML)).rejects.toThrow(AppSetupError);
+    });
+
+    it("ignores an enable_opds2 key in the config file", async () => {
+      delete process.env.PALACE_CPW_FEATURE_OPDS2;
+      expect((await load(`enable_opds2: true`)).enableOpds2).toBe(false);
+    });
+  });
+
   // --- openebooks ---
 
   describe("openebooks", () => {

--- a/src/server/__tests__/appConfig.test.ts
+++ b/src/server/__tests__/appConfig.test.ts
@@ -384,26 +384,13 @@ describe("config parsing", () => {
       expect((await load(MINIMAL_YAML)).enableOpds2).toBe(false);
     });
 
-    it("defaults to false when PALACE_CPW_FEATURE_OPDS2 is empty", async () => {
-      process.env.PALACE_CPW_FEATURE_OPDS2 = "";
-      expect((await load(MINIMAL_YAML)).enableOpds2).toBe(false);
+    it.each([
+      ["true", true],
+      ["false", false]
+    ])("is %s when PALACE_CPW_FEATURE_OPDS2 is %s", async (raw, expected) => {
+      process.env.PALACE_CPW_FEATURE_OPDS2 = raw;
+      expect((await load(MINIMAL_YAML)).enableOpds2).toBe(expected);
     });
-
-    it.each(["true", "TRUE", "1", "yes", "on", "t", "y"])(
-      "is true when PALACE_CPW_FEATURE_OPDS2 is %s",
-      async value => {
-        process.env.PALACE_CPW_FEATURE_OPDS2 = value;
-        expect((await load(MINIMAL_YAML)).enableOpds2).toBe(true);
-      }
-    );
-
-    it.each(["false", "FALSE", "0", "no", "off", "f", "n"])(
-      "is false when PALACE_CPW_FEATURE_OPDS2 is %s",
-      async value => {
-        process.env.PALACE_CPW_FEATURE_OPDS2 = value;
-        expect((await load(MINIMAL_YAML)).enableOpds2).toBe(false);
-      }
-    );
 
     it("rejects unrecognized PALACE_CPW_FEATURE_OPDS2 values", async () => {
       process.env.PALACE_CPW_FEATURE_OPDS2 = "yes please";

--- a/src/server/__tests__/instrumentation.test.ts
+++ b/src/server/__tests__/instrumentation.test.ts
@@ -156,6 +156,36 @@ describe("register", () => {
 });
 
 // ---------------------------------------------------------------------------
+// OPDS 2 startup logging
+// ---------------------------------------------------------------------------
+
+describe("OPDS 2 startup logging", () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    process.env.NEXT_RUNTIME = "nodejs";
+    mockGetLibraries.mockResolvedValue({});
+  });
+
+  it("logs that OPDS 2 negotiation is enabled when enableOpds2 is true", async () => {
+    mockGetAppConfig.mockResolvedValue({ enableOpds2: true });
+    await register();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("OPDS 2 negotiation is enabled")
+    );
+  });
+
+  it("logs that OPDS 2 negotiation is disabled when enableOpds2 is false", async () => {
+    mockGetAppConfig.mockResolvedValue({ enableOpds2: false });
+    await register();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("OPDS 2 negotiation is disabled")
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // HTTP request logging
 // ---------------------------------------------------------------------------
 
@@ -168,6 +198,9 @@ describe("HTTP request logging", () => {
     mockGetAppConfig.mockResolvedValue({});
     mockGetLibraries.mockResolvedValue({});
     await register();
+    // register() itself logs an OPDS 2 startup message; clear that so tests
+    // only observe logging caused by their own request/response actions.
+    logSpy.mockClear();
   });
 
   afterEach(() => {

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -34,6 +34,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     bugsnagApiKey: null,
     companionApp: "simplye",
     showMedium: true,
+    enableOpds2: false,
     openebooks: null,
     mediaSupport: {},
     authenticationDocuments: null,

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -54,6 +54,29 @@ const RawConfigSchema = type({
 const DEFAULT_MIN_INTERVAL = 60;
 const DEFAULT_MAX_INTERVAL = 300;
 
+/**
+ * Feature flags are environment variables, following the circulation
+ * manager's PALACE_<app>_FEATURE_<flag> convention.
+ */
+export const OPDS2_FEATURE_FLAG_ENV = "PALACE_CPW_FEATURE_OPDS2";
+
+// The boolean spellings pydantic accepts, so flags behave the same here as
+// in the circulation manager.
+const TRUE_ENV_VALUES = new Set(["1", "on", "t", "true", "y", "yes"]);
+const FALSE_ENV_VALUES = new Set(["0", "off", "f", "false", "n", "no"]);
+
+function parseBooleanEnv(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return defaultValue;
+  const value = raw.trim().toLowerCase();
+  if (TRUE_ENV_VALUES.has(value)) return true;
+  if (FALSE_ENV_VALUES.has(value)) return false;
+  throw new AppSetupError(
+    `Environment variable ${name} has unrecognized boolean value "${raw}". ` +
+      `Valid values: ${[...TRUE_ENV_VALUES, ...FALSE_ENV_VALUES].join(", ")}.`
+  );
+}
+
 const VALID_MEDIA_SUPPORT_VALUES = new Set<string>([
   "show",
   "redirect",
@@ -375,6 +398,7 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     bugsnagApiKey: process.env.BUGSNAG_API_KEY ?? null,
     companionApp,
     showMedium,
+    enableOpds2: parseBooleanEnv(OPDS2_FEATURE_FLAG_ENV, false),
     openebooks,
     itemLandingSlugs
   };

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -19,6 +19,7 @@ import type {
 } from "interfaces";
 import { AppSetupError } from "errors";
 import { isHttpUrl } from "utils/parse";
+import { parseBoolean } from "utils/envParse";
 import { DEFAULT_REGISTRY_FETCH_TIMEOUT } from "constants/registry";
 import { DEFAULT_ITEM_LANDING_SLUG, RESERVED_NEXT_SLUGS } from "constants/app";
 
@@ -59,23 +60,6 @@ const DEFAULT_MAX_INTERVAL = 300;
  * manager's PALACE_<app>_FEATURE_<flag> convention.
  */
 export const OPDS2_FEATURE_FLAG_ENV = "PALACE_CPW_FEATURE_OPDS2";
-
-// The boolean spellings pydantic accepts, so flags behave the same here as
-// in the circulation manager.
-const TRUE_ENV_VALUES = new Set(["1", "on", "t", "true", "y", "yes"]);
-const FALSE_ENV_VALUES = new Set(["0", "off", "f", "false", "n", "no"]);
-
-function parseBooleanEnv(name: string, defaultValue: boolean): boolean {
-  const raw = process.env[name];
-  if (raw === undefined || raw.trim() === "") return defaultValue;
-  const value = raw.trim().toLowerCase();
-  if (TRUE_ENV_VALUES.has(value)) return true;
-  if (FALSE_ENV_VALUES.has(value)) return false;
-  throw new AppSetupError(
-    `Environment variable ${name} has unrecognized boolean value "${raw}". ` +
-      `Valid values: ${[...TRUE_ENV_VALUES, ...FALSE_ENV_VALUES].join(", ")}.`
-  );
-}
 
 const VALID_MEDIA_SUPPORT_VALUES = new Set<string>([
   "show",
@@ -398,7 +382,7 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     bugsnagApiKey: process.env.BUGSNAG_API_KEY ?? null,
     companionApp,
     showMedium,
-    enableOpds2: parseBooleanEnv(OPDS2_FEATURE_FLAG_ENV, false),
+    enableOpds2: parseBoolean(OPDS2_FEATURE_FLAG_ENV, false),
     openebooks,
     itemLandingSlugs
   };

--- a/src/test-utils/fixtures/config.ts
+++ b/src/test-utils/fixtures/config.ts
@@ -6,6 +6,7 @@ export const config: AppConfig = {
   bugsnagApiKey: null,
   companionApp: "simplye",
   showMedium: true,
+  enableOpds2: false,
   openebooks: null,
   authenticationDocuments: null,
   itemLandingSlugs: [DEFAULT_ITEM_LANDING_SLUG],

--- a/src/test-utils/fixtures/index.ts
+++ b/src/test-utils/fixtures/index.ts
@@ -6,6 +6,7 @@ export * from "./server";
 export * from "./auth-document";
 export * from "./parsed-opds-feed";
 export * as opds2 from "./opds2";
+export * as opds2Catalog from "./opds2-catalog";
 export * from "./collection";
 export * from "./user";
 export * from "./config";

--- a/src/test-utils/fixtures/opds2-catalog.ts
+++ b/src/test-utils/fixtures/opds2-catalog.ts
@@ -1,0 +1,400 @@
+/**
+ * OPDS 2 catalog fixtures shaped like the output of the Palace Circulation
+ * Manager's OPDS2Serializer (palace-opds Pydantic models serialized with
+ * by_alias / exclude_unset / exclude_none, so optional fields are simply
+ * absent).
+ */
+
+export const CATALOG_URL = "https://cm.example.com/catalog";
+
+const OPDS2_FEED_TYPE = "application/opds+json";
+const OPDS2_PUBLICATION_TYPE = "application/opds-publication+json";
+const ADOBE_TYPE = "application/vnd.adobe.adept+xml";
+const EPUB_TYPE = "application/epub+zip";
+const STREAMING_TYPE =
+  'text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"';
+
+function makePublication(
+  id: number,
+  title: string,
+  acquisitionLinks: unknown[],
+  metadataOverrides: Record<string, unknown> = {}
+) {
+  return {
+    metadata: {
+      "@type": "http://schema.org/Book",
+      identifier: `urn:isbn:978000000000${id}`,
+      title,
+      language: "en",
+      modified: "2026-01-02T03:04:05+00:00",
+      published: "2020-06-15",
+      description: "A <b>very</b> good book.",
+      author: { name: "Test Author" },
+      publisher: { name: "Test Publisher" },
+      subject: [
+        {
+          name: "Adult",
+          scheme: "http://schema.org/audience",
+          code: "Adult"
+        },
+        {
+          name: "Fiction",
+          scheme: "http://librarysimplified.org/terms/fiction/"
+        }
+      ],
+      ...metadataOverrides
+    },
+    images: [
+      {
+        href: `https://cm.example.com/covers/${id}-thumb.png`,
+        rel: "http://opds-spec.org/image/thumbnail",
+        type: "image/png"
+      },
+      {
+        href: `https://cm.example.com/covers/${id}.png`,
+        rel: "http://opds-spec.org/image",
+        type: "image/png"
+      }
+    ],
+    links: [
+      {
+        href: `https://cm.example.com/works/${id}`,
+        rel: "alternate",
+        type: OPDS2_PUBLICATION_TYPE
+      },
+      ...acquisitionLinks
+    ]
+  };
+}
+
+export const borrowablePublication = makePublication(1, "Borrowable Book", [
+  {
+    href: "https://cm.example.com/works/1/borrow",
+    rel: "http://opds-spec.org/acquisition/borrow",
+    type: OPDS2_PUBLICATION_TYPE,
+    properties: {
+      availability: { state: "available" },
+      holds: { total: 0 },
+      copies: { total: 5, available: 3 },
+      indirectAcquisition: [{ type: ADOBE_TYPE, child: [{ type: EPUB_TYPE }] }]
+    }
+  }
+]);
+
+export const reservablePublication = makePublication(2, "Reservable Book", [
+  {
+    href: "https://cm.example.com/works/2/borrow",
+    rel: "http://opds-spec.org/acquisition/borrow",
+    type: OPDS2_PUBLICATION_TYPE,
+    properties: {
+      availability: { state: "unavailable" },
+      holds: { total: 4 },
+      copies: { total: 2, available: 0 },
+      indirectAcquisition: [{ type: ADOBE_TYPE, child: [{ type: EPUB_TYPE }] }]
+    }
+  }
+]);
+
+export const onHoldPublication = makePublication(3, "Ready Hold Book", [
+  {
+    href: "https://cm.example.com/works/3/borrow",
+    rel: "http://opds-spec.org/acquisition/borrow",
+    type: OPDS2_PUBLICATION_TYPE,
+    properties: {
+      availability: {
+        state: "ready",
+        until: "2026-02-01T00:00:00+00:00"
+      },
+      indirectAcquisition: [{ type: ADOBE_TYPE, child: [{ type: EPUB_TYPE }] }]
+    }
+  },
+  {
+    href: "https://cm.example.com/loans/3/revoke",
+    rel: "http://librarysimplified.org/terms/rel/revoke"
+  }
+]);
+
+export const reservedPublication = makePublication(4, "Reserved Book", [
+  {
+    href: "https://cm.example.com/works/4/borrow",
+    rel: "http://opds-spec.org/acquisition/borrow",
+    type: OPDS2_PUBLICATION_TYPE,
+    properties: {
+      availability: { state: "reserved" },
+      holds: { total: 10, position: 3 },
+      actions: { cancellable: true },
+      indirectAcquisition: [{ type: ADOBE_TYPE, child: [{ type: EPUB_TYPE }] }]
+    }
+  },
+  {
+    href: "https://cm.example.com/loans/4/revoke",
+    rel: "http://librarysimplified.org/terms/rel/revoke"
+  }
+]);
+
+export const openAccessPublication = makePublication(5, "Open Access Book", [
+  {
+    href: "https://cm.example.com/works/5/open-access.epub",
+    rel: "http://opds-spec.org/acquisition/open-access",
+    type: EPUB_TYPE
+  }
+]);
+
+/** An active loan: fulfill link with an indirect chain, plus a revoke link. */
+export const loanedPublication = makePublication(6, "Loaned Book", [
+  {
+    href: "https://cm.example.com/loans/6/fulfill",
+    rel: "http://opds-spec.org/acquisition",
+    type: ADOBE_TYPE,
+    properties: {
+      availability: {
+        state: "ready",
+        since: "2026-01-01T00:00:00+00:00",
+        until: "2026-01-22T00:00:00+00:00"
+      },
+      indirectAcquisition: [{ type: EPUB_TYPE }]
+    }
+  },
+  {
+    href: "https://cm.example.com/loans/6/revoke",
+    rel: "http://librarysimplified.org/terms/rel/revoke"
+  }
+]);
+
+/**
+ * An active "Read Online" loan: a streaming link behind OPDS entry
+ * indirection, which the CM types as the OPDS 2 publication media type.
+ */
+export const streamingLoanedPublication = makePublication(
+  10,
+  "Streaming Loaned Book",
+  [
+    {
+      href: "https://cm.example.com/loans/10/fulfill",
+      rel: "http://opds-spec.org/acquisition",
+      type: OPDS2_PUBLICATION_TYPE,
+      properties: {
+        availability: { state: "ready" },
+        indirectAcquisition: [{ type: STREAMING_TYPE }]
+      }
+    },
+    {
+      href: "https://cm.example.com/loans/10/revoke",
+      rel: "http://librarysimplified.org/terms/rel/revoke"
+    }
+  ]
+);
+
+/** A borrowable book whose only format is streaming. */
+export const streamingBorrowablePublication = makePublication(
+  11,
+  "Streaming Borrowable Book",
+  [
+    {
+      href: "https://cm.example.com/works/11/borrow",
+      rel: "http://opds-spec.org/acquisition/borrow",
+      type: OPDS2_PUBLICATION_TYPE,
+      properties: {
+        availability: { state: "available" },
+        indirectAcquisition: [
+          { type: OPDS2_PUBLICATION_TYPE, child: [{ type: STREAMING_TYPE }] }
+        ]
+      }
+    }
+  ]
+);
+
+/** An audiobook loan with Palace time-tracking metadata. */
+export const audiobookPublication = makePublication(
+  7,
+  "Audiobook on Loan",
+  [
+    {
+      href: "https://cm.example.com/loans/7/fulfill",
+      rel: "http://opds-spec.org/acquisition",
+      type: "application/audiobook+json"
+    },
+    {
+      href: "https://cm.example.com/loans/7/revoke",
+      rel: "http://librarysimplified.org/terms/rel/revoke"
+    }
+  ],
+  {
+    "@type": "http://schema.org/Audiobook",
+    duration: 7620,
+    narrator: [{ name: "First Narrator" }, "Second Narrator"],
+    "http://palaceproject.io/terms/timeTracking": true
+  }
+);
+
+/** Only unsupported formats behind the borrow link. */
+export const unsupportedPublication = makePublication(8, "Unsupported Book", [
+  {
+    href: "https://cm.example.com/works/8/borrow",
+    rel: "http://opds-spec.org/acquisition/borrow",
+    type: OPDS2_PUBLICATION_TYPE,
+    properties: {
+      availability: { state: "available" },
+      indirectAcquisition: [
+        {
+          type: "application/x-unknown-drm",
+          child: [{ type: "application/x-unknown-format" }]
+        }
+      ]
+    }
+  }
+]);
+
+/** A loan for a title removed from the collection: no acquisition links. */
+export const noAcquisitionPublication = {
+  metadata: {
+    "@type": "http://schema.org/Book",
+    identifier: "urn:isbn:9780000000009",
+    title: "Removed Book"
+  },
+  images: [],
+  links: [
+    {
+      href: "https://cm.example.com/works/9",
+      rel: "alternate",
+      type: OPDS2_PUBLICATION_TYPE
+    }
+  ]
+};
+
+const searchLink = {
+  href: "https://cm.example.com/search",
+  rel: "search",
+  type: "application/opensearchdescription+xml"
+};
+
+const startLink = {
+  href: CATALOG_URL,
+  rel: "start",
+  type: OPDS2_FEED_TYPE
+};
+
+export const groupedFeed = {
+  metadata: { title: "Test Library" },
+  links: [
+    { href: CATALOG_URL, rel: "self", type: OPDS2_FEED_TYPE },
+    searchLink,
+    startLink
+  ],
+  groups: [
+    {
+      metadata: { title: "Popular Books" },
+      links: [
+        {
+          href: "https://cm.example.com/groups/popular",
+          rel: "self",
+          type: OPDS2_FEED_TYPE
+        }
+      ],
+      publications: [borrowablePublication, reservablePublication]
+    },
+    {
+      metadata: { title: "New Arrivals" },
+      links: [
+        {
+          href: "https://cm.example.com/groups/new",
+          rel: "self",
+          type: OPDS2_FEED_TYPE
+        }
+      ],
+      publications: [openAccessPublication, borrowablePublication]
+    }
+  ]
+};
+
+export const paginatedFeed = {
+  metadata: {
+    title: "All Books",
+    itemsPerPage: 2,
+    currentPage: 1,
+    numberOfItems: 4
+  },
+  links: [
+    {
+      href: "https://cm.example.com/catalog/all",
+      rel: "self",
+      type: OPDS2_FEED_TYPE
+    },
+    {
+      href: "https://cm.example.com/catalog/all?page=2",
+      rel: "next",
+      type: OPDS2_FEED_TYPE
+    },
+    { href: CATALOG_URL, rel: "up", type: OPDS2_FEED_TYPE },
+    searchLink,
+    startLink
+  ],
+  publications: [borrowablePublication, openAccessPublication],
+  facets: [
+    {
+      metadata: {
+        title: "Sort by",
+        "@type": "http://palaceproject.io/terms/rel/sort"
+      },
+      links: [
+        {
+          href: "https://cm.example.com/catalog/all?order=author",
+          title: "Author",
+          rel: "self",
+          type: OPDS2_FEED_TYPE,
+          properties: {
+            "http://palaceproject.io/terms/properties/default": true
+          }
+        },
+        {
+          href: "https://cm.example.com/catalog/all?order=title",
+          title: "Title",
+          type: OPDS2_FEED_TYPE
+        }
+      ]
+    }
+  ]
+};
+
+export const navigationFeed = {
+  metadata: { title: "Browse" },
+  links: [
+    {
+      href: "https://cm.example.com/catalog/nav",
+      rel: "self",
+      type: OPDS2_FEED_TYPE
+    },
+    searchLink
+  ],
+  navigation: [
+    {
+      href: "https://cm.example.com/catalog/fiction",
+      title: "Fiction",
+      rel: "subsection",
+      type: OPDS2_FEED_TYPE
+    },
+    {
+      href: "https://cm.example.com/catalog/nonfiction",
+      title: "Nonfiction",
+      rel: "subsection",
+      type: OPDS2_FEED_TYPE
+    }
+  ]
+};
+
+export const loansFeed = {
+  metadata: { title: "Loans and Holds" },
+  links: [
+    {
+      href: "https://cm.example.com/loans",
+      rel: "self",
+      type: OPDS2_FEED_TYPE
+    }
+  ],
+  publications: [
+    loanedPublication,
+    reservedPublication,
+    audiobookPublication,
+    noAcquisitionPublication
+  ]
+};

--- a/src/test-utils/fixtures/opds2-catalog.ts
+++ b/src/test-utils/fixtures/opds2-catalog.ts
@@ -13,6 +13,8 @@ const ADOBE_TYPE = "application/vnd.adobe.adept+xml";
 const EPUB_TYPE = "application/epub+zip";
 const STREAMING_TYPE =
   'text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"';
+const BEARER_TOKEN_TYPE = "application/vnd.librarysimplified.bearer-token+json";
+const PDF_TYPE = "application/pdf";
 
 function makePublication(
   id: number,
@@ -139,6 +141,26 @@ export const openAccessPublication = makePublication(5, "Open Access Book", [
     type: EPUB_TYPE
   }
 ]);
+
+/**
+ * An anonymous direct-fulfillment link: the CM serializes these with the
+ * open-access rel even though the format is wrapped in indirection (here, a
+ * bearer-token exchange), per LibraryAnnotator.acquisition_links.
+ */
+export const openAccessBearerTokenPublication = makePublication(
+  12,
+  "Open Access Bearer Token Book",
+  [
+    {
+      href: "https://cm.example.com/works/12/fulfill",
+      rel: "http://opds-spec.org/acquisition/open-access",
+      type: BEARER_TOKEN_TYPE,
+      properties: {
+        indirectAcquisition: [{ type: PDF_TYPE }]
+      }
+    }
+  ]
+);
 
 /** An active loan: fulfill link with an indirect chain, plus a revoke link. */
 export const loanedPublication = makePublication(6, "Loaned Book", [

--- a/src/test-utils/index.tsx
+++ b/src/test-utils/index.tsx
@@ -18,7 +18,7 @@ import mockConfig from "test-utils/mockConfig";
 import mockCookie from "../../__mocks__/js-cookie";
 import track from "analytics/track";
 import "react-intersection-observer/test-utils";
-import "test-utils/mockToDateString";
+import { mockToDateString } from "test-utils/mockToDateString";
 import AppConfigContext from "components/context/AppConfigContext";
 import { getCurrentTestConfig } from "test-utils/mockConfig";
 
@@ -28,6 +28,7 @@ expect.addSnapshotSerializer(serializer);
 // standard config mock
 beforeEach(() => {
   mockConfig();
+  mockToDateString();
   localStorage.clear();
   mockCookie.reset();
 });

--- a/src/test-utils/mockConfig.ts
+++ b/src/test-utils/mockConfig.ts
@@ -1,6 +1,7 @@
 import { AppConfig } from "interfaces";
 import { fixtures } from "test-utils";
 import { setMediaSupportConfig } from "utils/fulfill";
+import { setOpds2Enabled } from "dataflow/catalog";
 
 let _currentTestConfig: AppConfig = fixtures.config;
 
@@ -10,9 +11,10 @@ export function getCurrentTestConfig(): AppConfig {
 }
 
 /**
- * Sets the active app config for the current test. Updates the media support
- * singleton (used by parse/fulfill utilities) and the shared config used by
- * the render() test wrapper. Call in beforeEach or at the top of a test.
+ * Sets the active app config for the current test. Updates the config-driven
+ * singletons (media support and OPDS 2 negotiation, as _app.tsx does at
+ * startup) and the shared config used by the render() test wrapper. Call in
+ * beforeEach or at the top of a test.
  */
 export default function mockConfig(custom?: Partial<AppConfig>) {
   const config: AppConfig = {
@@ -21,5 +23,6 @@ export default function mockConfig(custom?: Partial<AppConfig>) {
   };
   _currentTestConfig = config;
   setMediaSupportConfig(config.mediaSupport);
+  setOpds2Enabled(config.enableOpds2);
   return config;
 }

--- a/src/test-utils/mockToDateString.ts
+++ b/src/test-utils/mockToDateString.ts
@@ -1,10 +1,13 @@
 import { jest } from "@jest/globals";
 /**
- * This file mocks Date.prototype.toDateString so that it just returns a
- * stub string. This makes code using that function testable across timezones
- * since we can't reliably set the timezone of a node process to something specific.
+ * Mocks Date.prototype.toDateString so tests are timezone-independent.
+ * Called in the global beforeEach so it is re-applied after each test's
+ * restoreMocks cleanup.
  */
 export const MOCK_DATE_STRING = "mock-date-string";
-export const toDateStringSpy = jest
-  .spyOn(Date.prototype, "toDateString")
-  .mockImplementation(() => MOCK_DATE_STRING);
+
+export function mockToDateString(): void {
+  jest
+    .spyOn(Date.prototype, "toDateString")
+    .mockImplementation(() => MOCK_DATE_STRING);
+}

--- a/src/types/opds1.ts
+++ b/src/types/opds1.ts
@@ -13,8 +13,10 @@
 export const SelfRel = "self";
 export const AuthDocLinkRelation = "http://opds-spec.org/auth/document";
 export const AcquisitionLinkRel = "http://opds-spec.org/acquisition";
+export const OpenAccessLinkRel = "http://opds-spec.org/acquisition/open-access";
 export const BorrowLinkRel = "http://opds-spec.org/acquisition/borrow";
 export const RevokeLinkRel = "http://librarysimplified.org/terms/rel/revoke";
+export const ThumbnailImageRel = "http://opds-spec.org/image/thumbnail";
 export const TrackOpenBookRel =
   "http://librarysimplified.org/terms/rel/analytics/open-book";
 export const PreviewRel = "preview";

--- a/src/types/opds2.ts
+++ b/src/types/opds2.ts
@@ -111,6 +111,10 @@ export const PublicationMediaType = "application/opds-publication+json";
 export const AuthDocumentMediaType =
   "application/vnd.opds.authentication.v1.0+json";
 
+// Values of a Circulation Manager publication's metadata["@type"].
+export const AudiobookMetadataType = "http://schema.org/Audiobook";
+export const EBookMetadataType = "http://schema.org/Book";
+
 export type AnyMediaType =
   | typeof BaseDocumentMediaType
   | typeof AuthDocumentMediaType

--- a/src/types/opds2.ts
+++ b/src/types/opds2.ts
@@ -20,6 +20,18 @@ export type {
   RegistryFeed as LibraryRegistryFeed
 } from "validation/registryFeed";
 
+// Schema-derived types for Circulation Manager OPDS 2 catalogs
+// (validation/opds2Catalog.ts). Named Catalog* to avoid colliding with the
+// hand-written structural types below.
+export type {
+  Opds2Feed as CatalogFeed,
+  Opds2Publication as CatalogPublication,
+  Opds2Link as CatalogLink,
+  Opds2LinkProperties as CatalogLinkProperties,
+  Opds2Contributor as CatalogContributor,
+  Opds2Availability as CatalogAvailability
+} from "validation/opds2Catalog";
+
 export interface Collection<M extends AnyObject = AnyObject> {
   metadata: M;
   links: Link[];
@@ -95,6 +107,7 @@ export type AnyLinkRelation =
   | "registry";
 
 export const BaseDocumentMediaType = "application/opds+json";
+export const PublicationMediaType = "application/opds-publication+json";
 export const AuthDocumentMediaType =
   "application/vnd.opds.authentication.v1.0+json";
 

--- a/src/utils/__tests__/book.test.ts
+++ b/src/utils/__tests__/book.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "@jest/globals";
 import { AnyBook } from "interfaces";
-import { queueString, bookIsAudiobook } from "utils/book";
+import { queueString, bookIsAudiobook, getMedium } from "utils/book";
 import { makeBorrowableBooks } from "../../test-utils/fixtures/book";
 import { getAuthors } from "../book";
 
@@ -92,5 +92,46 @@ describe("book is audiobook", () => {
     };
 
     expect(bookIsAudiobook(book)).toBe(true);
+  });
+});
+
+describe("getMedium", () => {
+  test("reads OPDS 2 metadata['@type'] for an audiobook", () => {
+    const book: AnyBook = {
+      ...bookFixture,
+      raw: { metadata: { "@type": "http://schema.org/Audiobook" } }
+    };
+
+    expect(getMedium(book)).toBe("http://bib.schema.org/Audiobook");
+  });
+
+  test("reads OPDS 2 metadata['@type'] for an ebook", () => {
+    const book: AnyBook = {
+      ...bookFixture,
+      raw: { metadata: { "@type": "http://schema.org/Book" } }
+    };
+
+    expect(getMedium(book)).toBe("http://schema.org/EBook");
+  });
+
+  test("falls back to the OPDS 1 schema:additionalType attribute", () => {
+    const book: AnyBook = {
+      ...bookFixture,
+      raw: {
+        $: {
+          "schema:additionalType": {
+            value: "http://bib.schema.org/Audiobook"
+          }
+        }
+      }
+    };
+
+    expect(getMedium(book)).toBe("http://bib.schema.org/Audiobook");
+  });
+
+  test("returns an empty string when no medium can be determined", () => {
+    const book: AnyBook = { ...bookFixture, raw: {} };
+
+    expect(getMedium(book)).toBe("");
   });
 });

--- a/src/utils/__tests__/envParse.test.ts
+++ b/src/utils/__tests__/envParse.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { parseBoolean } from "../envParse";
+import { AppSetupError } from "errors";
+
+const ENV_VAR = "TEST_PARSE_BOOLEAN_FLAG";
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+describe("parseBoolean", () => {
+  it("returns the default when the variable is unset", () => {
+    delete process.env[ENV_VAR];
+    expect(parseBoolean(ENV_VAR, true)).toBe(true);
+    expect(parseBoolean(ENV_VAR, false)).toBe(false);
+  });
+
+  it("returns the default when the variable is empty", () => {
+    process.env[ENV_VAR] = "  ";
+    expect(parseBoolean(ENV_VAR, true)).toBe(true);
+  });
+
+  it.each(["1", "on", "t", "true", "y", "yes", "TRUE", " True "])(
+    "returns true for %s",
+    value => {
+      process.env[ENV_VAR] = value;
+      expect(parseBoolean(ENV_VAR, false)).toBe(true);
+    }
+  );
+
+  it.each(["0", "off", "f", "false", "n", "no", "FALSE", " False "])(
+    "returns false for %s",
+    value => {
+      process.env[ENV_VAR] = value;
+      expect(parseBoolean(ENV_VAR, true)).toBe(false);
+    }
+  );
+
+  it("throws AppSetupError for an unrecognized value", () => {
+    process.env[ENV_VAR] = "yes please";
+    expect(() => parseBoolean(ENV_VAR, false)).toThrow(AppSetupError);
+  });
+});

--- a/src/utils/book.tsx
+++ b/src/utils/book.tsx
@@ -153,6 +153,17 @@ export function getMediumName(book: AnyBook): BookMediumName | "" {
 }
 
 export function getMedium(book: AnyBook): BookMedium | "" {
+  // OPDS 2 publications carry the medium as metadata["@type"], with values
+  // that differ from the Atom schema:additionalType ones; translate to the
+  // internal BookMedium values.
+  const opds2Type = book.raw?.metadata?.["@type"];
+  if (opds2Type === "http://schema.org/Audiobook") {
+    return "http://bib.schema.org/Audiobook";
+  }
+  if (opds2Type === "http://schema.org/Book") {
+    return "http://schema.org/EBook";
+  }
+
   if (!book.raw || !book.raw["$"] || !book.raw["$"]["schema:additionalType"]) {
     return "";
   }

--- a/src/utils/book.tsx
+++ b/src/utils/book.tsx
@@ -6,6 +6,7 @@ import {
   BorrowableBook,
   FulfillableBook,
   OnHoldBook,
+  OPDS2,
   ReservableBook,
   ReservedBook,
   UnsupportedBook
@@ -157,10 +158,10 @@ export function getMedium(book: AnyBook): BookMedium | "" {
   // that differ from the Atom schema:additionalType ones; translate to the
   // internal BookMedium values.
   const opds2Type = book.raw?.metadata?.["@type"];
-  if (opds2Type === "http://schema.org/Audiobook") {
+  if (opds2Type === OPDS2.AudiobookMetadataType) {
     return "http://bib.schema.org/Audiobook";
   }
-  if (opds2Type === "http://schema.org/Book") {
+  if (opds2Type === OPDS2.EBookMetadataType) {
     return "http://schema.org/EBook";
   }
 

--- a/src/utils/envParse.ts
+++ b/src/utils/envParse.ts
@@ -1,0 +1,23 @@
+import { AppSetupError } from "errors";
+
+// The "boolean" values Pydantic accepts in Palace Manager, so flags parsed
+// here behave similarly to their counterparts there.
+const TRUE_ENV_VALUES = new Set(["1", "on", "t", "true", "y", "yes"]);
+const FALSE_ENV_VALUES = new Set(["0", "off", "f", "false", "n", "no"]);
+
+/**
+ * Parses an environment variable as a boolean. An unset or empty variable
+ * returns defaultValue; any other value (trimmed and lowercased) must match
+ * one of the recognized spellings above or an AppSetupError is thrown.
+ */
+export function parseBoolean(name: string, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return defaultValue;
+  const value = raw.trim().toLowerCase();
+  if (TRUE_ENV_VALUES.has(value)) return true;
+  if (FALSE_ENV_VALUES.has(value)) return false;
+  throw new AppSetupError(
+    `Environment variable ${name} has unrecognized boolean value "${raw}". ` +
+      `Valid values: ${[...TRUE_ENV_VALUES, ...FALSE_ENV_VALUES].join(", ")}.`
+  );
+}

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -1,4 +1,5 @@
-import { fetchBearerToken, fetchBook } from "dataflow/opds1/fetch";
+import { fetchBearerToken } from "dataflow/opds1/fetch";
+import { fetchBook } from "dataflow/catalog";
 import ApplicationError from "errors";
 import {
   AnyBook,

--- a/src/validation/__tests__/opds2Catalog.test.ts
+++ b/src/validation/__tests__/opds2Catalog.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { type } from "arktype";
+import {
+  lenientValidate,
+  Opds2FeedSchema,
+  Opds2PublicationSchema,
+  resetOpds2MismatchReports
+} from "validation/opds2Catalog";
+import * as fixtures from "test-utils/fixtures/opds2-catalog";
+import { mockTrackError } from "test-utils";
+
+beforeEach(() => {
+  resetOpds2MismatchReports();
+});
+
+describe("OPDS 2 catalog schemas", () => {
+  test.each([
+    ["grouped feed", fixtures.groupedFeed],
+    ["paginated feed", fixtures.paginatedFeed],
+    ["navigation feed", fixtures.navigationFeed],
+    ["loans feed", fixtures.loansFeed]
+  ])("accepts a realistic CM %s", (_label, feed) => {
+    expect(Opds2FeedSchema(feed)).not.toBeInstanceOf(type.errors);
+  });
+
+  test.each([
+    ["borrowable", fixtures.borrowablePublication],
+    ["reserved", fixtures.reservedPublication],
+    ["loaned", fixtures.loanedPublication],
+    ["audiobook", fixtures.audiobookPublication],
+    ["no acquisition", fixtures.noAcquisitionPublication]
+  ])("accepts a realistic CM %s publication", (_label, publication) => {
+    expect(Opds2PublicationSchema(publication)).not.toBeInstanceOf(type.errors);
+  });
+
+  test("ignores unknown keys so CM extensions pass through", () => {
+    const result = Opds2FeedSchema({
+      metadata: { title: "Extended", "http://example.com/x-extension": 1 },
+      links: [],
+      publications: []
+    });
+    expect(result).not.toBeInstanceOf(type.errors);
+  });
+});
+
+describe("lenientValidate", () => {
+  const drifted = { metadata: { title: 42 } };
+
+  test("returns validated data and does not report on success", () => {
+    const result = lenientValidate(
+      Opds2FeedSchema,
+      fixtures.groupedFeed,
+      "https://cm.example.com/catalog"
+    );
+    expect(result).toEqual(fixtures.groupedFeed);
+    expect(mockTrackError).not.toHaveBeenCalled();
+  });
+
+  test("returns the raw data and reports a warning on mismatch", () => {
+    const result = lenientValidate(
+      Opds2FeedSchema,
+      drifted,
+      "https://cm.example.com/catalog"
+    );
+    expect(result).toBe(drifted);
+    expect(mockTrackError).toHaveBeenCalledTimes(1);
+    const [error, options] = mockTrackError.mock.calls[0];
+    expect(error.message).toContain("OPDS 2 Schema Mismatch");
+    expect(options.severity).toBe("warning");
+    expect(options.metadata["OPDS 2 Validation"].url).toBe(
+      "https://cm.example.com/catalog"
+    );
+    expect(options.metadata["OPDS 2 Validation"].summary).toContain("title");
+  });
+
+  test("dedupes repeat mismatches for the same url path", () => {
+    lenientValidate(Opds2FeedSchema, drifted, "https://cm.example.com/a?p=1");
+    lenientValidate(Opds2FeedSchema, drifted, "https://cm.example.com/a?p=2");
+    expect(mockTrackError).toHaveBeenCalledTimes(1);
+
+    lenientValidate(Opds2FeedSchema, drifted, "https://cm.example.com/b");
+    expect(mockTrackError).toHaveBeenCalledTimes(2);
+  });
+
+  test("resetOpds2MismatchReports clears dedupe state", () => {
+    lenientValidate(Opds2FeedSchema, drifted, "https://cm.example.com/a");
+    resetOpds2MismatchReports();
+    lenientValidate(Opds2FeedSchema, drifted, "https://cm.example.com/a");
+    expect(mockTrackError).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/validation/__tests__/opds2Catalog.test.ts
+++ b/src/validation/__tests__/opds2Catalog.test.ts
@@ -88,4 +88,16 @@ describe("lenientValidate", () => {
     lenientValidate(Opds2FeedSchema, drifted, "https://cm.example.com/a");
     expect(mockTrackError).toHaveBeenCalledTimes(2);
   });
+
+  test("dedupe state clears once the report window elapses", () => {
+    const t0 = Date.now();
+    const dateSpy = jest.spyOn(Date, "now").mockReturnValue(t0);
+
+    lenientValidate(Opds2FeedSchema, drifted, "https://cm.example.com/a");
+    expect(mockTrackError).toHaveBeenCalledTimes(1);
+
+    dateSpy.mockReturnValue(t0 + 61 * 60 * 1000);
+    lenientValidate(Opds2FeedSchema, drifted, "https://cm.example.com/a");
+    expect(mockTrackError).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/validation/opds2Catalog.ts
+++ b/src/validation/opds2Catalog.ts
@@ -1,0 +1,239 @@
+/* eslint-disable camelcase */
+
+/**
+ * ArkType runtime schemas for OPDS 2.0 catalog responses from a Palace
+ * Circulation Manager.
+ *
+ * These schemas are aligned with the Pydantic models in the CM's
+ * `palace-opds` package (opds2.py, rwpm.py, palace.py). The CM serializes
+ * those models with `by_alias, exclude_unset, exclude_none` and drops empty
+ * collections, so nearly every field can be absent on the wire — every key
+ * here is optional. Several fields are unions by design:
+ *
+ * - LanguageMap fields (titles, contributor names) serialize as either a
+ *   plain string or a `{lang: translation}` object.
+ * - Contributor-role fields accept a string, an object, or an array of
+ *   either.
+ * - Link `rel` is a string or an array of strings.
+ *
+ * Validation of these schemas is telemetry-only: `lenientValidate` reports
+ * mismatches to Bugsnag but always returns usable data, so schema drift in
+ * the CM never surfaces as a user-facing error. The OPDS 2 mappers in
+ * dataflow/opds2/parse.ts therefore treat all of this data defensively.
+ */
+
+import { type } from "arktype";
+import track from "analytics/track";
+import ApplicationError from "errors";
+
+// -- Shared scalar shapes -----------------------------------------------------
+
+export const LanguageMapSchema = type("string | Record<string, string>");
+
+// -- Contributors and subjects ------------------------------------------------
+
+export const Opds2ContributorSchema = type({
+  "name?": LanguageMapSchema,
+  "sortAs?": "string",
+  "identifier?": "string",
+  "position?": "number",
+  "role?": "string | string[]",
+  "links?": "unknown[]"
+});
+
+const ContributorEntry = Opds2ContributorSchema.or("string");
+export const ContributorFieldSchema = ContributorEntry.or(
+  ContributorEntry.array()
+);
+
+export const Opds2SubjectSchema = type({
+  "name?": LanguageMapSchema,
+  "sortAs?": "string",
+  "code?": "string",
+  "scheme?": "string",
+  "links?": "unknown[]"
+});
+
+const SubjectEntry = Opds2SubjectSchema.or("string");
+export const SubjectFieldSchema = SubjectEntry.or(SubjectEntry.array());
+
+// -- Links ----------------------------------------------------------------------
+
+export const AvailabilitySchema = type({
+  "state?": "'available' | 'unavailable' | 'reserved' | 'ready'",
+  "since?": "string",
+  "until?": "string"
+});
+
+// Indirect acquisition chains nest recursively via `child`. They are
+// validated shallowly here and walked defensively in the mapper.
+export const AcquisitionObjectSchema = type({
+  "type?": "string",
+  "child?": "unknown[]"
+});
+
+export const Opds2LinkPropertiesSchema = type({
+  "numberOfItems?": "number",
+  "availability?": AvailabilitySchema,
+  "holds?": { "total?": "number", "position?": "number" },
+  "copies?": { "total?": "number", "available?": "number" },
+  "indirectAcquisition?": AcquisitionObjectSchema.array(),
+  "actions?": { "cancellable?": "boolean" },
+  "licensor?": { "vendor?": "string", "clientToken?": "string" },
+  "lcp_hashed_passphrase?": "string",
+  '"http://palaceproject.io/terms/properties/default"?': "boolean"
+});
+
+export const Opds2LinkSchema = type({
+  "href?": "string",
+  "rel?": "string | string[]",
+  "type?": "string",
+  "title?": "string",
+  "templated?": "boolean",
+  "properties?": Opds2LinkPropertiesSchema
+});
+
+// -- Publications -----------------------------------------------------------------
+
+export const Opds2PublicationMetadataSchema = type({
+  "identifier?": "string",
+  '"@type"?': "string",
+  "title?": LanguageMapSchema,
+  "subtitle?": LanguageMapSchema,
+  "sortAs?": "string",
+  "language?": "string | string[]",
+  "modified?": "string",
+  "published?": "string",
+  "description?": "string",
+  "duration?": "number",
+  "numberOfPages?": "number",
+  "abridged?": "boolean",
+  "author?": ContributorFieldSchema,
+  "narrator?": ContributorFieldSchema,
+  "contributor?": ContributorFieldSchema,
+  "publisher?": ContributorFieldSchema,
+  "subject?": SubjectFieldSchema,
+  "belongsTo?": {
+    "series?": ContributorFieldSchema,
+    "collection?": ContributorFieldSchema
+  },
+  "availability?": AvailabilitySchema,
+  '"http://palaceproject.io/terms/timeTracking"?': "boolean"
+});
+
+export const Opds2PublicationSchema = type({
+  "metadata?": Opds2PublicationMetadataSchema,
+  "links?": Opds2LinkSchema.array(),
+  "images?": Opds2LinkSchema.array()
+});
+
+// -- Feed --------------------------------------------------------------------------
+
+export const Opds2FeedMetadataSchema = type({
+  "title?": LanguageMapSchema,
+  '"@type"?': "string",
+  "subtitle?": LanguageMapSchema,
+  "modified?": "string",
+  "description?": "string",
+  "itemsPerPage?": "number",
+  "currentPage?": "number",
+  "numberOfItems?": "number"
+});
+
+export const Opds2FacetSchema = type({
+  "metadata?": Opds2FeedMetadataSchema,
+  "links?": Opds2LinkSchema.array()
+});
+
+export const Opds2GroupSchema = type({
+  "metadata?": Opds2FeedMetadataSchema,
+  "links?": Opds2LinkSchema.array(),
+  "publications?": Opds2PublicationSchema.array(),
+  "navigation?": Opds2LinkSchema.array()
+});
+
+export const Opds2FeedSchema = type({
+  "metadata?": Opds2FeedMetadataSchema,
+  "links?": Opds2LinkSchema.array(),
+  "publications?": Opds2PublicationSchema.array(),
+  "navigation?": Opds2LinkSchema.array(),
+  "facets?": Opds2FacetSchema.array(),
+  "groups?": Opds2GroupSchema.array()
+});
+
+// -- Derived types -------------------------------------------------------------------
+
+export type LanguageMap = typeof LanguageMapSchema.infer;
+export type Opds2Contributor = typeof Opds2ContributorSchema.infer;
+export type ContributorField = typeof ContributorFieldSchema.infer;
+export type Opds2Subject = typeof Opds2SubjectSchema.infer;
+export type SubjectField = typeof SubjectFieldSchema.infer;
+export type Opds2Availability = typeof AvailabilitySchema.infer;
+export type Opds2AcquisitionObject = typeof AcquisitionObjectSchema.infer;
+export type Opds2LinkProperties = typeof Opds2LinkPropertiesSchema.infer;
+export type Opds2Link = typeof Opds2LinkSchema.infer;
+export type Opds2PublicationMetadata =
+  typeof Opds2PublicationMetadataSchema.infer;
+export type Opds2Publication = typeof Opds2PublicationSchema.infer;
+export type Opds2FeedMetadata = typeof Opds2FeedMetadataSchema.infer;
+export type Opds2Facet = typeof Opds2FacetSchema.infer;
+export type Opds2Group = typeof Opds2GroupSchema.infer;
+export type Opds2Feed = typeof Opds2FeedSchema.infer;
+
+// -- Lenient validation ----------------------------------------------------------------
+
+const MAX_REPORTS_PER_SESSION = 50;
+const reportedMismatches = new Set<string>();
+
+/**
+ * Reports an OPDS 2 schema mismatch to Bugsnag at warning severity. Repeat
+ * mismatches for the same URL path and leading finding are suppressed, and
+ * reporting stops entirely past a session cap, so a systematically drifted
+ * server does not flood error tracking.
+ */
+export function reportOpds2SchemaMismatch(url: string, summary: string): void {
+  const key = `${url.split("?")[0]}|${summary.split("\n")[0]}`;
+  if (
+    reportedMismatches.has(key) ||
+    reportedMismatches.size >= MAX_REPORTS_PER_SESSION
+  ) {
+    return;
+  }
+  reportedMismatches.add(key);
+  track.error(
+    new ApplicationError({
+      title: "OPDS 2 Schema Mismatch",
+      detail: `The OPDS 2 document at ${url} did not match the expected schema.`
+    }),
+    {
+      severity: "warning",
+      metadata: {
+        "OPDS 2 Validation": { url, summary: summary.slice(0, 3000) }
+      }
+    }
+  );
+}
+
+/** Clears mismatch dedupe state. Intended for use in tests only. */
+export function resetOpds2MismatchReports(): void {
+  reportedMismatches.clear();
+}
+
+/**
+ * Validates an OPDS 2 document for telemetry only. On mismatch, the raw data
+ * is returned as-is (cast to the schema type) so parsing can proceed
+ * best-effort; downstream mappers must not rely on validation having
+ * succeeded.
+ */
+export function lenientValidate<T>(
+  schema: (data: unknown) => T | type.errors,
+  data: unknown,
+  url: string
+): T {
+  const result = schema(data);
+  if (result instanceof type.errors) {
+    reportOpds2SchemaMismatch(url, result.summary);
+    return data as T;
+  }
+  return result;
+}

--- a/src/validation/opds2Catalog.ts
+++ b/src/validation/opds2Catalog.ts
@@ -182,20 +182,38 @@ export type Opds2Feed = typeof Opds2FeedSchema.infer;
 
 // -- Lenient validation ----------------------------------------------------------------
 
-const MAX_REPORTS_PER_SESSION = 50;
+const MAX_REPORTS_PER_WINDOW = 50;
+const REPORT_WINDOW_MS = 60 * 60 * 1000;
 const reportedMismatches = new Set<string>();
+let reportWindowStart = Date.now();
+
+/**
+ * Error report throttling: a single budget shared across every OPDS server
+ * this process talks to, reset on a fixed time window. Prevents the dedupe
+ * cap from silencing reports permanently, but a systemic issue on one server
+ * can still crowd out reports from others within the same window.
+ *
+ * Note: This is a placeholder until we figure out something better.
+ */
+function resetReportWindowIfExpired(): void {
+  if (Date.now() - reportWindowStart >= REPORT_WINDOW_MS) {
+    reportedMismatches.clear();
+    reportWindowStart = Date.now();
+  }
+}
 
 /**
  * Reports an OPDS 2 schema mismatch to Bugsnag at warning severity. Repeat
- * mismatches for the same URL path and leading finding are suppressed, and
- * reporting stops entirely past a session cap, so a systematically drifted
- * server does not flood error tracking.
+ * mismatches for the same URL path and main finding are suppressed, and
+ * reporting stops past a per-window cap, so a broken server does not flood
+ * error tracking.
  */
 export function reportOpds2SchemaMismatch(url: string, summary: string): void {
+  resetReportWindowIfExpired();
   const key = `${url.split("?")[0]}|${summary.split("\n")[0]}`;
   if (
     reportedMismatches.has(key) ||
-    reportedMismatches.size >= MAX_REPORTS_PER_SESSION
+    reportedMismatches.size >= MAX_REPORTS_PER_WINDOW
   ) {
     return;
   }
@@ -217,6 +235,7 @@ export function reportOpds2SchemaMismatch(url: string, summary: string): void {
 /** Clears mismatch dedupe state. Intended for use in tests only. */
 export function resetOpds2MismatchReports(): void {
   reportedMismatches.clear();
+  reportWindowStart = Date.now();
 }
 
 /**

--- a/tests/pages/api/libraries.test.ts
+++ b/tests/pages/api/libraries.test.ts
@@ -42,6 +42,7 @@ const VALID_APP_CONFIG: AppConfig = {
   bugsnagApiKey: null,
   companionApp: "simplye",
   showMedium: true,
+  enableOpds2: false,
   openebooks: null,
   mediaSupport: {},
   authenticationDocuments: null,


### PR DESCRIPTION
## Description

Adds OPDS 2 (JSON) support as a format-agnostic alternative to the existing OPDS 1.x (Atom/XML) catalog client, gated behind a feature flag.
- New format-agnostic fetch layer (`dataflow/catalog.ts`) negotiates OPDS 2 via an `Accept` header and dispatches to an OPDS 2 or OPDS 1.x parser based on the response's `Content-Type`. Servers that don't serve OPDS 2 (or ignore the header) fall back to the existing (and unchanged) Atom parser. All call sites that previously imported `fetchCollection`/`fetchBook` from `dataflow/opds1/fetch` now import them from here instead.
- New OPDS 2 catalog parser and lenient runtime validation (`dataflow/opds2/`, `validation/opds2Catalog.ts`) map Palace Manager-produced OPDS 2 JSON into the same internal `Book`/`CollectionData` model the OPDS 1 parser produces, including borrow/hold/loan status, fulfillment and open-access links (with indirection chains, e.g. bearer-token-wrapped or streaming formats), series, and facets/groups/navigation. Schema mismatches are reported as telemetry only and never block rendering.
- Feature flag env var `PALACE_CPW_FEATURE_OPDS2` controls whether OPDS 2 negotiation is attempted; off by default.

**Supporting changes**: 
- OPDS-entry indirection types are normalized between the two spec's differing media-type spellings.
- `getMedium` now recognizes OPDS 2's `@type` metadata.

**Note for review**: 
- `jest.config.js` now sets `restoreMocks: true` so spies auto-restore after each test, fixing a latent footgun that I noticed after forgetting to manually `mockRestore()`. It could leak a mock into later tests. It is unrelated to OPDS 2 but was needed to keep the new OPDS 2 test suites isolated from each other, and it required moving a handful of pre-existing module-scope spies into `beforeEach` in files that I wouldn't have otherwise touched: `
- test-utils/mockToDateString.ts`, 
- `test-utils/index.tsx`, 
- `UserContext.test.tsx`, 
- `ContextProvider.test.tsx`, and
- `BookDetails.test.tsx`.
No test behavior changes here, so it's probably safe to just skim these.

## Motivation and Context

This adds client support so the web patron app can consume OPDS 2 feeds, working toward parity with the mobile apps and what the circulation manager exposes, without disrupting existing OPDS 1.x deployments.

[Jira PP-2718]

## How Has This Been Tested?

- Manual testing in my local development environment.
- New and updated tests for the new functionality.
- Tests and checks pass locally.
- [CI tests / checks](https://github.com/ThePalaceProject/web-patron/actions/runs/29867770774) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
