### PR TITLE
Feature flag gates language selection support (PP-4937)

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,7 @@ CONFIG_FILE=/community-config.yml
 # turn this on to request OPDS 2 (JSON) catalogs from the circulation
 # manager, falling back to OPDS 1 (Atom) when the server does not serve it
 # PALACE_CPW_FEATURE_OPDS2=true
+
+# turn this on to enable patron-facing language support (the language
+# selector in the catalog header, locale detection, and locale URLs)
+# PALACE_CPW_FEATURE_LANGUAGE_SELECTOR=true

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The following environment variables can be set to further configure the applicat
 - Set `BUGSNAG_API_KEY` to your Bugsnag project API key to enable error tracking. If unset, Bugsnag is disabled.
 - Set `GTM_ID` to your Google Tag Manager container ID (format: `GTM-XXXXXXXX`) to enable web analytics. If unset, GTM is not loaded.
 - Set `PALACE_CPW_FEATURE_OPDS2=true` to request OPDS 2 (JSON) catalogs from the circulation manager via content negotiation, with automatic fallback to OPDS 1 (Atom) when the server does not serve OPDS 2. This is an experimental feature flag; the default is `false`. Boolean values follow the circulation manager's conventions (`true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`).
+- Set `PALACE_CPW_FEATURE_LANGUAGE_SELECTOR=true` to enable patron-facing language support: the language selector in the catalog header, automatic locale detection, and locale-prefixed URLs. While the flag is off (the default, while localization work is in progress), the selector is hidden, locale detection is disabled, and locale-prefixed URLs redirect to English. Boolean values follow the circulation manager's conventions (`true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`).
 - Set `REACT_AXE=true` to run the application with `react-axe` enabled (only works when `NODE_ENV` is "development").
 - Set `ANALYZE=true` to generate bundle analysis files inside `.next/analyze` which will show bundle sizes for server and client, as well as composition.
 

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -14,6 +14,7 @@ import { styleProps } from "./Button/styles";
 import { lightness } from "@theme-ui/color";
 import track from "analytics/track";
 import Cookie from "js-cookie";
