### PR TITLE
Make i18n config visible to containerized app (PP-4961)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,8 @@ ENV NODE_ENV=production \
 COPY --from=builder /app/_next/standalone ./
 COPY --from=builder /app/_next/static ./_next/static
 COPY --from=builder /app/public ./public
+# next-i18next resolves ./next-i18next.config.js against the working directory
+# when a call site does not pass the config explicitly.
+COPY --from=builder /app/next-i18next.config.js ./
 EXPOSE 3000
 CMD ["node", "server.js"]

--- a/next-i18next.config.d.ts
+++ b/next-i18next.config.d.ts
@@ -1,0 +1,5 @@
+import type { UserConfig } from "next-i18next/pages";
+
+declare const nextI18NextConfig: UserConfig;
+
+export = nextI18NextConfig;

--- a/src/dataflow/translationProps.ts
+++ b/src/dataflow/translationProps.ts
@@ -1,4 +1,5 @@
 import { serverSideTranslations } from "next-i18next/pages/serverSideTranslations";
+import nextI18NextConfig from "../../next-i18next.config";
 
 // define the translation file namespaces, mirroring `ns` in
 // next-i18next.config.js. Both must be listed here, or the omitted namespace
@@ -17,8 +18,18 @@ export async function getTranslationProps(locale: string | undefined) {
   // use the locale from context, or if it is missing, the app's default locale
   const currentLocale = locale ?? "en";
 
+  /*
+   * Pass the config explicitly. Left to itself, next-i18next resolves
+   * next-i18next.config.js against the working directory at request time,
+   * which is the standalone bundle directory in a production build and does
+   * not contain the file.
+   */
   return {
     _locale: currentLocale,
-    ...(await serverSideTranslations(currentLocale, TRANSLATION_NAMESPACES))
+    ...(await serverSideTranslations(
+      currentLocale,
+      TRANSLATION_NAMESPACES,
+      nextI18NextConfig
+    ))
   };
 }


### PR DESCRIPTION
## Description

Pass the `next-i18next` config to `serverSideTranslations` explicitly instead of relying on it being found on disk at request time.

- Every page builds its i18n props through one helper, so this is a single call site.
- Adds a type declaration so the CommonJS config can be imported under `allowJs: false`.
- Also copies the config into the runtime image in case a future call site omits it.

## Motivation and Context

Every server-rendered page returned an error page in the dev deployment, and locally when running the standalone server directly.

Left to itself, next-i18next resolves `./next-i18next.config.js` against the working directory on every render. Nothing in our code referenced the file, so it only ever reached the standalone bundle because Next's file tracer inferred it. Up until Next 16.3.0 replaced it (`@vercel/nft` 0.27.1 -> 1.10.2). Now it no longer emits "working-directory-relative" assets discovered in dependency code, and the file stopped being copied. Importing the config removes the dependency on both the tracer and the working directory.

[Jira PP-4961]

## How Has This Been Tested?

- Manual testing in local dev environment. Specifically:
  - Production build run through the standalone server with the config file absent: the multi-library home page, library pages, and the `/en` locale route all render with translations and no errors.
  - `npm run dev` verified for the same routes, with the language selector flag both on and off.
- All tests / checks pass locally.
- [CI tests / checks](https://github.com/ThePalaceProject/web-patron/actions/runs/32385569818) pass.

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
