### PR TITLE
Reduce prefetching on multi-library pages (PP-5018)

### DIFF
--- a/src/components/LibraryHomeLink.tsx
+++ b/src/components/LibraryHomeLink.tsx
@@ -1,6 +1,13 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import * as React from "react";
 import Link from "next/link";
+import { useRouter } from "next/router";
+
+/*
+ * Long enough to wait out an auto-repeating Tab key, yet short enough to
+ * do prefetch before a patron presses Enter after settling on a library.
+ */
+export const FOCUS_PREFETCH_DEBOUNCE_MS = 300;
 
 export interface LibraryHomeLinkProps {
   slug: string;
@@ -10,11 +17,51 @@ export interface LibraryHomeLinkProps {
 /**
  * A link to a library's home page from the multi-library selection page.
  * Displays the library's title, if available. Otherwise, falls back to its slug.
+ *
+ * prefetch={false} turns off next/link's prefetch of every link in the viewport,
+ * which would otherwise fetch many libraries at once. next/link prefetches on
+ * hover and on touch, but not on focus, so the handlers below extend the same
+ * treatment to keyboard navigation. They wait out FOCUS_PREFETCH_DEBOUNCE_MS to
+ * reduce prefetches for libraries the patron is tabbing past.
+ *
+ * Notes:
+ * - Next.js skips prefetching outside a production build, so neither path
+ * does anything when running in dev mode.
+ * - Importing Link from next/link rather than components/Link because the
+ * latter prepends the current library's slug, which it reads from a
+ * LibraryContext that the multi-library home page does not have handy.
  */
 const LibraryHomeLink: React.FC<
   React.PropsWithChildren<LibraryHomeLinkProps>
 > = ({ slug, title, children }) => {
-  return <Link href={`/${slug}`}>{children ?? (title || slug)}</Link>;
+  const router = useRouter();
+  const href = `/${slug}`;
+  const timer = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+
+  const cancelPrefetch = () => clearTimeout(timer.current);
+  React.useEffect(() => cancelPrefetch, []);
+
+  const prefetchOnFocus = () => {
+    cancelPrefetch();
+    timer.current = setTimeout(
+      /* Ignore a failed prefetch. The page still loads when the link is clicked. */
+      () => void router.prefetch(href).catch(() => null),
+      FOCUS_PREFETCH_DEBOUNCE_MS
+    );
+  };
+
+  return (
+    <Link
+      href={href}
+      prefetch={false}
+      onFocus={prefetchOnFocus}
+      onBlur={cancelPrefetch}
+    >
+      {children ?? (title || slug)}
+    </Link>
+  );
 };
 
 export default LibraryHomeLink;

--- a/src/components/__tests__/LibraryHomeLink.test.tsx
+++ b/src/components/__tests__/LibraryHomeLink.test.tsx
@@ -1,8 +1,36 @@
+import { jest } from "@jest/globals";
 import * as React from "react";
-import { render } from "test-utils";
-import LibraryHomeLink from "../LibraryHomeLink";
+import { act, fireEvent, render } from "test-utils";
+import LibraryHomeLink, {
+  FOCUS_PREFETCH_DEBOUNCE_MS
+} from "../LibraryHomeLink";
+
+/*
+ * prefetch={false} leaves no trace in the DOM, and next/link skips its viewport
+ * prefetch outside a production build, so the prop can only be read from what
+ * LibraryHomeLink hands to next/link. The stand-in records those props and
+ * then defers to the real next/link, so every other test still covers it.
+ */
+const mockLinkProps: Record<string, unknown>[] = [];
+
+jest.mock("next/link", () => {
+  const ActualLink = jest.requireActual<{
+    default: React.ComponentType<any>;
+  }>("next/link").default;
+  return {
+    __esModule: true,
+    default: ({ children, ...props }: React.PropsWithChildren<any>) => {
+      mockLinkProps.push(props);
+      return <ActualLink {...props}>{children}</ActualLink>;
+    }
+  };
+});
 
 describe("LibraryHomeLink", () => {
+  beforeEach(() => {
+    mockLinkProps.length = 0;
+  });
+
   describe("link text", () => {
     test("displays title when provided", () => {
       const utils = render(
@@ -71,6 +99,109 @@ describe("LibraryHomeLink", () => {
 
       const link = utils.getByRole("link");
       expect(link).toHaveAttribute("href", "/my-library-123");
+    });
+  });
+
+  describe("viewport prefetching", () => {
+    test("turns off next/link's viewport prefetch", () => {
+      render(<LibraryHomeLink slug="my-library" title="My Library" />);
+
+      expect(mockLinkProps).toHaveLength(1);
+      expect(mockLinkProps[0]).toMatchObject({
+        href: "/my-library",
+        prefetch: false
+      });
+    });
+
+    test("turns off the viewport prefetch when no title is given", () => {
+      render(<LibraryHomeLink slug="another-library" />);
+
+      expect(mockLinkProps[0]).toMatchObject({ prefetch: false });
+    });
+  });
+
+  describe("focus prefetching", () => {
+    const mockPrefetch = () =>
+      jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    const settle = (ms: number) => act(() => jest.advanceTimersByTime(ms));
+
+    test("prefetches the library page once focus settles", () => {
+      const prefetch = mockPrefetch();
+      const utils = render(<LibraryHomeLink slug="focus-lib" />, {
+        router: { prefetch }
+      });
+
+      fireEvent.focus(utils.getByRole("link"));
+      settle(FOCUS_PREFETCH_DEBOUNCE_MS);
+
+      expect(prefetch).toHaveBeenCalledWith("/focus-lib");
+    });
+
+    test("does not prefetch while focus is still settling", () => {
+      const prefetch = mockPrefetch();
+      const utils = render(<LibraryHomeLink slug="focus-lib" />, {
+        router: { prefetch }
+      });
+
+      fireEvent.focus(utils.getByRole("link"));
+      settle(FOCUS_PREFETCH_DEBOUNCE_MS - 1);
+
+      expect(prefetch).not.toHaveBeenCalled();
+    });
+
+    test("does not prefetch a link tabbed past", () => {
+      const prefetch = mockPrefetch();
+      const utils = render(<LibraryHomeLink slug="focus-lib" />, {
+        router: { prefetch }
+      });
+
+      const link = utils.getByRole("link");
+      fireEvent.focus(link);
+      settle(50);
+      fireEvent.blur(link);
+      settle(FOCUS_PREFETCH_DEBOUNCE_MS);
+
+      expect(prefetch).not.toHaveBeenCalled();
+    });
+
+    test("does not prefetch before the link receives focus", () => {
+      const prefetch = mockPrefetch();
+      render(<LibraryHomeLink slug="focus-lib" />, { router: { prefetch } });
+      settle(FOCUS_PREFETCH_DEBOUNCE_MS);
+
+      expect(prefetch).not.toHaveBeenCalled();
+    });
+
+    test("restarts the wait when focus re-enters the same link", () => {
+      const prefetch = mockPrefetch();
+      const utils = render(<LibraryHomeLink slug="focus-lib" />, {
+        router: { prefetch }
+      });
+
+      const link = utils.getByRole("link");
+      fireEvent.focus(link);
+      settle(FOCUS_PREFETCH_DEBOUNCE_MS - 100);
+      fireEvent.focus(link);
+      settle(FOCUS_PREFETCH_DEBOUNCE_MS - 100);
+      fireEvent.blur(link);
+      settle(FOCUS_PREFETCH_DEBOUNCE_MS);
+
+      expect(prefetch).not.toHaveBeenCalled();
+    });
+
+    test("prefetches even when the router rejects", () => {
+      const prefetch = jest
+        .fn<() => Promise<void>>()
+        .mockRejectedValue(new Error("network down"));
+      const utils = render(<LibraryHomeLink slug="focus-lib" />, {
+        router: { prefetch }
+      });
+
+      fireEvent.focus(utils.getByRole("link"));
+      settle(FOCUS_PREFETCH_DEBOUNCE_MS);
+
+      expect(prefetch).toHaveBeenCalledWith("/focus-lib");
     });
   });
 


### PR DESCRIPTION
## Description

- Turn off `next/link`'s viewport prefetch for the library links on the multi-library home page, so a library is prefetched only when a patron shows intent by hovering it or by tabbing to it.
- Add a debounced prefetch when a link receives keyboard focus. Next.js prefetches on hover and touch but not on focus, so this provides comparable behavior for keyboard patrons. The debounce keeps links that are tabbed through quickly enough from being prefetched.

**Note**: Next.js disables prefetching outside a production build, so the change is only observable in a production build.

## Motivation and Context

The multi-library home page lists every configured library as a link, and Next.js prefetched every one that scrolled into view. Library pages are generated on demand, and each render fetches that library's authentication document from its circulation manager. Opening the page therefore triggered one on-demand render and one upstream fetch per visible library, which in a large window can be quite expensive. The work is wasted, since a patron goes to one library. This also created a lot of logging output.

[Jira PP-5018]

## How Has This Been Tested?

- Manual testing with build and standalone server.js in local dev environment.
- New tests for the added functionality.
- Tests and checks pass locally and [in CI](https://github.com/ThePalaceProject/web-patron/actions/runs/32612884764).

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