+import { useAppConfig } from "components/context/AppConfigContext";
 
 // define enums that match the Next.js i18n locales
 export enum Language {
@@ -79,6 +80,7 @@ const LanguageSelectItem: React.FC<{ lang: Language }> = ({ lang }) => {
 const LanguageSelector: React.FC<{ className?: string }> = ({ className }) => {
   const { t } = useTranslation();
   const router = useRouter();
+  const { enableLanguageSelector } = useAppConfig();
 
   // get the current locale from router,
   // and make sure it's a valid language we want to use
@@ -139,8 +141,10 @@ const LanguageSelector: React.FC<{ className?: string }> = ({ className }) => {
     }
   };
 
+  // - the selector is hidden unless the PALACE_CPW_FEATURE_LANGUAGE_SELECTOR
+  //   feature flag is enabled
   // - locale could be invalid, if unsupported language like "de" is used
-  if (!currentLocale) {
+  if (!enableLanguageSelector || !currentLocale) {
     return null;
   }
 

--- a/src/components/__tests__/LanguageSelector.test.tsx
+++ b/src/components/__tests__/LanguageSelector.test.tsx
@@ -31,7 +31,10 @@ const mockRouter = (locale: string) => {
 };
 
 // define helper function to set up the test environment
-const setup = async (locale: string) => {
+const setup = async (
+  locale: string,
+  { enableLanguageSelector = true } = {}
+) => {
   // first mock the router
   const push = mockRouter(locale);
 
@@ -39,7 +42,11 @@ const setup = async (locale: string) => {
   mockUseTranslation().i18n.changeLanguage(locale);
 
   // then render the component
-  const { user } = customSetup(<LanguageSelector />);
+  // (the selector is behind a feature flag that is off by default,
+  // so tests enable it unless they exercise the disabled state)
+  const { user } = customSetup(<LanguageSelector />, {
+    appConfig: { enableLanguageSelector }
+  });
 
   // Ariakit registers the select items with its store in a microtask that runs
   // after render() returns, so the re-render it triggers falls outside the
@@ -198,6 +205,14 @@ describe("LanguageSelector", () => {
     await setup("de");
 
     // should not find language selector
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("should not render selector when the feature flag is disabled", async () => {
+    await setup(Language.EN, { enableLanguageSelector: false });
+
+    // nothing should be rendered, so the selector is absent from the
+    // accessibility tree, not merely hidden
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
   });
 });

--- a/src/config/fallbackAppConfig.ts
+++ b/src/config/fallbackAppConfig.ts
@@ -7,6 +7,7 @@ const FALLBACK_APP_CONFIG: AppConfig = {
   companionApp: "simplye",
   showMedium: true,
   enableOpds2: false,
+  enableLanguageSelector: false,
   bugsnagApiKey: null,
   openebooks: null,
   authenticationDocuments: null,

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -1,0 +1,9 @@
+/**
+ * Feature flags are environment variables, following the circulation
+ * manager's PALACE_<app>_FEATURE_<flag> convention. They live here rather
+ * than in server/appConfig.ts so that the request proxy (src/proxy.ts) can
+ * import the names without pulling in the Node-only config loader.
+ */
+export const OPDS2_FEATURE_FLAG_ENV = "PALACE_CPW_FEATURE_OPDS2";
+export const LANGUAGE_SELECTOR_FEATURE_FLAG_ENV =
+  "PALACE_CPW_FEATURE_LANGUAGE_SELECTOR";

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,5 +1,37 @@
+import { parseBoolean } from "utils/envParse";
+import { LANGUAGE_SELECTOR_FEATURE_FLAG_ENV } from "constants/env";
+
+/*
+ * When true, the request inputs that drive Next.js's automatic locale
+ * detection (the NEXT_LOCALE cookie and the Accept-Language header) are
+ * removed from every inbound request, so all patrons are served the default
+ * (English) locale. This is how the language selector feature flag disables
+ * locale detection at runtime: i18n config from next.config.js is baked into
+ * the standalone build, so its localeDetection option cannot be driven by a
+ * runtime environment variable. The cookie is only ignored, not cleared from
+ * the browser, so a saved language choice resumes working when the flag is
+ * enabled.
+ */
+let stripLocaleDetectionHeaders = false;
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    /*
+     * The standalone server starts listening before register() finishes, so
+     * the stripping flag is computed synchronously here, before the first
+     * await, rather than only after the (possibly remote) config file has
+     * been loaded. Requests that arrive mid-startup are then already served
+     * with the correct behavior.
+     */
+    try {
+      stripLocaleDetectionHeaders = !parseBoolean(
+        LANGUAGE_SELECTOR_FEATURE_FLAG_ENV,
+        false
+      );
+    } catch {
+      // getAppConfig() below parses the same variable and exits on the error.
+    }
+
     const http = await import("node:http");
     // Full URLs including query strings are logged. This app makes no inbound
     // or outbound requests expected to carry sensitive data in URLs.
@@ -10,6 +42,19 @@ export async function register() {
         if (event === "request") {
           const req = args[0] as import("http").IncomingMessage;
           const res = args[1] as import("http").ServerResponse;
+          if (stripLocaleDetectionHeaders && req.headers) {
+            delete req.headers["accept-language"];
+            if (req.headers.cookie !== undefined) {
+              const remaining = req.headers.cookie
+                .split(";")
+                .filter(pair => !pair.trimStart().startsWith("NEXT_LOCALE="));
+              if (remaining.length > 0) {
+                req.headers.cookie = remaining.join(";");
+              } else {
+                delete req.headers.cookie;
+              }
+            }
+          }
           res.once("finish", () => {
             console.log(`recv ${req.method} ${req.url} ${res.statusCode}`);
           });
@@ -49,6 +94,10 @@ export async function register() {
       console.log(
         `OPDS 2 negotiation is ${appConfig.enableOpds2 ? "enabled" : "disabled"} (PALACE_CPW_FEATURE_OPDS2).`
       );
+      console.log(
+        `The language selector is ${appConfig.enableLanguageSelector ? "enabled" : "disabled"} (PALACE_CPW_FEATURE_LANGUAGE_SELECTOR).`
+      );
+      stripLocaleDetectionHeaders = !appConfig.enableLanguageSelector;
       /*
        * Pre-warm the registry cache before any requests are served.
        * getLibraries() sets pendingRefreshes synchronously before its first

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,6 +25,7 @@ export type AppConfig = {
   companionApp: "simplye" | "openebooks";
   showMedium: boolean;
   enableOpds2: boolean;
+  enableLanguageSelector: boolean;
   bugsnagApiKey: string | null;
   openebooks: OpenEbooksConfig | null;
   /** Reserved item landing path segments. See constants/app.ts. */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { parseBoolean } from "utils/envParse";
+import { LANGUAGE_SELECTOR_FEATURE_FLAG_ENV } from "constants/env";
+
+/**
+ * While the language selector feature flag is off, locale-prefixed URLs
+ * (for example /es/...) redirect to the same path in the default locale, so
+ * a bookmarked or hand-typed URL cannot reach a partially localized catalog.
+ * Automatic locale detection is disabled separately (see instrumentation.ts),
+ * so the redirect cannot bounce back to a non-default locale.
+ */
+export function proxy(request: NextRequest): NextResponse | undefined {
+  if (parseBoolean(LANGUAGE_SELECTOR_FEATURE_FLAG_ENV, false)) {
+    return undefined;
+  }
+  const { nextUrl } = request;
+  if (
+    nextUrl.locale !== "" &&
+    nextUrl.defaultLocale !== undefined &&
+    nextUrl.locale !== nextUrl.defaultLocale
+  ) {
+    const url = nextUrl.clone();
+    url.locale = nextUrl.defaultLocale;
+    return NextResponse.redirect(url, 307);
+  }
+  return undefined;
+}
+
+// Locale prefixes only occur on page routes; API routes and build assets are
+// excluded so the proxy does not run for them. With i18n configured, Next.js
+// prepends a locale segment and a literal "/" to non-root matchers, so the
+// pattern cannot match a bare locale root; "/" is listed separately to cover
+// locale roots like /es.
+export const config = {
+  matcher: ["/", "/((?!api/|_next/).*)"]
+};

--- a/src/server/__tests__/appConfig.test.ts
+++ b/src/server/__tests__/appConfig.test.ts
@@ -403,6 +403,40 @@ describe("config parsing", () => {
     });
   });
 
+  // --- enableLanguageSelector ---
+
+  describe("enableLanguageSelector", () => {
+    it("defaults to false when PALACE_CPW_FEATURE_LANGUAGE_SELECTOR is not set", async () => {
+      delete process.env.PALACE_CPW_FEATURE_LANGUAGE_SELECTOR;
+      expect((await load(MINIMAL_YAML)).enableLanguageSelector).toBe(false);
+    });
+
+    it.each([
+      ["true", true],
+      ["false", false]
+    ])(
+      "is %s when PALACE_CPW_FEATURE_LANGUAGE_SELECTOR is %s",
+      async (raw, expected) => {
+        process.env.PALACE_CPW_FEATURE_LANGUAGE_SELECTOR = raw;
+        expect((await load(MINIMAL_YAML)).enableLanguageSelector).toBe(
+          expected
+        );
+      }
+    );
+
+    it("rejects unrecognized PALACE_CPW_FEATURE_LANGUAGE_SELECTOR values", async () => {
+      process.env.PALACE_CPW_FEATURE_LANGUAGE_SELECTOR = "yes please";
+      await expect(load(MINIMAL_YAML)).rejects.toThrow(AppSetupError);
+    });
+
+    it("ignores an enable_language_selector key in the config file", async () => {
+      delete process.env.PALACE_CPW_FEATURE_LANGUAGE_SELECTOR;
+      expect(
+        (await load(`enable_language_selector: true`)).enableLanguageSelector
+      ).toBe(false);
+    });
+  });
+
   // --- openebooks ---
 
   describe("openebooks", () => {

--- a/src/server/__tests__/instrumentation.test.ts
+++ b/src/server/__tests__/instrumentation.test.ts
@@ -186,6 +186,130 @@ describe("OPDS 2 startup logging", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Language selector startup logging
+// ---------------------------------------------------------------------------
+
+describe("language selector startup logging", () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    process.env.NEXT_RUNTIME = "nodejs";
+    mockGetLibraries.mockResolvedValue({});
+  });
+
+  it("logs that the language selector is enabled when enableLanguageSelector is true", async () => {
+    mockGetAppConfig.mockResolvedValue({ enableLanguageSelector: true });
+    await register();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("The language selector is enabled")
+    );
+  });
+
+  it("logs that the language selector is disabled when enableLanguageSelector is false", async () => {
+    mockGetAppConfig.mockResolvedValue({ enableLanguageSelector: false });
+    await register();
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining("The language selector is disabled")
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Locale detection header stripping
+// ---------------------------------------------------------------------------
+
+describe("locale detection header stripping", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    process.env.NEXT_RUNTIME = "nodejs";
+    mockGetLibraries.mockResolvedValue({});
+  });
+
+  function emitRequest(
+    headers: Record<string, string>
+  ): Record<string, string> {
+    const patchedEmit = serverProto.emit;
+    const mockReq = { method: "GET", url: "/", headers };
+    const mockRes = new EventEmitter() as any;
+    mockRes.statusCode = 200;
+    patchedEmit.call({}, "request", mockReq, mockRes);
+    return mockReq.headers;
+  }
+
+  describe("when the language selector is disabled", () => {
+    beforeEach(async () => {
+      mockGetAppConfig.mockResolvedValue({ enableLanguageSelector: false });
+      await register();
+    });
+
+    it("removes the accept-language header", () => {
+      const headers = emitRequest({ "accept-language": "es-ES,es;q=0.9" });
+      expect(headers["accept-language"]).toBeUndefined();
+    });
+
+    it("removes the NEXT_LOCALE cookie but keeps other cookies", () => {
+      const headers = emitRequest({
+        cookie: "session=abc; NEXT_LOCALE=es; theme=dark"
+      });
+      expect(headers.cookie).not.toContain("NEXT_LOCALE");
+      expect(headers.cookie).toContain("session=abc");
+      expect(headers.cookie).toContain("theme=dark");
+    });
+
+    it("removes the cookie header entirely when NEXT_LOCALE is the only cookie", () => {
+      const headers = emitRequest({ cookie: "NEXT_LOCALE=es" });
+      expect(headers.cookie).toBeUndefined();
+    });
+
+    it("leaves requests without locale headers unchanged", () => {
+      const headers = emitRequest({ host: "example.com" });
+      expect(headers).toEqual({ host: "example.com" });
+    });
+  });
+
+  it("strips headers for requests that arrive before the config file has loaded", async () => {
+    delete process.env.PALACE_CPW_FEATURE_LANGUAGE_SELECTOR;
+    let resolveConfig: (value: unknown) => void = () => undefined;
+    mockGetAppConfig.mockReturnValue(
+      new Promise(resolve => (resolveConfig = resolve))
+    );
+    const pending = register();
+
+    // let register() progress past its dynamic imports so the emit patch is
+    // installed, while getAppConfig() is still unresolved
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    expect(serverProto.emit.name).toBe("patchedEmit");
+
+    const headers = emitRequest({
+      "accept-language": "es-ES,es;q=0.9",
+      cookie: "NEXT_LOCALE=es"
+    });
+    expect(headers["accept-language"]).toBeUndefined();
+    expect(headers.cookie).toBeUndefined();
+
+    resolveConfig({ enableLanguageSelector: false });
+    await pending;
+  });
+
+  describe("when the language selector is enabled", () => {
+    beforeEach(async () => {
+      mockGetAppConfig.mockResolvedValue({ enableLanguageSelector: true });
+      await register();
+    });
+
+    it("leaves the accept-language header and NEXT_LOCALE cookie in place", () => {
+      const headers = emitRequest({
+        "accept-language": "es-ES,es;q=0.9",
+        cookie: "NEXT_LOCALE=es; session=abc"
+      });
+      expect(headers["accept-language"]).toBe("es-ES,es;q=0.9");
+      expect(headers.cookie).toBe("NEXT_LOCALE=es; session=abc");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // HTTP request logging
 // ---------------------------------------------------------------------------
 

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -35,6 +35,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     companionApp: "simplye",
     showMedium: true,
     enableOpds2: false,
+    enableLanguageSelector: false,
     openebooks: null,
     mediaSupport: {},
     authenticationDocuments: null,

--- a/src/server/__tests__/proxy.test.ts
+++ b/src/server/__tests__/proxy.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for src/proxy.ts. They live under server/__tests__ so they run
+ * in the Node.js Jest project; the proxy itself must live at src/proxy.ts
+ * for Next.js to pick it up.
+ */
+
+import { NextRequest } from "next/server";
+import { proxy } from "../../proxy";
+
+const I18N = {
+  locales: ["en", "fr", "it", "es"],
+  defaultLocale: "en"
+};
+
+function makeRequest(path: string): NextRequest {
+  return new NextRequest(`https://catalog.example.com${path}`, {
+    nextConfig: { i18n: I18N }
+  });
+}
+
+function redirectLocation(response: Response | undefined): URL {
+  expect(response?.status).toBe(307);
+  const location = response?.headers.get("location");
+  expect(location).toBeTruthy();
+  return new URL(location as string);
+}
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+describe("proxy", () => {
+  describe("when the language selector flag is off", () => {
+    beforeEach(() => {
+      delete process.env.PALACE_CPW_FEATURE_LANGUAGE_SELECTOR;
+    });
+
+    it("redirects a locale-prefixed path to the default locale", () => {
+      const response = proxy(makeRequest("/es/library/books"));
+      const location = redirectLocation(response);
+      expect(location.host).toBe("catalog.example.com");
+      expect(location.pathname).toBe("/library/books");
+    });
+
+    it.each(["fr", "it", "es"])("redirects the /%s root to /", locale => {
+      const response = proxy(makeRequest(`/${locale}`));
+      expect(redirectLocation(response).pathname).toBe("/");
+    });
+
+    it("preserves the query string on redirect", () => {
+      const response = proxy(makeRequest("/fr/search?q=dune&page=2"));
+      const location = redirectLocation(response);
+      expect(location.pathname).toBe("/search");
+      expect(location.searchParams.get("q")).toBe("dune");
+      expect(location.searchParams.get("page")).toBe("2");
+    });
+
+    it("does not redirect default-locale paths", () => {
+      expect(proxy(makeRequest("/library/books"))).toBeUndefined();
+    });
+
+    it("does not redirect the root path", () => {
+      expect(proxy(makeRequest("/"))).toBeUndefined();
+    });
+  });
+
+  describe("when the language selector flag is on", () => {
+    it.each(["true", "1", "on"])(
+      "does not redirect locale-prefixed paths (flag value %s)",
+      value => {
+        process.env.PALACE_CPW_FEATURE_LANGUAGE_SELECTOR = value;
+        expect(proxy(makeRequest("/es/library/books"))).toBeUndefined();
+      }
+    );
+  });
+});

--- a/src/server/appConfig.ts
+++ b/src/server/appConfig.ts
@@ -22,6 +22,10 @@ import { isHttpUrl } from "utils/parse";
 import { parseBoolean } from "utils/envParse";
 import { DEFAULT_REGISTRY_FETCH_TIMEOUT } from "constants/registry";
 import { DEFAULT_ITEM_LANDING_SLUG, RESERVED_NEXT_SLUGS } from "constants/app";
+import {
+  LANGUAGE_SELECTOR_FEATURE_FLAG_ENV,
+  OPDS2_FEATURE_FLAG_ENV
+} from "constants/env";
 
 // ---------------------------------------------------------------------------
 // Schema
@@ -54,12 +58,6 @@ const RawConfigSchema = type({
 
 const DEFAULT_MIN_INTERVAL = 60;
 const DEFAULT_MAX_INTERVAL = 300;
-
-/**
- * Feature flags are environment variables, following the circulation
- * manager's PALACE_<app>_FEATURE_<flag> convention.
- */
-export const OPDS2_FEATURE_FLAG_ENV = "PALACE_CPW_FEATURE_OPDS2";
 
 const VALID_MEDIA_SUPPORT_VALUES = new Set<string>([
   "show",
@@ -383,6 +381,10 @@ function parseYaml(input: Record<string, unknown>): AppConfig {
     companionApp,
     showMedium,
     enableOpds2: parseBoolean(OPDS2_FEATURE_FLAG_ENV, false),
+    enableLanguageSelector: parseBoolean(
+      LANGUAGE_SELECTOR_FEATURE_FLAG_ENV,
+      false
+    ),
     openebooks,
     itemLandingSlugs
   };

--- a/src/test-utils/fixtures/config.ts
+++ b/src/test-utils/fixtures/config.ts
@@ -7,6 +7,7 @@ export const config: AppConfig = {
   companionApp: "simplye",
   showMedium: true,
   enableOpds2: false,
+  enableLanguageSelector: false,
   openebooks: null,
   authenticationDocuments: null,
   itemLandingSlugs: [DEFAULT_ITEM_LANDING_SLUG],

--- a/tests/pages/api/libraries.test.ts
+++ b/tests/pages/api/libraries.test.ts
@@ -43,6 +43,7 @@ const VALID_APP_CONFIG: AppConfig = {
   companionApp: "simplye",
   showMedium: true,
   enableOpds2: false,
+  enableLanguageSelector: false,
   openebooks: null,
   mediaSupport: {},
   authenticationDocuments: null,


### PR DESCRIPTION
Adds a PALACE_CPW_FEATURE_LANGUAGE_SELECTOR environment variable feature flag (default off) that gates all patron-facing language support, following the existing PALACE_CPW_FEATURE_OPDS2 pattern:

- Language selector: with the flag off, the selector in the catalog header is not rendered at all, so it is absent from the accessibility tree.
- Automatic locale detection: with the flag off, the NEXT_LOCALE cookie and Accept-Language header are stripped from inbound requests before Next.js sees them, so every patron is served the default (English) locale. This is done dynamically at the HTTP layer in instrumentation.ts because the standalone build bakes next.config.js values in at build time, so i18n.localeDetection cannot follow a runtime environment variable. A patron's saved locale cookie is ignored, not cleared, so their choice resumes working when the flag is enabled.
- Locale-prefixed URLs: a new request proxy (src/proxy.ts, Next 16's successor to the middleware convention) 307-redirects bookmarked / hand-typed / etc. locale URLs (e.g. /es/...) to the same path in the default locale.

With the flag on, behavior is exactly as delivered in PP-4708. The i18n runtime, message catalogs, and tooling remain active in both flag states. The flag is documented in the README and .env, its state is logged at server startup, and the flag env var names moved to src/constants/env.ts so the proxy can import them without pulling in the Node-only config loader.

Motivation and Context

PP-4708 shipped the i18n framework, including a patron-facing language switcher, but other elements of the localization epic is still in progress, so the non-English catalogs are stubs that fall back to English. A patron who selects one of those languages might be confused by the lack of translation. This flag can hide the switcher and prevents any locale other than English from activating, so the framework can keep shipping to production as the localization work lands incrementally and invisibly. The flag will be removed when the epic is finished.

[Jira PP-4937]

How Has This Been Tested?

- Manual testing in local development environment.
- New / updated unit tests to cover the new functionality.
- All tests and other checks pass locally.
- [CI checks](https://github.com/ThePalaceProject/web-patron/actions/runs/31748494566) pass.

Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.