### PR TITLE
Memoize getLibraries merge (PP-5018)

### DIFF
--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -927,6 +927,87 @@ describe("getLibraries", () => {
     await getLibraries(config);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("returns the same merged object across calls while the cache is unchanged", async () => {
+    const feed = makePagedFeed([
+      { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/" }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+
+    const config = makeConfig({
+      registries: [
+        makeRegistryConfig({ refreshMinInterval: 60, refreshMaxInterval: 300 })
+      ]
+    });
+
+    const first = await getLibraries(config);
+    const second = await getLibraries(config);
+    expect(second).toBe(first);
+  });
+
+  it("recomputes the merge after a refresh updates the cache", async () => {
+    const NOW = 1_000_000;
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(NOW * 1000);
+
+    const feedA = makePagedFeed([
+      { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/" }
+    ]);
+    const feedB = makePagedFeed([
+      { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/" },
+      { id: "urn:uuid:b", title: "B", authDocUrl: "https://b.example.com/" }
+    ]);
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => feedA
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => feedB
+      }) as unknown as typeof fetch;
+
+    const config = makeConfig({
+      registries: [
+        makeRegistryConfig({ refreshMinInterval: 1, refreshMaxInterval: 10 })
+      ]
+    });
+
+    const first = await getLibraries(config);
+    expect(first["urn:uuid:b"]).toBeUndefined();
+
+    nowSpy.mockReturnValue((NOW + 11) * 1000);
+    const second = await getLibraries(config);
+    expect(second).not.toBe(first);
+    expect(second["urn:uuid:b"]).toBeDefined();
+  });
+
+  it("does not reuse a memoized result for a different config object", async () => {
+    const feed = makePagedFeed([
+      { id: "urn:uuid:a", title: "A", authDocUrl: "https://a.example.com/" }
+    ]);
+    global.fetch = mockFetchSuccess(feed) as unknown as typeof fetch;
+
+    const registries = [
+      makeRegistryConfig({ refreshMinInterval: 60, refreshMaxInterval: 300 })
+    ];
+    const staticLibraries = {
+      "my-lib": { title: "My Lib", authDocUrl: "https://my.lib/auth" }
+    };
+
+    const first = await getLibraries(makeConfig({ registries }));
+    expect(first["my-lib"]).toBeUndefined();
+
+    const second = await getLibraries(
+      makeConfig({ registries, staticLibraries })
+    );
+    expect(second["my-lib"]).toBeDefined();
+    expect(second["urn:uuid:a"]).toBeDefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/__tests__/libraryRegistry.test.ts
+++ b/src/server/__tests__/libraryRegistry.test.ts
@@ -802,18 +802,19 @@ describe("crawlRegistryFeed (incremental behaviour via getLibraries)", () => {
 // ---------------------------------------------------------------------------
 
 describe("getLibraries", () => {
-  let warnSpy: jest.SpyInstance;
-
   beforeEach(() => {
     resetRegistryCaches();
-    warnSpy = expectAndSuppressConsole(
+    expectAndSuppressConsole(
       "warn",
       "has no order=modified facet; incremental fetching is not supported. " +
         "Full crawls will run every refresh."
     );
   });
 
-  afterEach(() => warnSpy.mockRestore());
+  // restoreAllMocks (not just warnSpy) so the Date.now spies used in this
+  // describe cannot leak into later tests; jest.config.node.js does not set
+  // restoreMocks.
+  afterEach(() => jest.restoreAllMocks());
 
   it("returns static libraries when no registries are configured", async () => {
     const staticLibraries = {

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -54,6 +54,13 @@ interface CrawlResult {
 interface RegistryModuleState {
   registryCaches: Map<string, RegistryState>;
   pendingRefreshes: Map<string, Promise<void>>;
+  /*
+   * Incremented on every registryCaches write. getLibraries compares it to
+   * decide whether its memoized merge is still valid. Lives on the shared
+   * state so a write from one bundle context invalidates the memos held by
+   * all the others.
+   */
+  cacheVersion: number;
 }
 
 declare const global: typeof globalThis & {
@@ -63,11 +70,30 @@ declare const global: typeof globalThis & {
 if (!global.__cpwRegistryState) {
   global.__cpwRegistryState = {
     registryCaches: new Map<string, RegistryState>(),
-    pendingRefreshes: new Map<string, Promise<void>>()
+    pendingRefreshes: new Map<string, Promise<void>>(),
+    cacheVersion: 0
   };
 }
 
-const { registryCaches, pendingRefreshes } = global.__cpwRegistryState;
+const moduleState = global.__cpwRegistryState;
+/*
+ * `global` survives dev-server hot reloads, so the state object found above
+ * may have been created by an earlier build of this module in which
+ * cacheVersion did not yet exist. In that case, backfill the field so that
+ * the version checks below can always compare numbers.
+ */
+moduleState.cacheVersion ??= 0;
+
+const { registryCaches, pendingRefreshes } = moduleState;
+
+/*
+ * Records a registry cache entry and invalidates the memoized merge in
+ * getLibraries. All registryCaches writes must go through this helper.
+ */
+function setRegistryCache(url: string, state: RegistryState): void {
+  registryCaches.set(url, state);
+  moduleState.cacheVersion++;
+}
 
 const emptyState: RegistryState = {
   libraries: {},
@@ -334,7 +360,7 @@ async function refreshRegistry(
     (registryConfig.timeout ?? DEFAULT_REGISTRY_FETCH_TIMEOUT) * 1000;
   const attemptTime = nowSeconds;
 
-  registryCaches.set(registryConfig.url, {
+  setRegistryCache(registryConfig.url, {
     ...existing,
     lastAttemptedFetch: attemptTime
   });
@@ -367,7 +393,7 @@ async function refreshRegistry(
         ? result.libraries
         : { ...existing.libraries, ...result.libraries };
 
-      registryCaches.set(registryConfig.url, {
+      setRegistryCache(registryConfig.url, {
         libraries: mergedLibraries,
         lastSuccessfulFetch: attemptTime,
         lastAttemptedFetch: attemptTime,
@@ -391,12 +417,27 @@ async function refreshRegistry(
   }
 }
 
+/*
+ * Most recent getLibraries merge, valid while cacheVersion and the config
+ * reference are both unchanged. Per-bundle: each bundle context recomputes at
+ * most once per cache write, since the shared cacheVersion invalidates every
+ * bundle's copy.
+ */
+let memoizedMerge: {
+  cacheVersion: number;
+  config: AppConfig;
+  libraries: LibrariesConfig;
+} | null = null;
+
 /**
  * Returns the current merged library list, refreshing all configured registries
  * in parallel if their data is stale. Incremental refreshes (stopping at entries
  * older than lastSuccessfulFetch) are used when the feed advertises an
  * order=modified facet. Full crawls replace the cache; partial crawls merge
  * new entries into it. On failure, the existing cached state is retained.
+ *
+ * The merged result is memoized between registry cache writes, so repeated
+ * calls with the same config return a shared object that must not be mutated.
  *
  * Merge precedence (highest to lowest):
  *   1. Static libraries from config
@@ -421,6 +462,23 @@ export async function getLibraries(
     )
   );
 
+  /*
+   * The merge below allocates a fresh object spanning every library, so the
+   * result is memoized. Until a registry cache entry is written, calls passing
+   * the same config object get the previous result back. The comparison is
+   * per-process. getAppConfig caches one AppConfig object for the life of its
+   * process, so requests served by the same instance pass the same reference
+   * (but each instance behind a load balancer keeps its own config, cache, and
+   * memo). Callers share the returned object and must not mutate it.
+   */
+  if (
+    memoizedMerge !== null &&
+    memoizedMerge.cacheVersion === moduleState.cacheVersion &&
+    memoizedMerge.config === config
+  ) {
+    return memoizedMerge.libraries;
+  }
+
   // Merge: earlier registries override later ones; static libraries override all.
   let mergedRegistryLibraries: LibrariesConfig = {};
   for (let i = registries.length - 1; i >= 0; i--) {
@@ -434,6 +492,11 @@ export async function getLibraries(
   }
 
   const merged = { ...mergedRegistryLibraries, ...staticLibraries };
+  memoizedMerge = {
+    cacheVersion: moduleState.cacheVersion,
+    config,
+    libraries: merged
+  };
   warnOnReservedSlugCollision(merged, config);
   return merged;
 }
@@ -449,4 +512,6 @@ export function resetRegistryCaches(): void {
   registryCaches.clear();
   pendingRefreshes.clear();
   warnedReservedSlugCollisions.clear();
+  memoizedMerge = null;
+  moduleState.cacheVersion++;
 }

--- a/src/server/libraryRegistry.ts
+++ b/src/server/libraryRegistry.ts
@@ -80,7 +80,11 @@ const moduleState = global.__cpwRegistryState;
  * `global` survives dev-server hot reloads, so the state object found above
  * may have been created by an earlier build of this module in which
  * cacheVersion did not yet exist. In that case, backfill the field so that
- * the version checks below can always compare numbers.
+ * the version checks below can always compare numbers. The converse is not
+ * guarded: a bundle still running an earlier build writes to the cache
+ * without bumping the version, so a reloaded bundle can serve a stale memo
+ * until the next write from current code. That window is dev-only and closes
+ * on the next refresh.
  */
 moduleState.cacheVersion ??= 0;
 
@@ -88,7 +92,8 @@ const { registryCaches, pendingRefreshes } = moduleState;
 
 /*
  * Records a registry cache entry and invalidates the memoized merge in
- * getLibraries. All registryCaches writes must go through this helper.
+ * getLibraries. All registryCaches.set calls go through this helper;
+ * resetRegistryCaches clears the map directly and bumps the version itself.
  */
 function setRegistryCache(url: string, state: RegistryState): void {
   registryCaches.set(url, state);
@@ -446,7 +451,7 @@ let memoizedMerge: {
  */
 export async function getLibraries(
   config: AppConfig
-): Promise<LibrariesConfig> {
+): Promise<Readonly<LibrariesConfig>> {
   const { registries = [], staticLibraries = {} } = config;
 
   if (registries.length === 0) {
@@ -466,10 +471,11 @@ export async function getLibraries(
    * The merge below allocates a fresh object spanning every library, so the
    * result is memoized. Until a registry cache entry is written, calls passing
    * the same config object get the previous result back. The comparison is
-   * per-process. getAppConfig caches one AppConfig object for the life of its
-   * process, so requests served by the same instance pass the same reference
-   * (but each instance behind a load balancer keeps its own config, cache, and
-   * memo). Callers share the returned object and must not mutate it.
+   * local. getAppConfig caches one AppConfig object per bundle context, so
+   * repeated calls within a bundle pass the same reference and pair with this
+   * bundle's memo (and each server instance behind a load balancer keeps its
+   * own config, cache, and memo). Callers share the returned object and must
+   * not mutate it.
    */
   if (
     memoizedMerge !== null &&


### PR DESCRIPTION
## Description

Memoize the merged library list in `getLibraries`. The merge result is reused until a registry cache entry is written, instead of allocating a fresh object spanning every library on each call. A version counter on the shared registry state invalidates the memo on every cache write (including across Next.js bundle contexts), and the memo is also keyed on the config object reference. Because callers now share one object, the return type is `Readonly` to enforce the no-mutation contract. Memoization is per-process; instances behind a load balancer each keep their own cache and memo.

## Motivation and Context

`getLibraries` runs on every page render and every `/api/libraries` request, but its result only changes when a registry refresh writes new data (at most once per refresh interval). With a large registry, rebuilding the merged map per request created constant allocation and GC pressure on the server. This addresses one of the findings from the server-side memory investigation (PP-4959).

[Jira PP-5018]

## How Has This Been Tested?

- Manual testing in local dev environment.
- New tests verify:
  - that repeated calls return the same object while the cache is unchanged;
  - that the merge is recomputed after a refresh writes new data;
  -  and that a memoized result is not reused for a different config object. 
- All tests / check pass locally and [in CI](https://github.com/ThePalaceProject/web-patron/actions/runs/32505496838). 

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
